### PR TITLE
Fix typo in building-a-card.md

### DIFF
--- a/content/courses/tailwind/building-a-card.md
+++ b/content/courses/tailwind/building-a-card.md
@@ -165,7 +165,7 @@ We added the following classes to the container:
 
 ## Constraining the Width
 
-It's still a little too wide for my tastes. Let's set a maximum with for the card using `max-w-sm` on the container.
+It's still a little too wide for my tastes. Let's set a maximum width for the card using `max-w-sm` on the container.
 
 ```html tailwind
 <div


### PR DESCRIPTION
Fix typo: "maximum with" → "maximum width" in Tailwind course