### PR TITLE
Fix: serve the Atom feed as application/atom+xml (not octet-stream)

### DIFF
--- a/applications/website/src/routes/writing/rss/+server.ts
+++ b/applications/website/src/routes/writing/rss/+server.ts
@@ -44,7 +44,7 @@ export async function GET() {
 
   return new Response(xml, {
     headers: {
-      'Content-Type': 'application/rss+xml',
+      'Content-Type': 'application/atom+xml; charset=utf-8',
       'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
       'Access-Control-Allow-Origin': '*',
       'Last-Modified': updated.toUTCString(),

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "installCommand": "bun install",
   "buildCommand": "LD_LIBRARY_PATH=$PWD/node_modules/@img/sharp-libvips-linux-x64/lib bun run build",
-  "ignoreCommand": "if [ -n \"$VERCEL_GIT_PULL_REQUEST_ID\" ] && [ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" != \"stevekinney\" ]; then echo \"Skipping preview build for fork PR\"; exit 0; fi; exit 1"
+  "ignoreCommand": "if [ -n \"$VERCEL_GIT_PULL_REQUEST_ID\" ] && [ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" != \"stevekinney\" ]; then echo \"Skipping preview build for fork PR\"; exit 0; fi; exit 1",
+  "headers": [
+    {
+      "source": "/writing/rss",
+      "headers": [{ "key": "Content-Type", "value": "application/atom+xml; charset=utf-8" }]
+    }
+  ]
 }


### PR DESCRIPTION
Hi Steve — thanks for the writing! I went to subscribe in FreshRSS and it couldn't add the feed, so I dug in a little. Small fix below.

## What's happening

`https://stevekinney.com/feed` → `301` → `/writing/rss` responds with:

```
content-type: application/octet-stream
content-disposition: inline; filename="rss"
```

The body is a valid Atom feed, so browsers render the raw XML happily, but readers that sniff the content type (FreshRSS, etc.) reject `application/octet-stream`.

## Why

`src/routes/writing/rss/+server.ts` sets a `Content-Type`, but the route is `prerender = true`, so it's built to an **extensionless static file** (`writing/rss`). Once it's a static asset, Vercel infers the type from the file extension and falls back to `octet-stream` — response headers set inside a prerendered endpoint don't survive to the CDN. `/sitemap.xml` dodges this only because its filename happens to end in `.xml`.

## Fix (minimal, keeps the `/writing/rss` URL)

- **`vercel.json`** — assert `Content-Type: application/atom+xml; charset=utf-8` for `/writing/rss` (the [adapter-vercel-recommended](https://kit.svelte.dev/docs/adapter-vercel) way to set headers on prerendered routes).
- **`+server.ts`** — relabel the response `application/atom+xml` (it was `application/rss+xml`, but the document is Atom) so the dev server and production agree.

No URL changes, so existing subscribers and the `/feed`, `/rss`, `/rss.xml`, `/atom.xml` redirects are unaffected.

## Verify

```bash
curl -sIL https://stevekinney.com/writing/rss | grep -i content-type
# before: content-type: application/octet-stream
# after:  content-type: application/atom+xml; charset=utf-8
```

Totally understand if you'd rather tweak the approach (e.g. keep the `rss+xml` label) — happy to adjust. Thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)