### PR TITLE
Avoid caching node_modules in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-
+            ${{ runner.os }}-bun-v2-
 
       - name: Cache image preprocessing outputs
         uses: actions/cache@v4
@@ -86,9 +86,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-
+            ${{ runner.os }}-bun-v2-
 
       - name: Cache image preprocessing outputs
         uses: actions/cache@v4
@@ -162,9 +162,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-
+            ${{ runner.os }}-bun-v2-
 
       - name: Cache image preprocessing outputs
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: bun run continuous-integration:build
 
       - name: Check build budget
-        run: bun check-build-budget
+        run: bun packages/scripts/build-report/check-build-budget.ts
 
       - name: Upload build report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
       - name: Cache Bun dependencies
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.bun/install/cache
-            node_modules
+          path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
@@ -87,9 +85,7 @@ jobs:
       - name: Cache Bun dependencies
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.bun/install/cache
-            node_modules
+          path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
@@ -165,9 +161,7 @@ jobs:
       - name: Cache Bun dependencies
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.bun/install/cache
-            node_modules
+          path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-

--- a/applications/website/src/routes/writing/[slug]/+page.svelte
+++ b/applications/website/src/routes/writing/[slug]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { page } from '$app/state';
   import { env } from '$env/dynamic/public';
   import Date from '$lib/components/date.svelte';
   import ContentEnhancements from '$lib/components/content-enhancements.svelte';
@@ -11,7 +10,7 @@
 
   const { data } = $props();
 
-  const baseUrl = env.PUBLIC_SITE_URL || page.url.origin;
+  const baseUrl = env.PUBLIC_SITE_URL || url;
 
   const articleJsonLd = $derived(
     buildArticleSchema({


### PR DESCRIPTION
## Summary
- stop restoring `node_modules` from the broad Bun dependency cache fallback
- keep caching Bun's package cache so `bun install --frozen-lockfile --ignore-scripts` starts from a clean dependency tree

## Verification
- bunx prettier --check .github/workflows/ci.yml
- bunx bun@1.3.2 install --frozen-lockfile --ignore-scripts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI caching and a small URL fallback change for article schema; no auth, security, or data-path changes.
> 
> **Overview**
> CI’s Bun dependency cache no longer restores **`node_modules`**—only **`~/.bun/install/cache`**—with a bumped **`bun-v2`** cache key so each job runs **`bun install`** against a fresh tree while still speeding installs from Bun’s package cache. The same cache block is updated in **validation**, **build**, and **integration**.
> 
> On writing article pages, structured-data **`baseUrl`** now falls back to **`url`** from **`$lib/metadata`** instead of **`page.url.origin`**, dropping the **`$app/state`** **`page`** import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a600e26602f9eceb6c82e4f0bcadd3ce27f6501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->