### PR TITLE
Clarify Command Palette intro

### DIFF
--- a/content/courses/visual-studio-code/vscode-command-palette.md
+++ b/content/courses/visual-studio-code/vscode-command-palette.md
@@ -3,11 +3,11 @@ title: Command Palette in Visual Studio Code
 description: >-
   Master Visual Studio Code's Command Palette to quickly access commands and
   customize keybindings
-modified: '2025-07-29T15:09:56-06:00'
+modified: '2025-09-22T09:27:10-06:00'
 date: '2025-03-16T17:35:22-06:00'
 ---
 
-The Command Palette solves this by offering fuzzy-search across all commands. Even if you only remember part of a command's name, typing snippets of it in the Command Palette often reveals exactly what you need. For instance, typing `pref key` might surface commands like `Preferences: Open Keyboard Shortcuts` or `Preferences: Open User Settings`.
+Visual Studio Code has hundreds of commands spread across menus, settings screens, and keybindings. When you can't remember where something lives, hunting through the UI is slow. The Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) solves this by offering fuzzy-search across all commands. Even if you only remember part of a command's name, typing snippets of it in the Command Palette often reveals exactly what you need. For instance, typing `pref key` might surface commands like `Preferences: Open Keyboard Shortcuts` or `Preferences: Open User Settings`.
 
 As you get comfortable with the Command Palette, you'll notice how partial matches quickly narrow down your options. This is incredibly useful for discovering new features or reminding yourself of rarely used commands. If you're not sure what to type, just open the palette and scroll.
 


### PR DESCRIPTION
Adds missing context ahead of the Command Palette explanation and includes the shortcut to open it. Closes #18.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the introduction of the `vscode-command-palette.md` lesson to better frame the Command Palette and explicitly list its keyboard shortcut.
> 
> - Rewrites the opening paragraph to add context about command discovery and includes `Ctrl+Shift+P` / `Cmd+Shift+P`
> - Updates the `modified` frontmatter timestamp; other content remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87b3c579b7e36da92a775317965bed838098a4f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->