### PR TITLE
Fix typo in how tests work documentation

### DIFF
--- a/courses/testing/how-tests-work.md
+++ b/courses/testing/how-tests-work.md
@@ -41,7 +41,7 @@ it('should pass', () => {
 });
 ```
 
-What we can summise—outside of the fact that I spelled it ou in that second test there is that a test fails when an error is thrown. This means that if we got _really_ board, we _could_ write our own super naïve version of `expect` that is missing a lot of the niceities of the one provided by Vitest or Jest or whatever.
+What we can summise—outside of the fact that I spelled it ou in that second test there is that a test fails when an error is thrown. This means that if we got _really_ bored, we _could_ write our own super naïve version of `expect` that is missing a lot of the niceities of the one provided by Vitest or Jest or whatever.
 
 ```javascript
 const expect = (a) => {


### PR DESCRIPTION
Corrected a typo from 'board' to 'bored' in the explanation of test failures.