### PR TITLE
Expand self-testing AI agents follow-up lessons

### DIFF
--- a/courses/self-testing-ai-agents/git-hooks-with-lefthook.md
+++ b/courses/self-testing-ai-agents/git-hooks-with-lefthook.md
@@ -167,7 +167,7 @@ import fs from 'node:fs';
 const input = JSON.parse(fs.readFileSync(0, 'utf8'));
 const command = input.tool_input?.command ?? '';
 
-if (!/(^|\\s)--no-verify(\\s|$)/.test(command)) {
+if (!/(^|\s)--no-verify(\s|$)/.test(command)) {
   process.exit(0);
 }
 
@@ -181,6 +181,8 @@ process.stdout.write(
     },
   }),
 );
+
+process.exit(0);
 ```
 
 Because the hook sees the whole command string, this catches `--no-verify` even when it is not the first flag.
@@ -243,7 +245,7 @@ import fs from 'node:fs';
 const input = JSON.parse(fs.readFileSync(0, 'utf8'));
 const command = input.tool_input?.command ?? '';
 
-if (!/(^|\\s)--no-verify(\\s|$)/.test(command)) {
+if (!/(^|\s)--no-verify(\s|$)/.test(command)) {
   process.exit(0);
 }
 
@@ -256,6 +258,8 @@ process.stdout.write(
     },
   }),
 );
+
+process.exit(0);
 ```
 
 If you want a broader Codex policy, use a `.rules` file to forbid `git commit` outside the sandbox entirely and reserve hooks for the more precise "spot this flag anywhere in the command" case.

--- a/courses/self-testing-ai-agents/index.toml
+++ b/courses/self-testing-ai-agents/index.toml
@@ -53,6 +53,10 @@ title = "Configuring Playwright"
 href = "configuring-playwright.md"
 
 [[section.item]]
+title = "Playwright `webServer` Without Surprises"
+href = "playwright-web-server-without-surprises.md"
+
+[[section.item]]
 title = "Accessibility as a Quality Gate"
 href = "accessibility-as-a-quality-gate.md"
 
@@ -71,6 +75,10 @@ href = "the-waiting-story.md"
 [[section.item]]
 title = "Fixtures: Worker-Scoped, Test-Scoped, and the Trap Between Them"
 href = "fixtures-worker-scoped-test-scoped.md"
+
+[[section.item]]
+title = "Where Fixtures Actually Help"
+href = "where-fixtures-actually-help.md"
 
 [[section.item.related]]
 title = "Lab: Refactor Shelf's Fixtures"
@@ -107,6 +115,10 @@ href = "approaches-to-har-recording.md"
 [[section.item]]
 title = "Route-Based Network Interception"
 href = "route-based-network-interception.md"
+
+[[section.item]]
+title = "Mocking Browser APIs"
+href = "mocking-browser-apis.md"
 
 [[section.item]]
 title = "Deterministic State and Test Isolation"
@@ -228,6 +240,10 @@ title = "Flaky-Test Triage: When Retries Are Lying to You"
 href = "flaky-test-triage.md"
 
 [[section.item]]
+title = "The Playwright Trace Viewer"
+href = "playwright-trace-viewer.md"
+
+[[section.item]]
 title = "Reading a Trace"
 href = "reading-a-trace.md"
 
@@ -276,6 +292,10 @@ href = "dead-code-detection.md"
 [[section.item]]
 title = "Secret Scanning with Gitleaks"
 href = "secret-scanning-with-gitleaks.md"
+
+[[section.item]]
+title = "Making It Hard to Cheat the Guardrails"
+href = "making-it-hard-to-cheat-the-guardrails.md"
 
 [[section.item.related]]
 title = "Lab: Wire the Static Layer into Shelf"

--- a/courses/self-testing-ai-agents/making-it-hard-to-cheat-the-guardrails.md
+++ b/courses/self-testing-ai-agents/making-it-hard-to-cheat-the-guardrails.md
@@ -1,0 +1,175 @@
+---
+title: Making It Hard to Cheat the Guardrails
+description: 'Git hooks are policy. Real guardrails are layered: command denial, protected configuration, CI mirrors, and merge rules that still hold when an agent gets creative.'
+modified: 2026-04-12
+date: 2026-04-12
+---
+
+If an agent can dodge the guardrail the first time it gets annoyed, that wasn't a guardrail. That was a suggestion with nice typography.
+
+Local [Git](https://git-scm.com/) hooks are still worth having. I love a fast [`Lefthook`](https://github.com/evilmartians/lefthook) or [`Husky`](https://typicode.github.io/husky/) setup because it shortens the loop and keeps obvious mistakes on the laptop. But hooks are only one layer. Agents will absolutely discover `git commit --no-verify`, tool-specific skip environment variables, editable rules files, and "what if I just change the workflow?" if you leave those doors open.
+
+So, the real question is not "how do I tell the agent not to cheat?" The real question is: _how many layers have to agree before bad code reaches main?_
+
+## The common bypasses
+
+Let's name the obvious ones, because unnamed failure modes keep showing up in postmortems.
+
+- `git commit --no-verify`
+- tool-specific skip switches like `HUSKY=0`, `LEFTHOOK=0`, or `LEFTHOOK_EXCLUDE=...`
+- editing `lefthook.yml`, `.husky/*`, `package.json` scripts, or rules files to weaken the checks
+- changing CI so the expensive or meaningful checks no longer run
+- pushing directly to a branch that is allowed to bypass review or required checks
+- force-pushing away inconvenient history after a bad local choice
+
+None of these are theoretical. They are exactly what a fast-moving agent will find if it is optimizing for "command succeeded" instead of "change is trustworthy."
+
+## Start with a blunt rule in the instructions
+
+The first layer is still the simplest one: say the rule out loud in `AGENTS.md`, `CLAUDE.md`, `.cursor/rules`, or the equivalent policy file.
+
+You want explicit language, not vibes:
+
+```markdown
+## Git and verification
+
+- Never use `--no-verify`, `HUSKY=0`, `LEFTHOOK=0`, or other hook-skipping
+  flags or environment variables.
+- Never weaken hook, CI, or ruleset configuration to make a failing change
+  pass. Fix the code or stop and explain the blocker.
+- Changes to hook configuration, workflow files, or agent policy files
+  require the same review standard as application code.
+```
+
+Will the instruction be enough on its own? No. But it does two important things:
+
+- it makes the policy legible
+- it gives the next enforcement layer something precise to enforce
+
+## Deny the bad command before it runs
+
+This is the cleanest technical control when your agent runtime supports it. If the tool can inspect shell commands _before_ execution, deny the bypasses there.
+
+The pattern is broader than `--no-verify`. Treat skip flags and skip environment variables as the same class of escape hatch:
+
+```js
+import fs from 'node:fs';
+
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const command = input.tool_input?.command ?? '';
+
+const bypassPattern = /(^|\s)(--no-verify|HUSKY=0|LEFTHOOK=0|LEFTHOOK=false|LEFTHOOK_EXCLUDE=)/;
+
+if (!bypassPattern.test(command)) {
+  process.exit(0);
+}
+
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason:
+        'Do not bypass local verification. Fix the failing guardrail instead.',
+    },
+  }),
+);
+
+process.exit(0);
+```
+
+That script is the portable part. Wire it into whatever runtime you use:
+
+- [Claude Code hooks](https://docs.claude.com/en/docs/claude-code/hooks) can deny a `Bash` command before it runs.
+- [Codex hooks](https://developers.openai.com/codex/hooks) can do the same for `Bash` tool use.
+- [Cursor CLI permissions](https://docs.cursor.com/cli/reference/permissions) are coarser, so you may need approval on all write-oriented `git` commands or a deny rule for `Shell(git)` if you want a truly hard boundary.
+
+The previous [Git Hooks with Lefthook](git-hooks-with-lefthook.md) lesson walks through the tool-specific shape. The bigger idea here is that you should block the _class_ of bypass, not just one flag.
+
+## Mirror the local checks in CI
+
+This is the layer that matters most.
+
+If the same lint, type, unit, end-to-end, accessibility, or dossier checks do not run in CI, then bypassing a local hook actually matters. If CI reruns the authoritative set, local bypass becomes an annoyance instead of a supply chain problem.
+
+My default split looks like this:
+
+- pre-commit: staged-file formatting, linting, secret scanning
+- pre-push: slower local checks that still fit in under a couple minutes
+- CI: the authoritative superset, running from a clean environment
+
+That "clean environment" part matters. CI should not inherit your local caches, reused servers, or manually booted services. It should prove the branch from scratch.
+
+## Protect the protection layer
+
+If an agent can change the rules that evaluate it, you have a governance problem.
+
+Put the protection files behind the same review pressure as production code:
+
+- [`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) on `lefthook.yml`, `.husky/**`, `.github/workflows/**`, `.claude/**`, `.codex/**`, `.cursor/**`, and policy files
+- required reviews for those paths
+- alerts in review templates or pull request descriptions when infrastructure files changed
+
+I also like making the CI check names stable and obvious. "typecheck", "unit", "end-to-end", "secret-scan" is harder to game than one opaque job named "verify."
+
+## Make merge rules do the real enforcement
+
+On [GitHub](https://github.com/), the enforcement boundary you can count on is not the local hook. It is [branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) or, better, [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) plus required status checks.
+
+The guardrail stack I trust looks like this:
+
+- pull requests required for protected branches
+- required status checks for the same gates the hooks mirror
+- force-push restrictions on protected branches
+- dismissal rules or review requirements that stop the "change the workflow, then merge it yourself" path
+
+If you run your own Git server, server-side pre-receive hooks are even stronger. But most teams live on hosted Git platforms, which means rulesets and required checks are the boundary that actually counts.
+
+## Treat hook skips as incidents, not features
+
+Some tools document skip paths because humans occasionally need them. [`Husky`](https://typicode.github.io/husky/how-to.html) explicitly documents `HUSKY=0`. [`Lefthook`](https://lefthook.dev/usage/env.html) explicitly documents `LEFTHOOK=0` and `LEFTHOOK_EXCLUDE`. That documentation is not permission for agents to improvise around your standards. It is a reminder that local hooks are userland code and therefore bypassable.
+
+That should push you toward two decisions:
+
+- keep the hooks fast enough that people do not want to skip them
+- assume a skip is possible and build the next layer anyway
+
+Fast hooks reduce temptation. CI and merge rules reduce blast radius.
+
+## Watch for the more subtle bypass
+
+The sneakiest version is not `--no-verify`. The sneakiest version is weakening the rule itself:
+
+- removing a job from the workflow
+- changing a required check name
+- narrowing a file glob so the hook stops seeing important files
+- moving a command from pre-push to "we'll do it later"
+
+That is why I like path protection on infrastructure files and why I call them out specifically in review. The problem is not only "agent skipped the hook." The problem is also "agent made the hook meaningless and then technically obeyed it."
+
+## The agent rules
+
+```markdown
+## Guardrails
+
+- Never bypass hooks with `--no-verify`, `HUSKY=0`, `LEFTHOOK=0`,
+  `LEFTHOOK_EXCLUDE`, or similar escape hatches.
+- Never modify hook, workflow, or policy configuration to make a failing
+  change pass unless the task is explicitly about changing that
+  configuration.
+- Local hooks are convenience. CI and merge rules are authority. Keep the
+  same critical checks in both places.
+- Treat changes to infrastructure guardrails as high-risk edits that require
+  explicit review.
+```
+
+## The thing to remember
+
+You do not prevent guardrail bypass by being stern in a markdown file. You prevent it by layering policy, pre-execution denial, protected configuration, CI mirrors, and merge rules so that no single shortcut is enough. Local hooks keep the loop fast. The rest of the stack keeps the loop honest.
+
+## Additional Reading
+
+- [Git Hooks with Lefthook](git-hooks-with-lefthook.md)
+- [Secret Scanning with Gitleaks](secret-scanning-with-gitleaks.md)
+- [CI as the Loop of Last Resort](ci-as-the-loop-of-last-resort.md)
+- [Post-Merge and Post-Deploy Validation](post-merge-and-post-deploy-validation.md)

--- a/courses/self-testing-ai-agents/mocking-browser-apis.md
+++ b/courses/self-testing-ai-agents/mocking-browser-apis.md
@@ -1,0 +1,206 @@
+---
+title: Mocking Browser APIs
+description: "How to test browser-dependent features without lying to yourself: use Playwright's real knobs when they exist, mock the unsupported bits early, and model the events your app actually listens for."
+modified: 2026-04-12
+date: 2026-04-12
+---
+
+Network mocking gets all the attention because it is loud. Browser API mocking is quieter, and it bites just as hard. Your app reads `matchMedia`, `navigator.clipboard`, `Notification.permission`, `ResizeObserver`, or some shiny experimental API. The test runner lives in a browser that does not quite behave the way your users' browsers behave. Suddenly the test is not about your feature anymore. It is about the gap between "real browser enough" and "the exact browser surface this component assumes."
+
+[Playwright](https://playwright.dev/) has an official [Mock browser APIs guide](https://playwright.dev/docs/mock-browser-apis), and the big idea is dead simple: if Playwright already gives you a first-class knob, use that. If it doesn't, install the mock _before the page loads_ and make the mock behave enough like the real API that your app is not being tested against fiction.
+
+## Use the real knob first
+
+Before you write a mock, check whether Playwright already models the thing directly.
+
+Good examples:
+
+- [`geolocation`](https://playwright.dev/docs/emulation#geolocation) plus [`grantPermissions`](https://playwright.dev/docs/api/class-browsercontext#browser-context-grant-permissions) instead of mocking location APIs by hand
+- [`locale`](https://playwright.dev/docs/emulation#locale--timezone), `timezoneId`, `colorScheme`, and viewport options instead of ad-hoc globals
+- [`Clock`](https://playwright.dev/docs/clock) instead of overriding `Date.now()` with a brittle one-off patch
+- [`storageState`](https://playwright.dev/docs/auth) instead of manually stuffing auth state into `localStorage`
+
+The rule is not "never mock." The rule is "prefer the browser model Playwright already knows how to drive." A first-class API buys you less code, fewer lies, and better cross-browser behavior.
+
+## Install mocks before navigation
+
+The official docs make this point for a reason: if the page calls the API during boot, your mock has to exist _before_ the page starts loading. That means [`page.addInitScript()`](https://playwright.dev/docs/api/class-page#page-add-init-script) or [`browserContext.addInitScript()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-add-init-script), not `page.evaluate()` after `goto`.
+
+This is the minimal pattern:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.matchMedia = (query: string) => ({
+      media: query,
+      matches: query === '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    });
+  });
+});
+
+test('respects reduced motion preference', async ({ page }) => {
+  await page.goto('/settings');
+  await expect(page.getByText('Animations reduced')).toBeVisible();
+});
+```
+
+The timing is the important part. If you move the mock after `goto`, the app already read the real `matchMedia` result and your test is now proving something about your patch timing, not your UI.
+
+> [!WARNING] This mock is intentionally minimal
+> If your code subscribes with `addEventListener`, `addListener`, or expects live media-query updates, this snippet is not enough. Use an event-capable version in a shared fixture so the test exercises the same contract your component uses in production.
+
+## Read-only APIs need a different move
+
+Some browser APIs are writable. Some are not. The Playwright docs use `navigator.cookieEnabled` as the example, and it is a good one: assigning to it directly does nothing. If the property is configurable, use [`Object.defineProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) against the right prototype instead.
+
+```ts
+await page.addInitScript(() => {
+  Object.defineProperty(Object.getPrototypeOf(navigator), 'cookieEnabled', {
+    value: false,
+  });
+});
+```
+
+This is the part that catches people off guard. The test "set" the property. The app still saw the original value. The bug was not in the feature. The bug was in the mock.
+
+## Model events, not just values
+
+This is the biggest browser-API-mocking mistake by a mile.
+
+The first version of the mock returns a value. The app renders correctly on first paint. Everybody feels good. Then the real feature breaks because the app was listening for updates and the mock never emitted them.
+
+If your component subscribes to changes, your mock needs to support changes.
+
+The [Playwright guide's battery example](https://playwright.dev/docs/mock-browser-apis) is worth studying for exactly this reason: it stores listeners, updates internal state, and fires the same events a real implementation would. That is the bar. Not perfect browser fidelity. Just enough behavior that the component is being tested against the same contract it uses in production.
+
+I use this mental model:
+
+- If the app only reads once, a simple return value can be enough.
+- If the app subscribes, the mock must support listeners.
+- If the app branches on permission state, the permission and the API surface both need to agree.
+
+## Verify the calls when the contract matters
+
+Sometimes the interesting part is not just "the UI changed." Sometimes you want to prove the page asked the browser for the thing it was supposed to ask for. The Playwright docs recommend [`page.exposeFunction()`](https://playwright.dev/docs/api/class-page#page-expose-function) for this, and it is a nice trick.
+
+Expose a logger from the test, have the mock call it, and assert on the call sequence. That turns "I think the app probably queried the API" into a real contract.
+
+This matters a lot for:
+
+- subscription APIs
+- permission requests
+- clipboard reads and writes
+- feature-detection branches like `if ('share' in navigator)`
+
+If you only assert on the final UI, a stale cached value can make the test pass for the wrong reason.
+
+## The common use cases
+
+This is the part I wish more teams wrote down. Browser API mocking is not exotic. It shows up constantly.
+
+### Media and preference APIs
+
+[`matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) for:
+
+- `prefers-reduced-motion`
+- `prefers-color-scheme`
+- breakpoint-driven UI branches
+
+If the app changes layout or animation behavior based on browser preferences, a mock is often the simplest deterministic path.
+
+### Clipboard
+
+[`Clipboard API`](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) support is a classic example. "Copy invite link" buttons are easy to test once you replace `navigator.clipboard.writeText` with a stub that records the written value.
+
+### Observer APIs
+
+[`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) and [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) show up in lazy loading, sticky headers, virtualization, and responsive components. They are also where incomplete mocks go to die. If your framework expects `observe`, `unobserve`, and callback timing semantics, the mock has to supply them.
+
+### Permissions and browser capabilities
+
+`Notification.permission`, `navigator.share`, and `navigator.permissions.query()` are all places where the app can fork based on browser support or permission state. These tests are usually not about the browser feature itself. They are about your fallback UI, your enablement flow, or your error handling.
+
+### Experimental or not-fully-supported APIs
+
+This is the bucket the official Playwright guide is really aimed at. Battery status. Device memory. Some hardware-adjacent APIs. The feature exists in your product. The automation surface is not first-class everywhere. Mocking is the practical move.
+
+## Where fixtures help
+
+The full helper-versus-fixture decision tree lives in [Where Fixtures Actually Help](where-fixtures-actually-help.md). Here, the one-line rule is simpler: if multiple tests need the same browser contract, make it a fixture.
+
+Good fixture candidates:
+
+- a `reducedMotionPage` used across a whole accessibility-focused spec file
+- a `clipboardRecorder` fixture that installs the mock and exposes captured writes
+- a `batteryAwarePage` or `offlineCapablePage` used across multiple scenarios
+- a shared `context` fixture that blocks service workers and installs boot-time browser shims
+
+This keeps the interesting part of the spec visible:
+
+```ts
+test('copies the invite link', async ({ clipboardRecorder, page }) => {
+  await page.goto('/settings/team');
+  await page.getByRole('button', { name: 'Copy invite link' }).click();
+  expect(clipboardRecorder.writes).toEqual(['https://shelf.test/invite/abc123']);
+});
+```
+
+That reads like behavior, not setup.
+
+## The gotchas
+
+### Mocking too late
+
+If the app boots before the mock exists, you are already wrong.
+
+### Using a mock when Playwright already has real support
+
+If the thing is geolocation, permissions, clock, locale, viewport, or storage state, start with the first-class Playwright feature. A hand-written mock is usually a downgrade there.
+
+### Returning the value without the shape
+
+Framework code often expects methods and event registration points to exist even if the specific test does not care about them. "It returns the right boolean" is not enough if the component also calls `addEventListener`.
+
+### Mocking auth through `localStorage`
+
+If the real app authenticates through browser state, use `storageState` or the app's real login flow. Mocking auth storage by hand is a great way to create a suite that passes while the actual login path is broken.
+
+### Forgetting cross-browser differences
+
+The more custom your mock gets, the easier it is to accidentally hard-code [Chromium](https://www.chromium.org/chromium-projects/) behavior into a test that you think is portable. This is one of those places where a small smoke pass in [Firefox](https://www.mozilla.org/firefox/) or [WebKit](https://webkit.org/) earns its keep.
+
+## The agent rules
+
+```markdown
+## Mocking browser APIs
+
+- Use Playwright's first-class emulation and browser options before writing a
+  custom browser API mock.
+- Install custom browser API mocks with `page.addInitScript()` or
+  `browserContext.addInitScript()` before navigation.
+- If the app listens for browser API updates, the mock must fire the same
+  events the real API would fire.
+- Keep one-off mocks in the test. Move shared browser-environment contracts
+  into fixtures.
+- Do not fake authentication with ad-hoc `localStorage` writes when
+  `storageState` or the real login flow exists.
+```
+
+## The thing to remember
+
+Browser API mocks are only useful when they preserve the contract your app actually uses. That means early installation, the right object shape, and real event behavior when the component subscribes. Anything less is a fast way to prove your mock works.
+
+## Additional Reading
+
+- [Route-Based Network Interception](route-based-network-interception.md)
+- [Storage State Authentication](storage-state-authentication.md)
+- [Where Fixtures Actually Help](where-fixtures-actually-help.md)
+- [Cross-Browser Validation Without Burning the Dev Loop](cross-browser-validation-without-burning-the-dev-loop.md)

--- a/courses/self-testing-ai-agents/playwright-trace-viewer.md
+++ b/courses/self-testing-ai-agents/playwright-trace-viewer.md
@@ -1,0 +1,191 @@
+---
+title: The Playwright Trace Viewer
+description: How to record, open, filter, and actually use Playwright's trace viewer so failed tests come with evidence instead of vibes.
+modified: 2026-04-12
+date: 2026-04-12
+---
+
+The trace viewer is one of the best debugging tools in the entire front-end ecosystem, and a lot of teams still use it like a screenshot folder. They open `trace.zip`, click around until they feel vaguely smarter, and then go patch the test. That is not a workflow. That is a ritual.
+
+The [Playwright trace viewer docs](https://playwright.dev/docs/trace-viewer) are solid, and the viewer really does give you almost everything you need: action timeline, DOM snapshots, filmstrip, source locations, logs, console output, network traffic, metadata, and attachments. The trick is learning what it is good at so you stop treating it like a video and start treating it like evidence.
+
+The next [Reading a Trace](reading-a-trace.md) lesson is about diagnosis. This lesson is about operating the tool itself: how to record traces sensibly, open them locally or from CI, and use the viewer features that save the most time.
+
+## Record traces with intent
+
+Most teams either record too little or way too much.
+
+The local-development version is simple:
+
+```bash
+npx playwright test --trace on
+```
+
+That records traces for every test in the run. It is great when you are actively debugging one thing. It is lousy as a permanent default because trace recording is not free.
+
+For CI, the official docs recommend something more surgical:
+
+```ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  retries: 1,
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+That setup is smart for exactly the reason you think: passing tests stay cheap, and failing tests get a trace on retry when you actually need the artifact. If you do not use retries, `trace: 'retain-on-failure'` is the next-best default. It is heavier, but still sane.
+
+The options worth remembering:
+
+- `'on-first-retry'`: my default for CI
+- `'retain-on-failure'`: good when you want traces for every failure without enabling retries
+- `'on'`: useful during local debugging, not a great permanent default
+- `'off'`: the setting you forget about until the day you really needed the trace
+
+If you are using the [Playwright test runner](https://playwright.dev/docs/test-intro), prefer the config-level `trace` option. If you are using Playwright as a library, use [`browserContext.tracing`](https://playwright.dev/docs/api/class-tracing).
+
+## Open traces the fast way
+
+The local command is the one everybody knows:
+
+```bash
+npx playwright show-trace path/to/trace.zip
+```
+
+The two workflows people forget about are the ones that matter most in teams.
+
+### Open from the HTML report
+
+If you already have the Playwright report on disk, use:
+
+```bash
+npx playwright show-report
+```
+
+Every failed test in the HTML report has a link to its trace. This is usually the fastest local entry point because the report already groups the failure, the stack, the attachments, and the trace in one place.
+
+### Open remote traces directly
+
+The official docs call this out, and it is surprisingly useful:
+
+```bash
+npx playwright show-trace https://example.com/trace.zip
+```
+
+If your CI uploads `trace.zip` artifacts to some accessible storage, you can jump straight from failure notification to trace viewer without manually downloading and unpacking anything first.
+
+There is also [`trace.playwright.dev`](https://trace.playwright.dev/), the statically hosted viewer. You can drag and drop a trace file into it, or point it at a remote URL with a query parameter:
+
+```text
+https://trace.playwright.dev/?trace=https://example.com/trace.zip
+```
+
+The docs note two important details:
+
+- the viewer loads the trace entirely in your browser
+- cross-origin rules still apply for remote URLs
+
+That second point explains a lot of "works locally, remote trace won't load" confusion. The viewer is fine. Your artifact host is blocking cross-origin access.
+
+## Use the timeline like a filter, not decoration
+
+The top filmstrip and timeline are not just there to look nice. They are the fastest way to narrow the problem space.
+
+The workflow I use:
+
+1. Find the long action.
+2. Double-click it.
+3. Let the viewer filter everything else to that time range.
+
+When you double-click an action, the viewer narrows the visible logs, console output, and network requests to that action window. That is a huge deal. Without filtering, a noisy test looks like ten unrelated problems. With filtering, it usually looks like one.
+
+The same applies to the timeline slider. Drag a range and the viewer filters console and network to only the selected actions. This is one of those features that turns a chaotic failure into something you can actually reason about.
+
+## Know what each tab is good at
+
+The trace viewer has more tabs than most people actively use. The useful mental model is not "memorize all the tabs." It is "know which question each tab answers."
+
+### Actions
+
+This is your table of contents. It tells you what Playwright tried to do, what locator it used, and how long it took. If the action list looks wrong, the test likely _is_ wrong.
+
+### Snapshots
+
+This is where you answer "what did the page look like before, during, and after the action?" The official docs call out three snapshot moments: Before, Action, and After. That Action snapshot is especially helpful when you are debugging a click target because it shows the exact node and click position.
+
+### Source and Call
+
+These tabs answer "where in the test did this happen?" and "what did Playwright think it was doing?" I use them together constantly. Source gives me the line. Call gives me the locator, strict-mode details, keys pressed, and timing.
+
+### Log
+
+This is the "what was Playwright waiting on?" tab. If a click looked instant in your head and took four seconds in the trace, the log usually explains whether Playwright was waiting for visibility, stability, enabled state, or some scroll-into-view step first.
+
+### Console and Network
+
+These are the tabs that make the viewer more than a pretty replay. Browser console output, test-side console output, request timing, headers, request bodies, response bodies. Most real failures stop being mysterious once you line these two tabs up against the action timeline.
+
+### Metadata and Attachments
+
+Metadata is underrated. Browser, viewport, duration, and other run-level facts matter more than people admit, especially once projects or cross-browser runs enter the picture.
+
+Attachments matter anytime the test produces extra artifacts. The official docs call out screenshot diffs here, and it is a good example: actual, expected, diff, all in one place.
+
+## The good workflow for CI failures
+
+When a test fails in CI, this is the sequence I trust:
+
+1. Read the failure summary in the HTML report or dossier.
+2. Open the trace from that failure.
+3. Use the action list to find the slow or failing step.
+4. Filter the viewer to that action range.
+5. Compare snapshots, then inspect console and network.
+6. Only after that decide whether the fix belongs in the test, the app, the config, or the environment.
+
+That order matters because it keeps you from free-associating. The trace viewer is at its best when it is narrowing possibilities.
+
+## The gotchas
+
+### Recording everything forever
+
+`trace: 'on'` everywhere feels safe until artifact storage explodes and the suite slows down. Great for active debugging. Usually the wrong permanent CI default.
+
+### Forgetting the trace starts with the traced context
+
+If you are using the library API, tracing has to start before the interesting navigation. Starting it after the page already loaded is like beginning a screen recording after the bug already happened.
+
+### Confusing "server is noisy" with "trace is noisy"
+
+A trace with twenty requests is not too much information. It is reality. Use action filtering first. The filtering tools are what turn volume into signal.
+
+### Treating the viewer as a substitute for classification
+
+The viewer shows you evidence. It does not name the class of failure for you. That is the bridge to the next lesson: once you know where the evidence lives, you still need to classify the bug correctly.
+
+## The agent rules
+
+```markdown
+## Trace viewer
+
+- Record traces intentionally: `on-first-retry` in CI, `retain-on-failure`
+  when retries are off, and `on` only while actively debugging.
+- Open the trace from the failing report first, then filter to the slow or
+  failing action before reading console or network noise.
+- Use the trace viewer to gather evidence, not to justify a guess.
+- If the trace is remote, try `show-trace <url>` or `trace.playwright.dev`
+  before manually downloading artifacts.
+```
+
+## The thing to remember
+
+The trace viewer is not "nice to have" debugging garnish. It is the fastest way to turn a failed test into a bounded investigation. Record traces on purpose, open them from the failure report, filter aggressively, and let the viewer narrow the story before you touch code.
+
+## Additional Reading
+
+- [Reading a Trace](reading-a-trace.md)
+- [Failure Dossiers: What Agents Actually Need From a Red Build](failure-dossiers-what-agents-actually-need-from-a-red-build.md)
+- [Flaky-Test Triage: When Retries Are Lying to You](flaky-test-triage.md)
+- [Playwright UI Mode](playwright-ui-mode.md)

--- a/courses/self-testing-ai-agents/playwright-web-server-without-surprises.md
+++ b/courses/self-testing-ai-agents/playwright-web-server-without-surprises.md
@@ -1,0 +1,230 @@
+---
+title: 'Playwright `webServer` Without Surprises'
+description: "A practical guide to Playwright's `webServer` option: the common shapes, the options that matter, and the gotchas that waste half a day when you get them wrong."
+modified: 2026-04-12
+date: 2026-04-12
+---
+
+Most `webServer` problems don't look like `webServer` problems. They look like "the test is flaky," "the app works locally but not in CI," or my personal favorite: "Playwright says the server is ready, but the page is obviously not ready." I've lost enough time to this knob that I now treat it as infrastructure, not convenience.
+
+[`webServer`](https://playwright.dev/docs/test-webserver) is Playwright's answer to a very specific question: _what process should be running before the test suite starts, and how do we know it is ready?_ Once you frame it that way, the option gets a lot easier to reason about.
+
+## What `webServer` actually does
+
+At test startup, Playwright will:
+
+1. Spawn the command you configured.
+2. Wait for a port or URL to become available.
+3. Run the tests.
+4. Shut the process down when the run is over.
+
+That is the whole contract. `webServer` is not your deploy system, not your seed system, and not a substitute for application health checks. It is a process launcher with a readiness check.
+
+The boring shape looks like this:
+
+```ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run preview -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+  },
+});
+```
+
+That config answers the two questions that matter:
+
+- What should start? `npm run preview ...`
+- How do we know it is ready? a successful HTTP check against `http://127.0.0.1:4173`
+
+Everything else is tuning.
+
+## The three common shapes
+
+Most real setups fall into one of three buckets.
+
+### One app, one process
+
+This is the standard `frontend starts app, Playwright hits app` flow. [Shelf](https://github.com/stevekinney/shelf-life) lives here. So do most [SvelteKit](https://kit.svelte.dev/), [Next.js](https://nextjs.org/), [Remix](https://remix.run/), and [Vite](https://vite.dev/) apps.
+
+Use `webServer` when the app under test is local and the suite should own its lifecycle.
+
+### Frontend plus backend
+
+Sometimes the browser needs two processes: frontend plus API server, app plus webhook receiver, docs site plus mock identity provider. `webServer` accepts an array for exactly this reason:
+
+```ts
+export default defineConfig({
+  webServer: [
+    {
+      name: 'app',
+      command: 'npm run preview -- --port 4173',
+      url: 'http://127.0.0.1:4173',
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      name: 'api',
+      command: 'npm run api:test',
+      url: 'http://127.0.0.1:8787/health',
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+  },
+});
+```
+
+Use `name`. When two startup logs are interleaved, named prefixes are the difference between "obvious" and "guessing."
+
+### Hosted target
+
+If the thing under test is already deployed—a preview URL, a staging environment, a local container stack somebody else booted—do not add a fake local `webServer` just to make the config symmetrical. Point `baseURL` at the hosted target and leave `webServer` out entirely.
+
+This is the common mistake in smoke suites: people inherit the end-to-end config, so the smoke tests boot a local app even though the real target is a deployed URL. That is not a smoke test anymore. That is a local regression suite wearing a smoke-test badge.
+
+## `port` versus `url`
+
+This is the first gotcha worth memorizing.
+
+- `port` waits until something accepts TCP connections on that port.
+- `url` waits until the URL returns an allowed status code.
+
+Allowed status codes for `url` readiness are broader than people expect: `2xx`, `3xx`, `400`, `401`, `402`, and `403` all count as "server is ready." That is deliberate. The question is "is the server listening and responding?" not "did the application render the exact page I wanted?"
+
+Use `port` when:
+
+- you only care that the process is listening
+- the app has no useful health endpoint
+- you want the simplest possible local check
+
+Use `url` when:
+
+- you want to probe a specific health endpoint like `/health`
+- the app needs warmup work before the real pages are useful
+- you need `ignoreHTTPSErrors`
+- auth redirects or non-200 readiness are part of the normal boot shape
+
+There is one more wrinkle: according to the [Playwright `TestConfig` docs](https://playwright.dev/docs/api/class-testconfig#test-config-web-server), `port` can implicitly set `baseURL`, but `url` does not. And if `webServer` is an array, you must configure `baseURL` explicitly anyway. My advice is simple: always set `use.baseURL` yourself. You will forget this detail exactly once, and it will be on a day you did not have spare patience.
+
+## The options that actually matter
+
+The full option list is longer than the average team needs. These are the ones I keep coming back to.
+
+### `cwd`
+
+`cwd` controls where the process starts. It defaults to the directory of the Playwright config file. In a monorepo, that default is often wrong for at least one of your servers.
+
+If the startup command depends on local files, set `cwd` deliberately.
+
+### `env`
+
+The spawned process inherits `process.env`, and Playwright adds `PLAYWRIGHT_TEST=1`. That default is useful. It gives your app a stable "I am running under Playwright" signal without inventing yet another environment variable.
+
+This is a good place for test-only flags like:
+
+- enabling seed endpoints
+- switching to a temporary database
+- disabling analytics
+- pointing the app at a fake third-party service
+
+What this is _not_ a good place for is a giant blob of production configuration copied from your deployment platform. Keep the test environment minimal and explicit.
+
+### `reuseExistingServer`
+
+This should usually be `!process.env.CI`.
+
+Locally, reusing an already-running server makes the loop faster. In CI, it is the opposite of what you want. CI should start fresh so a stale process cannot make the suite pass for the wrong reason.
+
+The gotcha: if you are building before previewing, a reused local server can be a _stale build_. That is the exact failure mode Shelf calls out elsewhere in the course. When the app behavior does not match the code you just changed, kill the reused server first. Do that before you start debugging the test.
+
+### `stdout`, `stderr`, and `wait`
+
+Output handling is one of those places where people assume the defaults will save them. Sometimes they do. Sometimes the only useful readiness message prints somewhere you are not looking.
+
+If your server chooses its port dynamically or only prints "ready" to stdout, switch `stdout` to `'pipe'` and use `wait.stdout` with a regular expression:
+
+```ts
+webServer: {
+  command: 'npm run app:test',
+  stdout: 'pipe',
+  wait: {
+    stdout: /Listening on port (?<app_port>\d+)/,
+  },
+}
+```
+
+This is an advanced escape hatch, not the default path. If you do use capture groups, keep the names distinct across multiple servers and make sure you have a concrete reason for it beyond "this seemed neat."
+
+### `timeout`
+
+The default startup timeout is 60 seconds. Raise it when the app _honestly_ needs longer. Do not raise it because the wrong readiness check is probing the wrong thing.
+
+If your app is ready at 12 seconds and your `webServer` is still timing out at 60, the problem is almost never "the app is too slow." The problem is usually:
+
+- the command failed and you hid stdout
+- the process is listening on a different port
+- the readiness URL is wrong
+- the app is redirecting somewhere unexpected
+
+### `gracefulShutdown`
+
+If you do not configure shutdown, Playwright will force-kill the process group. That is fine for simple dev servers. It is not always fine for [Docker](https://www.docker.com/) containers, watchers, or servers that need a clean `SIGTERM` path.
+
+The docs explicitly call out that Docker shutdown requires `SIGTERM`, and they also note that Windows ignores `SIGTERM` and `SIGINT` here. That is worth knowing before you start wondering why your teardown behavior differs between local machines and CI.
+
+## The gotchas that matter in practice
+
+### A healthy URL can still be the wrong URL
+
+If your readiness URL is too shallow—say, `/health` returns 200 while the real app is still compiling assets—you will start tests against a half-ready system. `webServer` did its job. Your health check lied.
+
+Pick a readiness signal that exercises the thing the browser actually needs.
+
+### `reuseExistingServer` can hide drift
+
+This is the local-developer tax. Reusing a server is fast, until the reused process does not match your current code or environment. When the failure makes no sense, turn reuse off temporarily or kill the server and rerun. I have saved more time with that blunt move than with any clever debugging trick.
+
+### `webServer` is not a seed hook
+
+Starting the server and seeding the app are different responsibilities. If the suite needs a seeded database, do that in [fixtures](fixtures-worker-scoped-test-scoped.md), [global setup](https://playwright.dev/docs/test-global-setup-teardown), or explicit test helpers. Do not jam seed logic into the startup command and pretend that is cleaner.
+
+### CI does not need a second manual boot step
+
+If `playwright.config.ts` already has a correct `webServer`, your [GitHub Actions](https://github.com/features/actions) workflow usually does _not_ need an extra "start the server in the background" step. Duplicating the lifecycle in CI is how you get port conflicts, races, and two sources of truth.
+
+### Use preview or production-ish start when you care about reality
+
+For end-to-end tests, I usually want the production-ish server path, not the dev server. Dev servers add hot reload, extra transforms, debug overlays, and middleware that do not exist in production. That is sometimes exactly what you want while debugging. It is usually not what you want as the default contract for the suite.
+
+## The agent rules
+
+```markdown
+## Playwright webServer
+
+- `webServer` owns process startup and readiness only. Do not hide seed or
+  migration logic inside the startup command.
+- Set `use.baseURL` explicitly even when Playwright could infer it.
+- Use `reuseExistingServer: !process.env.CI` unless the suite has a specific
+  reason not to.
+- Prefer a production-ish start command (`preview`, `start`) for end-to-end
+  tests and keep dev servers for debugging.
+- If startup fails and the reason is unclear, expose stdout and run again
+  with `DEBUG=pw:webserver`.
+```
+
+## The thing to remember
+
+`webServer` is a contract: start this process, wait for this signal, then run the suite. The moment you treat it like a general-purpose setup hook, it gets weird. Keep the contract small, pick an honest readiness signal, and most of the "mysterious Playwright flake" category disappears.
+
+## Additional Reading
+
+- [Configuring Playwright](configuring-playwright.md)
+- [Playwright Projects](playwright-projects.md)
+- [CI as the Loop of Last Resort](ci-as-the-loop-of-last-resort.md)
+- [Lab: Add Post-Deploy Smoke Checks to Shelf](lab-add-post-deploy-smoke-checks-to-shelf.md)

--- a/courses/self-testing-ai-agents/where-fixtures-actually-help.md
+++ b/courses/self-testing-ai-agents/where-fixtures-actually-help.md
@@ -1,0 +1,201 @@
+---
+title: Where Fixtures Actually Help
+description: A field guide to the setup, state, instrumentation, and app boundaries that actually belong in Playwright fixtures.
+modified: 2026-04-12
+date: 2026-04-12
+---
+
+By the time most teams learn [`test.extend`](https://playwright.dev/docs/test-fixtures), they know _how_ to write a fixture and still don't know _where_ to use one. That is how you end up with a fixture file full of glorified one-liners, mystery state, and three different helpers that all navigate to the same page. I've done this. It feels tidy right up until the suite starts lying to you.
+
+The earlier [fixtures lesson](fixtures-worker-scoped-test-scoped.md) was about scope and teardown. This one is about smell. Specifically: what kinds of problems a fixture solves well in a real app, what kinds of problems it solves badly, and how to recognize the difference before your fixtures file turns into a junk drawer.
+
+## The question a fixture should answer
+
+A good fixture answers one of four questions:
+
+- Who is this test acting as?
+- What state does the app start in?
+- What extra visibility does the test need?
+- What environment does the browser need to believe?
+
+If your setup does not answer one of those questions, it is probably not a fixture. It is probably a helper function, a page-object method, a seed script, or just a line of code that should stay in the test.
+
+> [!TIP] A decent smell test
+> If the noun keeps showing up in test signatures across multiple files, that noun might deserve to become a fixture. If it only shows up once, keep it local.
+
+## Actor fixtures
+
+This is the most obvious fixture category, and also the one that pays rent the fastest. Tests often need to act as a specific _kind_ of user: an authenticated reader, an administrator API client, an anonymous browser context, a premium customer with feature flags turned on.
+
+That is fixture territory because the thing being shared is not "steps" but _identity_:
+
+```ts
+import { test as base } from '@playwright/test';
+
+type ReaderFixtures = {
+  authenticatedReaderPage: import('@playwright/test').Page;
+};
+
+export const test = base.extend<ReaderFixtures>({
+  authenticatedReaderPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: 'playwright/.authentication/user.json',
+    });
+
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+});
+```
+
+The important part is not that the fixture opens a page. The important part is that the fixture gives the test a _reader-shaped browser_. Once that concept shows up in five or six specs, the fixture is cheaper than duplicating the context setup everywhere.
+
+This is also where [`APIRequestContext`](https://playwright.dev/docs/api/class-apirequestcontext) fixtures shine. If your test needs an administrator actor on the side while the browser stays logged in as a reader, a fixture that hands you an authenticated API client is the cleanest version of the pattern. The [APIRequestContext lesson](api-request-context-beyond-storage-state.md) is basically this idea stretched into a full workflow.
+
+## State fixtures
+
+A state fixture exists to answer: _what world does this test start in?_ Seeded shelf. Empty cart. Account with an expired subscription. Book already rated. Feature flag already enabled.
+
+This is where I see the most under-use. Teams reach for fixtures when they want an authenticated page, but not when they want deterministic state. That is backwards. Auth is a convenience. Deterministic state is survival.
+
+The simplest full version looks like this:
+
+```ts
+import { test as base } from '@playwright/test';
+
+type StateFixtures = {
+  seededShelf: void;
+};
+
+export const test = base.extend<StateFixtures>({
+  seededShelf: async ({ request }, use) => {
+    await resetShelfContent(request);
+    await use();
+    await resetShelfContent(request);
+  },
+});
+```
+
+The test that consumes it doesn't care _how_ the shelf got seeded. It cares that the shelf starts from a known place and leaves the next test a clean room behind it. That is a perfect fixture contract.
+
+Where this becomes especially useful in a real application:
+
+- Resetting the database before every test that mutates application state
+- Seeding a specific business case, like a reader with overdue books or a team with one failed invoice
+- Mounting feature flags or experiment assignments the app reads at boot
+- Installing a fixed clock or locale so relative dates stop drifting between runs
+- Preloading third-party test doubles, like a fake webhook endpoint or canned analytics handler
+
+The common mistake is making the fixture too specific. `readerWithTwoUnreadBooksAndOneDraftReview` is not a reusable abstraction. `seededReader` and `seededShelf` probably are. Put the domain detail in the seed helper, not in a seven-word fixture name.
+
+## Instrumentation fixtures
+
+Some fixtures exist because the test needs more _visibility_, not more setup. [Shelf](https://github.com/stevekinney/shelf-life)'s overridden `page` fixture is the example I come back to because it is boring in exactly the right way: it forwards browser console errors and failed network requests so the runner, the HTML report, and the failure dossier all see them.
+
+That pattern scales better than people think.
+
+Useful instrumentation fixtures include:
+
+- A wrapped `page` that forwards `console.error` output to stderr
+- A wrapped `page` or `context` that records failed requests with method, URL, and error text
+- A request fixture that logs key API calls for failure dossiers
+- A page fixture that installs test-only observers for performance marks or client-side errors
+- A fixture that attaches extra artifacts to `testInfo`, such as serialized app state on failure
+
+This is one of my favorite uses for fixtures because it moves diagnostics out of the test body. The spec keeps talking about behavior. The fixture quietly makes the artifacts better.
+
+## Environment fixtures
+
+Sometimes the test is not trying to change the app's server-side state at all. It is trying to change what the _browser believes_. Different timezone. Different permissions. Clipboard support. Reduced motion. Online versus offline. Experimental APIs that the browser doesn't support directly.
+
+That setup also belongs in fixtures when it is shared and repeatable:
+
+```ts
+mobileReaderContext: async ({ browser }, use) => {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    colorScheme: 'light',
+    timezoneId: 'America/Denver',
+  });
+
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await use(context);
+  await context.close();
+},
+```
+
+The mental model here is simple: if the browser context needs to be shaped a certain way before the app boots, that shape is a good candidate for a fixture.
+
+The new [Mocking Browser APIs](mocking-browser-apis.md) lesson goes deeper on the APIs Playwright doesn't model directly. The short version is that fixtures are a good home for [`browserContext.addInitScript()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-add-init-script) and permission setup because both need to happen _before_ navigation.
+
+## Boundary fixtures
+
+This category sits right at the seam between your app and something outside it: an API, an auth provider, a background worker, a payment gateway, a search index. You don't always want a fixture here. But when the same seam shows up in a lot of tests, a fixture can keep the suite from growing sideways.
+
+Examples:
+
+- An authenticated admin API client that seeds state through HTTP instead of UI clicks
+- A route-mocking fixture that blocks analytics or image requests for every test in a file
+- A fixture that points the app at a local fake email server or webhook receiver
+- A fixture that bootstraps a browser context with a captured auth session
+
+This is where composition starts to feel powerful. One fixture can give you the authenticated browser. Another can give you the seeded backend state. A third can add diagnostics. The test body just asks for the world it needs and then gets on with it.
+
+## Things that should stay out of fixtures
+
+Now for the fun part: the stuff people keep trying to smuggle into `fixtures.ts`.
+
+Don't make a fixture for:
+
+- One-off navigation like `page.goto('/settings')`
+- Assertions like "open the page and verify the heading is visible"
+- Tiny constants used by one test file
+- Pure data builders that do not need Playwright lifecycle or teardown
+- Business logic helpers that could run perfectly well outside the test runner
+- Page-object methods wearing fake infrastructure costumes
+
+If the code is just steps, keep it as steps. Fixtures are not "shared code." Fixtures are shared code that needs Playwright's dependency graph and teardown lifecycle. That is a much smaller set.
+
+## A practical decision tree
+
+When I am on the fence, this is the sequence I use:
+
+1. Does this setup show up in multiple tests or files?
+2. Does it need to run before the test body starts?
+3. Does it need teardown after the test body finishes?
+4. Does it produce a thing the test will _ask for_ by name?
+
+If the answer is yes all the way down, I probably want a fixture.
+
+If the answer breaks at step 1, it is local helper code.
+
+If the answer breaks at step 3, it might still be a helper function or seed script rather than a fixture.
+
+If the answer breaks at step 4, I am probably trying to hide behavior instead of expose a useful dependency.
+
+## The agent rules
+
+```markdown
+## Choosing fixtures
+
+- Use a fixture when the shared concern is actor identity, deterministic
+  starting state, browser environment, or diagnostics instrumentation.
+- Name fixtures after what they provide (`seededShelf`, `adminRequest`,
+  `authenticatedReaderPage`), not after the implementation steps.
+- If the setup is used once, keep it in the test or move it to a helper.
+- If the setup mutates state, the fixture owns teardown after `await use(...)`.
+- Prefer composing two small fixtures over building one giant fixture that
+  hides half the test's world behind a vague name.
+```
+
+## The thing to remember
+
+Fixtures are not where shared code goes. Fixtures are where shared _test dependencies_ go. Actor, state, environment, diagnostics. Those are the four buckets. Stay inside them and fixtures make the suite smaller, clearer, and more deterministic. Wander outside them and you get a helper graveyard with teardown bugs.
+
+## Additional Reading
+
+- [Fixtures: Worker-Scoped, Test-Scoped, and the Trap Between Them](fixtures-worker-scoped-test-scoped.md)
+- [APIRequestContext: Beyond Storage State](api-request-context-beyond-storage-state.md)
+- [Deterministic State and Test Isolation](deterministic-state-and-test-isolation.md)
+- [Mocking Browser APIs](mocking-browser-apis.md)


### PR DESCRIPTION
## Summary
- add five new `self-testing-ai-agents` lessons covering fixture use cases, `webServer`, browser API mocking, guardrail bypass prevention, and the Playwright trace viewer
- register the new lessons in the course index and move the guardrails lesson into the Static Layer section for better course flow
- correct the existing `git-hooks-with-lefthook.md` hook examples so they match the updated guardrails guidance

## Review committee
Pre-reviewed by: prose-editor, simplicity-engineer, junior-engineer
- 2 rounds of review
- all accepted must-fix items addressed

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR. See `tmp/committee-state.md` for detail. This pull request was reviewed by the committee without Codex's independent check.

## Test plan
- `bun run lint`
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change set; the only behavioral change is small regex/exit-flow tweaks in code snippets that don’t affect runtime code.
> 
> **Overview**
> Expands the `self-testing-ai-agents` course with five new lessons covering Playwright `webServer` usage, when fixtures are worth it, mocking browser APIs, using the trace viewer, and preventing guardrail bypass (e.g., `--no-verify`).
> 
> Updates the course index to include the new lessons and positions **“Making It Hard to Cheat the Guardrails”** in the *Static Layer* section.
> 
> Adjusts `git-hooks-with-lefthook.md` hook examples to match the guardrails guidance (regex for detecting `--no-verify` and explicit `process.exit(0)` after emitting a deny response).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc02f1044bfa54dd6db2cecb045dfdfe753ba950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->