### PR TITLE
docs(figma): correct css property name

### DIFF
--- a/content/courses/figma/auto-layout.md
+++ b/content/courses/figma/auto-layout.md
@@ -65,7 +65,7 @@ You can control this by using the caret next to the value.
 
 ## Minding the Gap
 
-When you're basing the size of the frame based on it's children, then you can provide a value that represents how many pixels you want in between each child. Alternatively, if you want to use a fixed size, then you can set the `gap` to auto. This will spread the children out evenly across the entire height or width of the parent frame. You can think of this like using `justify-items: space-between` in flexbox when using CSS.
+When you're basing the size of the frame based on it's children, then you can provide a value that represents how many pixels you want in between each child. Alternatively, if you want to use a fixed size, then you can set the `gap` to auto. This will spread the children out evenly across the entire height or width of the parent frame. You can think of this like using `justify-content: space-between` in flexbox when using CSS.
 
 > [!TIP] Keyboard shortcut
 > You can quickly switch between fixed and automatic spacing using **Command+X**.


### PR DESCRIPTION
Change ```justify-items``` in "Minding the Gap" section to 
```justify-content```. In flex-box the equal behavior property name is justify-content