### PR TITLE
Correct detach component's instance shortcut

### DIFF
--- a/content/courses/figma/components.md
+++ b/content/courses/figma/components.md
@@ -56,7 +56,7 @@ If you no longer want an instance of a component to inherit properties from the 
 
 ![Detatch a component](assets/figma-detatch-component.png)
 
-The shortcut for detaching an instance is `Option/Alt-Shift-B`.
+The shortcut for detaching an instance is `Option/Ctrl-Alt-B`.
 
 ## Organizing Components
 


### PR DESCRIPTION
Detach instance shortcut in windows is Ctrl+Alt+B
![detach instance](https://github.com/user-attachments/assets/9ef71aa0-ad93-47ec-9d34-f97dda66806e)
