### PR TITLE
Use Bun ecosystem for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary

- Switch Dependabot's JavaScript package updater from `npm` to `bun`.
- This makes Dependabot update the repository's Bun lockfile instead of producing package-only updates that fail `bun install --frozen-lockfile`.

## Root Cause

The open Dependabot pull requests were generated with `package-ecosystem: npm`, but this repository uses Bun and commits `bun.lock`. CI correctly failed during `bun install --frozen-lockfile --ignore-scripts` because those Dependabot branches changed `package.json` without the matching `bun.lock` updates.

## Review Committee

Pre-reviewed by:
- Codex (gpt-5.4, xhigh reasoning) — 1 round
- dx-engineer (codex fallback, medium reasoning)
- simplicity-engineer (codex fallback, medium reasoning)
- All reviewers approved with no must-fix items.

## Test Plan

- `bun install --frozen-lockfile --ignore-scripts`
- `bunx prettier --check .github/dependabot.yml`
- `bun run continuous-integration:validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Dependabot config change with no runtime or application code impact.
> 
> **Overview**
> **Dependabot** is configured to use the **`bun`** package ecosystem instead of **`npm`** for the repo root, so weekly dependency PRs update **`bun.lock`** alongside **`package.json`**.
> 
> That aligns automated updates with how CI installs deps (`bun install --frozen-lockfile`), avoiding Dependabot branches that only touch **`package.json`** and fail the frozen lockfile check. The **github-actions** updater is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8466e4948b8549b50db18dcb855f4731f7a1149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->