### PR TITLE
Add Components navigation link

### DIFF
--- a/packages/components/navigation.svelte
+++ b/packages/components/navigation.svelte
@@ -14,7 +14,9 @@
     href="https://cinder.website/"
     target="_blank"
     rel="noopener noreferrer"
-    aria-label="Components, opens in a new tab">Components</Link
+    aria-label="Components, opens in a new tab"
   >
+    Components
+  </Link>
   <Link href="https://buttondown.com/stevekinney" target="_blank">Newsletter</Link>
 </nav>

--- a/packages/components/navigation.svelte
+++ b/packages/components/navigation.svelte
@@ -10,5 +10,11 @@
 <nav class={merge('flex items-center gap-4', className)} aria-label="Main Navigation">
   <Link href="/writing">Writing</Link>
   <Link href="/courses">Courses</Link>
+  <Link
+    href="https://cinder.website/"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Components, opens in a new tab">Components</Link
+  >
   <Link href="https://buttondown.com/stevekinney" target="_blank">Newsletter</Link>
 </nav>


### PR DESCRIPTION
## Summary

Adds a `Components` link to the top navigation that points to https://cinder.website/.

The link follows the existing external navigation pattern and makes the new-tab behavior explicit with `aria-label` plus `rel="noopener noreferrer"`.

## Review committee

Pre-reviewed by: frontend-architect, ux-designer, simplicity-engineer, codex
- frontend-architect: approved
- ux-designer: suggested making the external/new-tab behavior explicit; addressed
- simplicity-engineer: approved
- codex: suggested making `rel` explicit; addressed

## Test plan

- `bun lint`
- pre-commit hook: content validation, staged formatting, staged lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single navigation markup change with no auth, data, or business-logic impact.
> 
> **Overview**
> Adds a **Components** item to the main nav that points to `https://cinder.website/`, placed between Courses and Newsletter.
> 
> The link opens in a new tab with `target="_blank"`, `rel="noopener noreferrer"`, and an `aria-label` that states it opens in a new tab—matching the external-link pattern used for Newsletter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ebf7d8f80504ae35c564cc9f94b35466428b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->