### PR TITLE
Fix Animesis paper arXiv link in agent-memory-systems post

### DIFF
--- a/writing/agent-memory-systems.md
+++ b/writing/agent-memory-systems.md
@@ -6,7 +6,7 @@ description: >-
   and Dynamics—maps the design space from flat vector stores to RL-driven
   memory management. Here's what the research says and what you can build today.
 date: 2026-03-25
-modified: 2026-03-26
+modified: 2026-04-09
 tags:
   - ai
   - agents
@@ -283,7 +283,7 @@ The challenges are familiar to anyone who's built distributed systems: consisten
 
 ### The ontological question
 
-This is what happens when you let liberal arts majors play with technology. I'll end the frontiers section with something that most engineering papers don't ask. The ["Animesis"](https://arxiv.org/abs/2503.16667) paper from March 2026 asks: as agents become persistent and autonomous, what does memory _mean_ for a digital being?
+This is what happens when you let liberal arts majors play with technology. I'll end the frontiers section with something that most engineering papers don't ask. The ["Animesis"](https://arxiv.org/abs/2603.04740) paper from March 2026 asks: as agents become persistent and autonomous, what does memory _mean_ for a digital being?
 
 Current work answers "what memory does"—stores facts, enables retrieval, supports learning. But it doesn't answer "what memory is" in a deeper sense. As agent lifecycles extend from minutes to months—and they are extending, with persistent sessions, scheduled tasks, and always-on infrastructure—the assumption that memory is just a tool for the agent to use starts to break down. Is an agent with a rich memory of a user's preferences, communication style, and project history fundamentally different from an agent without one? Not in capability, but in kind?
 


### PR DESCRIPTION
## Summary

- Corrects the arXiv link for the "Animesis" paper from ID `2503.16667` (March 2025) to `2603.04740` (March 2026)
- The post attributes the paper to "March 2026" — the old ID was internally inconsistent with that attribution
- `modified` frontmatter updated to today's date automatically by the pre-commit hook

Fixes #78

## Review committee

Pre-reviewed by: prose-editor, junior-engineer, Codex (gpt-5.4, xhigh reasoning)
- 1 round of review
- All agents approved; no must-fix items

## Test plan

- [x] Visit https://arxiv.org/abs/2603.04740 and confirm it resolves to the Animesis paper ("Memory as Ontology: A Constitutional Memory Architecture for Persistent Digital Citizens")
- [x] Confirm the "March 2026" attribution in the post matches the paper's publication date

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating a single citation URL and the post frontmatter `modified` date, with no code or behavioral impact.
> 
> **Overview**
> Fixes the cited arXiv URL for the “Animesis” paper in `writing/agent-memory-systems.md` (updates the ID to match the stated March 2026 paper).
> 
> Updates the post frontmatter `modified` date to `2026-04-09`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ce16a516a6148593bfb757a59525139fc67b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->