### PR TITLE
Fix Atom feed content type

### DIFF
--- a/applications/website/src/routes/writing/rss/+server.ts
+++ b/applications/website/src/routes/writing/rss/+server.ts
@@ -44,7 +44,7 @@ export async function GET() {
 
   return new Response(xml, {
     headers: {
-      'Content-Type': 'application/atom+xml',
+      'Content-Type': 'application/atom+xml; charset=utf-8',
       'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
       'Access-Control-Allow-Origin': '*',
       'Last-Modified': updated.toUTCString(),

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
   "ignoreCommand": "if [ -n \"$VERCEL_GIT_PULL_REQUEST_ID\" ] && [ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" != \"stevekinney\" ]; then echo \"Skipping preview build for fork PR\"; exit 0; fi; exit 1",
   "headers": [
     {
+      "source": "/writing/rss",
+      "headers": [{ "key": "Content-Type", "value": "application/atom+xml; charset=utf-8" }]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         { "key": "X-Frame-Options", "value": "DENY" },


### PR DESCRIPTION
## Summary

- Serve `/writing/rss` as `application/atom+xml; charset=utf-8` from the SvelteKit route.
- Add the same `Content-Type` header in `vercel.json` for the prerendered Vercel route.
- Applies the same fix proposed in #95 on a branch that is current with `main`.

## Review committee

Pre-reviewed by: dx-engineer, simplicity-engineer
- 1 round of review
- All must-fix items addressed

## Test plan

- `bunx prettier --check applications/website/src/routes/writing/rss/+server.ts vercel.json`
- `bun run content:validate`
- `bun run build && bunx build-report && bun run check-build-budget`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only change for the RSS route with no auth, data, or business-logic impact.
> 
> **Overview**
> Sets the writing Atom feed (`/writing/rss`) to declare **`application/atom+xml; charset=utf-8`** instead of `application/atom+xml` without a charset.
> 
> The SvelteKit `GET` handler updates the response `Content-Type`, and **`vercel.json`** adds a route-specific header so the same type is sent for the prerendered deployment path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5a26740afe9027b206d0c992bc7954378c3f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->