### PR TITLE
Update AI Development course for Cursor and Claude Code

### DIFF
--- a/courses/ai-development/README.md
+++ b/courses/ai-development/README.md
@@ -1,32 +1,35 @@
 ---
-modified: 2026-03-17
 title: Developing with AI Tools
-layout: page
 description: >-
-  Set up a practical AI-assisted development workflow with Cursor and Claude
-  Code—covering context management, custom commands, hooks, MCP servers, and
-  model selection.
+  Learn practical workflows for Cursor, Claude Code, MCP, and agentic software
+  development with current installation, context, permission, and review
+  guidance.
+modified: 2026-06-23
 date: 2025-07-30
 ---
 
-This course covers all the things that I have learned about using AI-powered tools like [Cursor](https://cursor.com) and [Claude Code](https://www.anthropic.com/claude-code) to write software. Since this kind of stuff can go out of date quickly, I try to focus on the battle-tested approaches that have worked for decades: thinking things through before you jump into the code, maintaining good Git discipline so you can revert back to a known good state whenever things go off the rails, testing, linting code quality, and more.
+This course is about using agentic development tools without handing them the
+steering wheel by accident. The current core tools are
+[Cursor](https://cursor.com/) and
+[Claude Code](https://code.claude.com/docs/en/overview). Both can edit files, run
+commands, call MCP servers, create branches, and review changes. That power is
+the point. It is also why the workflow needs structure.
 
-We also spend a decent amount of time accidentally learning how large language models work and how to effectively manage context.
+The course baseline was refreshed on June 23, 2026 against official Cursor and
+Claude Code documentation and changelogs. Exact model menus, pricing, and version
+numbers will continue to change, so model-specific claims are dated or phrased as
+volatile.
 
-And, of course, we'll actually cover the tools themselves. You'll learn to use advanced AI coding assistants like Claude Code and Cursor, understand the Model Context Protocol (MCP) for extending AI capabilities, and master patterns that ensure consistent, high-quality results.
+The durable lessons are:
 
-> [!NOTE] This is designed to be a companion.
-> These are my notes for my course for [Frontend Masters](https://frontendmasters.com/?utm_source=kinney&utm_medium=social&code=kinney) and are designed to be supplementary to that course. If they're helpful to you outside of the course, then that's an added bonus. There is also plenty of content that I won't get to in the course. So, these notes serve as a way to assuage my guilt about the very practical trade-offs that come from the fact that you can only fit so much stuff into a single day.
+- Give the agent the files, rules, and verification commands that define
+  correctness.
+- Use rules for always-on constraints and skills for repeatable workflows.
+- Keep permissions explicit, especially for shell commands, MCP tools, cloud
+  agents, and automation.
+- Review diffs and run the quality gates yourself before shipping.
+- Persist durable knowledge in the repository, not in a chat transcript.
 
-## Resources and References
-
-- [Basic React, TypeScript, and Tailwind Template](https://github.com/stevekinney/basic-template)
-- [Model Context Protocol Overview](https://modelcontextprotocol.io/overview)
-- [Repomix](https://repomix.com/) - Tool for preparing repository content for AI analysis
-- [Extended Thinking Mode (Anthropic)](https://www.anthropic.com/news/visible-extended-thinking) - Documentation on Claude's thinking capabilities
-- [cursor.directory](https://cursor.directory) - Community examples for Cursor rules
-- [awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) - Collection of Cursor rules examples
-- [Crystal](https://github.com/stravu/crystal): A tool for managing Git worktrees for Claude Code.
-- [Claude Code Sub-Agents Collection](https://github.com/augmnt/agents)
-- [Awesome Claude Prompts](https://github.com/langgptai/awesome-claude-prompts)
-- [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code?tab=readme-ov-file)
+You should finish this course with a working mental model for when to use inline
+edits, chat, local agents, cloud agents, subagents, hooks, automations, MCP, and
+continuous integration integrations.

--- a/courses/ai-development/README.md
+++ b/courses/ai-development/README.md
@@ -1,5 +1,6 @@
 ---
 title: Developing with AI Tools
+layout: page
 description: >-
   Learn practical workflows for Cursor, Claude Code, MCP, and agentic software
   development with current installation, context, permission, and review

--- a/courses/ai-development/README.md
+++ b/courses/ai-development/README.md
@@ -8,19 +8,19 @@ modified: 2026-06-23
 date: 2025-07-30
 ---
 
-This course is about using agentic development tools without handing them the
-steering wheel by accident. The current core tools are
+When you give an agent the power to edit files, run commands, call
+[MCP](https://modelcontextprotocol.io/) servers, create branches, and review
+changes, the hard part is no longer getting it to act. The hard part is keeping
+it pointed at the right target. The current core tools are
 [Cursor](https://cursor.com/) and
-[Claude Code](https://code.claude.com/docs/en/overview). Both can edit files, run
-commands, call MCP servers, create branches, and review changes. That power is
-the point. It is also why the workflow needs structure.
+[Claude Code](https://code.claude.com/docs/en/overview).
 
 The course baseline was refreshed on June 23, 2026 against official Cursor and
 Claude Code documentation and changelogs. Exact model menus, pricing, and version
 numbers will continue to change, so model-specific claims are dated or phrased as
 volatile.
 
-The durable lessons are:
+The tools will change. The habits that keep you out of trouble are more durable:
 
 - Give the agent the files, rules, and verification commands that define
   correctness.

--- a/courses/ai-development/claude-code-and-bash-scripts.md
+++ b/courses/ai-development/claude-code-and-bash-scripts.md
@@ -7,6 +7,9 @@ modified: 2026-06-24
 date: 2025-07-29
 ---
 
+The first time an agent runs the wrong shell command confidently, you learn why
+terminal output needs to be evidence, not vibes.
+
 [Claude Code](https://code.claude.com/docs/en/overview) can run shell commands,
 and users can run bash commands inside a session. As of Claude Code 2.1.186,
 commands entered with `!` trigger a Claude response by default unless

--- a/courses/ai-development/claude-code-and-bash-scripts.md
+++ b/courses/ai-development/claude-code-and-bash-scripts.md
@@ -1,46 +1,53 @@
 ---
 title: Claude Code and Bash Scripts
 description: >-
-  Learn how Claude Code integrates with shell environments to create, execute,
-  and iterate on bash scripts for automated development workflows
-modified: 2026-03-17
+  Use Claude Code with shell commands and repository scripts while keeping
+  command execution auditable, bounded, and reproducible.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Claude Code is designed to integrate seamlessly with your shell environment, providing a flexible and scriptable power tool for developers.
+[Claude Code](https://code.claude.com/docs/en/overview) can run shell commands,
+and users can run bash commands inside a session. As of Claude Code 2.1.186,
+commands entered with `!` trigger a Claude response by default unless
+`respondToBashCommands` is set to `false`.
 
-- **Direct Execution and Generation**: Claude Code can reliably **create, execute, and iterate on bash scripts** of easy to medium complexity to automate various processes. It can run a script, interpret its output or errors, and then iterate on the script until it works as requested, creating a "tightest agentic debug loop" with instant feedback. This allows for dynamic generation of "ephemeral problem solving scripts" by one sub-agent for use by another, creating a dynamic ecosystem of autonomous tool generation and consumption.
-- **Accessing Shell Environment**: Claude Code inherits your bash environment, giving it access to all your command-line tools. This means it can use common utilities like Unix tools (e.g., `cat`, `grep`) and the `gh` CLI for GitHub interactions. For instance, it can search Git history, write commit messages, and handle complex Git operations like resolving rebase conflicts.
-- **Documenting Custom Tools**: To help Claude understand and use your custom bash tools, you should explicitly **tell it the tool name with usage examples** and instruct it to run `--help` to see tool documentation. It's also recommended to document frequently used custom bash tools in your project's `CLAUDE.md` file.
-- **Pipelining Data**: Claude Code can act as a **Unix-style utility** by allowing you to pipe data directly into it (`cat foo.txt | claude -p "query"`) and receive output, which is particularly useful for processing logs or CSVs. This enables integrating Claude into existing shell scripts and combining it with other Unix tools for powerful workflows. You can specify the output format, such as `text`, `json`, or `stream-json`, for easier automated processing.
+That makes terminal output part of the conversation. Treat it as evidence.
 
-## Enhancing Workflows with Bash via Claude Code Features
+## Prefer Repository Scripts
 
-Claude Code's extensibility relies on user-initiated custom slash commands and event-driven hooks, both of which can leverage bash scripts for powerful automations.
+Ask Claude to run documented scripts instead of ad hoc command chains:
 
-- **Custom Slash Commands**: You can create your own **reusable prompt templates** by adding Markdown files to the `.claude/commands/` directory (project-scoped) or `~/.claude/commands/` (user-scoped). These files can contain **dynamic content, including bash commands (`!`)**, whose output gets inserted into the prompt. This allows for encapsulating complex multi-step workflows into a single command, such as auto-generating commit messages or creating pull requests.
-- **Hooks**: Claude Code Hooks are user-defined shell commands that **execute automatically at specific lifecycle events** within a Claude Code session. These events include `PreToolUse` (before a tool is used), `PostToolUse` (after a tool is used), `Notification`, and `Stop`. A critical event for multi-agent workflows is `SubagentStop`, which fires when a sub-agent task completes.
-  - **Deterministic Control**: Hooks provide **deterministic control** over Claude Code's behavior, ensuring certain actions always happen. For example, a `PostToolUse` hook can be configured to automatically run linters (`ruff`, `black`) or test suites (`pytest`) after a file is edited, enforcing code quality and providing immediate feedback.
-  - **Security Guardrails**: Hooks can also act as security guardrails by blocking the agent from modifying sensitive files (e.g., `.env`, `.git/`) using `PreToolUse` hooks.
-  - **Debugging Hooks**: You can verify loaded hook configurations using the `/hooks` slash command. For verbose output on hook execution and errors, launch Claude Code with the `--verbose` or `--debug` flag.
-- **Headless Mode (`-p` flag)**: Claude Code's headless mode (`claude -p "query"`) is fundamental for **programmatic integration into non-interactive environments** like automation scripts and CI/CD pipelines.
-  - **Use Cases**: This mode enables large-scale code migrations by fanning out tasks to multiple Claude Code invocations. It can also power automated issue triage by having Claude analyze issue content and apply labels, or generate release notes from commit messages.
-  - **Structured Output**: Using `--output-format json` or `--output-format stream-json` in headless mode allows for programmatic parsing of Claude's responses, making it easy to integrate into larger processing pipelines.
-  - **Permissions**: While generally prioritizing safety, you can use the `--dangerously-skip-permissions` flag for complete automation in controlled, isolated environments (e.g., Docker Dev Containers with no internet access) to prevent accidental system damage.
+```text
+Run the targeted test command from package.json. If it fails, report the command
+and failure before editing files.
+```
 
-## Multi-Agent Workflows and Bash Orchestration
+Good scripts are repeatable. Long one-off shell pipelines are harder to review
+and easier to get wrong.
 
-Bash scripts are central to orchestrating **multi-agent collaboration** in Claude Code, where different Claude instances (subagents) work in parallel on specialized tasks.
+## Make Commands Bounded
 
-- **Git Worktrees for Isolation**: To prevent conflicts and maintain clean code isolation when running multiple Claude Code agents simultaneously on the same codebase, **Git worktrees are highly recommended**. Each worktree allows an agent to operate in its own isolated branch, and these sessions can be launched in new terminal tabs. Bash scripts are often used to automate the creation and management of these worktrees.
-- **Specialized Frameworks**: Frameworks built on Claude Code, such as **Claude-Flow** (`npx claude-flow`) and **BMad-Method** (`npx bmad-method install`), simplify the management and coordination of agent teams. These frameworks utilize bash scripts and Node.js for their installation and operation.
-  - For instance, BMad Method creates `.bmad-core/` and `.claude/commands/` folders with agent command files (Markdown) upon installation when selecting Claude Code as the IDE. You activate these agents by typing `/agent-name` in chat (e.g., `/bmad-master`).
-- **Role-Based Collaboration**: Multi-agent setups allow defining distinct roles (e.g., Architect, Builder, Validator, Scribe), mirroring human agile teams. These agents can communicate and coordinate through shared planning documents (e.g., `PLAN.md`, `ISSUE.md`), acting as persistent memory for the agent swarm.
+Avoid commands that can hang forever, write to production, or mutate broad state.
+For investigation, prefer:
 
-## General Tips and Tricks for Bash/Scripting Integration
+```bash
+rg "expired token" src tests
+git status --short
+bun test src/lib/server/invitations.test.ts
+```
 
-- **Plan Diligently**: Always start with a detailed plan. Instruct Claude Code _not to write code yet_, but rather to analyze existing code or documentation and write out a plan in a Markdown file. This structured roadmap significantly improves results.
-- **Structured Instructions and `CLAUDE.md`**: Provide Claude with **clear, direct, and structured instructions**. The `CLAUDE.md` file is automatically read by Claude Code and serves as a persistent, project-specific memory for coding standards, common bash commands, architecture, and key workflows. You can link to other relevant documentation files within `CLAUDE.md` (e.g., `@docs/testing.md`) to avoid making it too large.
-- **Commit Often**: Regularly commit changes with Git, especially when agents are making modifications. This ensures you have checkpoints to revert to and creates a clear history of the agent's work.
-- **Cost Management**: Be mindful that running multiple parallel agents, especially with powerful models like Opus, can be costly due to significant token consumption. Effective context management and planning help reduce wasted tokens.
-- **Debugging**: Utilize the `--verbose` flag for detailed output on Claude's thought process and tool calls, which is helpful for debugging both interactive and headless mode invocations. The `/doctor` command checks the health of your Claude Code installation, including npm permissions.
+For dangerous operations, require an explicit explanation before execution:
+
+```text
+Before running any command that deletes files, changes branches, or writes to an
+external service, explain the command and wait for approval.
+```
+
+## Turn Repeated Shell Work into Scripts
+
+If a command sequence becomes part of the workflow, commit it as a script with a
+clear name. Then rules, skills, hooks, and humans can all call the same thing.
+
+Agents are good at reasoning over command output. Build systems should still be
+owned by the repository.

--- a/courses/ai-development/claude-code-and-bash-scripts.md
+++ b/courses/ai-development/claude-code-and-bash-scripts.md
@@ -11,9 +11,11 @@ The first time an agent runs the wrong shell command confidently, you learn why
 terminal output needs to be evidence, not vibes.
 
 [Claude Code](https://code.claude.com/docs/en/overview) can run shell commands,
-and users can run bash commands inside a session. As of Claude Code 2.1.186,
-commands entered with `!` trigger a Claude response by default unless
-`respondToBashCommands` is set to `false`.
+and users can run bash commands inside a session. As of
+[Claude Code 2.1.186](https://code.claude.com/docs/en/changelog), commands
+entered with `!` trigger a Claude response by default unless
+[`respondToBashCommands`](https://code.claude.com/docs/en/settings) is set to
+`false`.
 
 That makes terminal output part of the conversation. Treat it as evidence.
 

--- a/courses/ai-development/claude-code-commands.md
+++ b/courses/ai-development/claude-code-commands.md
@@ -39,8 +39,9 @@ If it grows steps, examples, or tool policy, move it to a skill.
 ## Built-In Skills
 
 Claude Code ships bundled skills such as code review, batching, debugging, loops,
-and Claude API work. Use those before writing your own version. A custom skill is
-worth it when the repository has local conventions the bundled skill cannot know.
+and [Claude API](https://docs.anthropic.com/en/api/overview) work. Use those
+before writing your own version. A custom skill is worth it when the repository
+has local conventions the bundled skill cannot know.
 
 ## Migration Pattern
 

--- a/courses/ai-development/claude-code-commands.md
+++ b/courses/ai-development/claude-code-commands.md
@@ -1,79 +1,56 @@
 ---
-title: Claude Code Commands
+title: Claude Code Commands and Skills
 description: >-
-  Create and use custom slash commands to encapsulate expertise and workflows
-  into reusable, project-scoped and user-scoped command templates
-modified: 2026-03-17
+  Migrate Claude Code custom commands toward Skills while understanding how
+  .claude/commands still works.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-At their core, custom slash commands are Markdown files that contain instructions for Claude Code. When you invoke a slash command, its content becomes the prompt sent to Claude. This mechanism allows you to codify expertise and best practices into an executable format, enhancing user convenience and standardizing team knowledge.
+[Claude Code Skills](https://code.claude.com/docs/en/skills) are now the primary
+way to package reusable workflows. Custom commands in `.claude/commands/*.md`
+still work, but new substantial workflows should usually become skills.
 
-Claude Code supports two main types of slash commands:
+## What Changed
 
-- **Project-scoped commands**: These commands are specific to a particular project and are stored in the `.claude/commands/` directory within your project's root. They are **version-controlled** and shared with anyone else working on the repository, ensuring consistent procedures and prompts across the team. You access them using the `/project:command_name` or `/project:category:command_name` syntax.
-- **User-scoped commands (Personal Commands)**: Stored in your home directory's `~/.claude/commands/` folder, these commands are available to you across all your projects. They are ideal for personal workflow preferences and productivity enhancers. You invoke them with `/user:command_name`.
+Older lessons often taught custom commands as the main extension point:
 
-## How to Create Custom Slash Commands
+```text
+.claude/commands/review.md
+```
 
-Creating a custom slash command is straightforward:
+That still creates a slash command. The modern shape is:
 
-1. **Create the directory**: First, create the appropriate directory for your command scope:
-   - For project-scoped commands: `mkdir -p .claude/commands`.
-   - For user-scoped commands: `mkdir -p ~/.claude/commands`.
-2. **Create the Markdown file**: Inside this directory, create a Markdown file (`.md` extension). The filename (without the `.md` extension) will become the command name.
-3. **Add instructions**: Populate the Markdown file with the instructions you want Claude to execute.
+```text
+.claude/skills/code-review/
+  SKILL.md
+```
 
-**Example**: To create a project-scoped command named `optimize`: `echo "Analyze the performance of this code and suggest three specific optimizations:" > .claude/commands/optimize.md`. You would then use `/project:optimize` in your Claude session.
+Skills can include frontmatter, instructions, scripts, references, assets,
+allowed tools, disallowed tools, model preferences, effort, hooks, and agent
+configuration. That makes them better for workflows that need more than one
+Markdown file.
 
-## Key Features and Advanced Usage
+## When a Command Is Still Fine
 
-Custom slash commands offer several features to enhance their utility:
+Use `.claude/commands` for a tiny slash command that is mostly a prompt shortcut.
+If it grows steps, examples, or tool policy, move it to a skill.
 
-- **Namespacing**: You can organize commands into subdirectories to create logical and scalable command structures. For instance, a file at `.claude/commands/frontend/component.md` creates the command `/project:frontend:component`.
-- **Arguments (`$ARGUMENTS`)**: To create flexible commands that accept user input, include the `$ARGUMENTS` placeholder within your Markdown file. Whatever you type after the command in the Claude Code CLI will be passed as arguments.
-  - **Example**: A `fix-issue.md` command could contain: `Find and fix issue #$ARGUMENTS. Follow these steps: 1. Understand the issue…`. You would then invoke it as `/project:fix-issue 1234` to have Claude fix issue #1234.
-- **YAML Frontmatter**: Command files can include YAML frontmatter for metadata, such as `allowed-tools` (a list of tools the command can use) and `description` (a brief description of the command).
-- **Dynamic Content**: You can include dynamic content using bash commands (`!`) and file references (`@`) within your Markdown files.
-- **MCP Prompts as Slash Commands**: Model Context Protocol (MCP) servers can expose prompts that automatically become available as slash commands in Claude Code. These appear with the format `/mcp__servername__promptname`. This allows Claude to access specialized capabilities like controlling a web browser or querying a database via integrated external services.
+## Built-In Skills
 
-## Common Slash Command Examples
+Claude Code ships bundled skills such as code review, batching, debugging, loops,
+and Claude API work. Use those before writing your own version. A custom skill is
+worth it when the repository has local conventions the bundled skill cannot know.
 
-The community has developed numerous practical slash commands for various tasks:
+## Migration Pattern
 
-### GitHub/PR Workflows
+When migrating a command:
 
-    - `/project:fix-github-issue` or `/project:fix-issue`: Analyzes and fixes a GitHub issue by number, including steps for understanding the problem, searching the codebase, implementing changes, running tests, and creating a descriptive commit and PR.
-    - `/commit`: Auto-generates a commit message and commits staged changes.
-    - `/create-pr`: Handles the entire PR creation process, from branching and committing to formatting code and pushing to GitHub.
+1. Create `.claude/skills/<name>/SKILL.md`.
+2. Move the command instructions into the skill.
+3. Add scripts or references instead of lengthening the entrypoint.
+4. Keep the slash command name only if users already rely on it.
+5. Delete stale command files once the skill covers the workflow.
 
-### Code Quality and Testing
-
-    - `/project:optimize`: Analyzes code performance and suggests specific optimizations.
-    - `/user:security-review`: Reviews code for security vulnerabilities.
-    - `/test`: Runs unit tests and reports results.
-    - `/check`: Runs a battery of static analysis, security scans, and style checks.
-    - `/clean`: Automatically formats code, sorts imports, fixes lint errors, and resolves type-checker complaints.
-    - `/repro-issue`: Takes an issue number and generates a failing test case to reproduce the bug.
-    - `/tdd`: Guides Claude through a strict Test-Driven Development (TDD) process (red-green-refactor).
-
-### Context and Documentation
-
-    - `/context-prime`: Proactively loads an overview of the project and key design documents to give Claude a "warm start".
-    - Commands to generate or update changelogs and `README` files.
-    - BMad Method agents are activated by typing `/agent-name` in chat.
-    - SuperClaude includes commands like `/user:build` (with flags for `--react`, `--api`, `--tdd`) and `/user:design` (with flags like `--ddd`) for structured project phases. It also offers `/user:analyze` for profiling, security, or architecture analysis, and `/user:troubleshoot` for bug investigation.
-
-## Best Practices, Tips, and Tricks
-
-To maximize the effectiveness of your custom slash commands:
-
-- **Standardize and Share**: For team consistency, store project-scoped commands in your `.claude/commands/` directory and commit them to version control.
-- **Conciseness and Structure**: Keep your Markdown files readable and organized using headings and bullet points. A highly effective structure includes distinct sections to constrain the agent's behavior and guide it through a more deterministic process.
-- **Encapsulate Complex Instructions**: Use slash commands to turn multi-line, nuanced prompts into single, memorable commands. This helps codify team knowledge and best practices into an executable format.
-- **Complement `CLAUDE.md`**: Slash commands complement Claude Code's memory system (`CLAUDE.md`). Use `CLAUDE.md` for guidelines, preferences, and context that apply consistently across many tasks, while slash commands are for specific, repeatable procedures that follow a defined workflow.
-- **Optimize Token Usage**: By reducing repetitive instructions, custom commands can lead to more efficient interactions and potentially lower token consumption.
-- **Guide the LLM**: Simply providing a one-line prompt might give the LLM too much creative freedom. Structure your commands to explicitly guide Claude's behavior and provide clear direction.
-- **Leverage Discoverability**: Commands automatically appear when you type `/` in the Claude Code CLI, making them easy to discover and use.
-- **Automate Beyond Prompts**: While slash commands influence Claude's reasoning via structured prompting, they can also be combined with **hooks** for more deterministic control. Hooks are user-defined shell commands that execute automatically at specific points in Claude Code's lifecycle (e.g., `PreToolUse`, `PostToolUse`). This allows you to enforce quality control, security, and workflow integration without relying on the LLM to remember procedural instructions. For example, a `PreToolUse` hook can block dangerous actions, and a `PostToolUse` hook can automatically run a linter or tests after a file is edited.
-- **Human Oversight**: Even with advanced automation, human oversight is crucial, especially for broader architectural decisions. You can interrupt Claude's autonomous operations at any time (`Esc`) to course-correct its actions or clarify instructions, preventing it from going down the wrong path.
+Do not keep two copies of the same instruction. Duplicate agent instructions
+drift quickly.

--- a/courses/ai-development/claude-code-compaction.md
+++ b/courses/ai-development/claude-code-compaction.md
@@ -46,6 +46,8 @@ invisible automation.
 
 ## Large Context Is Not a Replacement
 
-Large-context model aliases such as `sonnet[1m]` and `opus[1m]` can reduce the
-need to compact, but they do not remove the need for clean task state. A million
-tokens of unclear conversation is still unclear.
+Large-context model aliases such as
+[`sonnet[1m]`](https://code.claude.com/docs/en/model-config) and
+[`opus[1m]`](https://code.claude.com/docs/en/model-config) can reduce the need to
+compact, but they do not remove the need for clean task state. A million tokens
+of unclear conversation is still unclear.

--- a/courses/ai-development/claude-code-compaction.md
+++ b/courses/ai-development/claude-code-compaction.md
@@ -7,9 +7,10 @@ modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Compaction summarizes a long [Claude Code](https://code.claude.com/docs/en/overview)
-session so work can continue with less context. It is useful, but it is also a
-compression step. Details can be lost.
+When a [Claude Code](https://code.claude.com/docs/en/overview) session gets long
+enough that nobody can remember which decision mattered, compaction starts to
+look attractive. It summarizes the session so work can continue with less
+context. That helps, but it is still compression. Details can be lost.
 
 ## What to Preserve Before Compacting
 

--- a/courses/ai-development/claude-code-compaction.md
+++ b/courses/ai-development/claude-code-compaction.md
@@ -1,37 +1,50 @@
 ---
-title: Claude Code Compaction
+title: Compacting Claude Code Sessions
 description: >-
-  Manage context windows and reduce token costs by compacting conversation
-  history into focused summaries while preserving key information
-modified: 2026-03-17
+  Use Claude Code compaction deliberately, preserve task state in files, and
+  avoid relying on long chat history for correctness.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Compacting in Claude Code is a **feature designed to manage the conversation's context window**, which is the amount of information the AI agent can process at one time.
+Compaction summarizes a long [Claude Code](https://code.claude.com/docs/en/overview)
+session so work can continue with less context. It is useful, but it is also a
+compression step. Details can be lost.
 
-As your conversation with Claude Code grows longer and longer, more data accumulates in the context window. Since every subsequent message you send includes the entire previous context, this can lead to increasing token costs and potential degradation of response quality as the model tries to keep track of a vast amount of information.
+## What to Preserve Before Compacting
 
-## Why It Even Exists
+Before a long task compacts, make sure the important state is in the filesystem:
 
-The primary purpose of compacting is to **reduce token usage** and prevent the context window from becoming overwhelmed. It helps maintain focus and ensures that the agent doesn't "forget" initial instructions or deviate from the plan during long or complex tasks.
+- The plan is written in a file or reflected in tests.
+- The branch diff is coherent.
+- Verification commands are known.
+- Blockers are documented with command output.
+- Decisions are captured in `CLAUDE.md`, rules, skills, or project
+  documentation when they need to persist.
 
-When you use the `/compact` command, Claude Code **takes your entire current conversation history and creates a summary of it**. It then starts a new chat session with this summary preloaded as the new context. This allows the agent to retain important information and key decisions from the previous conversation without having to carry forward every single message.
+If a future session needs to remember a subtle decision, put that decision in a
+file before compaction.
 
-## When to Use It
+## Manual Compaction
 
-- **Manual Trigger**: You can manually run `/compact` at any time, especially when you are continually working through a problem and want a smaller, more focused context for the model. It's recommended to do this when you finish a task to avoid unrelated tasks piling up in the same chat.
-- **Automatic Compaction**: Claude Code has an auto-compact feature that triggers when the context window reaches approximately **95% capacity** (or 25% remaining). This is a built-in mechanism to prevent hitting the context limit and causing the system to "break" or "go off the rails". However, users often advise against waiting for auto-compact, as it can sometimes lead to the agent losing important context and spiraling out of control.
+Use compaction when the session is still on the same goal but the context is
+getting noisy. After compaction, ask Claude to restate:
 
-## Benefits
+```text
+Restate the goal, files changed, remaining tasks, and verification commands.
+Do not edit files.
+```
 
-- **Reduced Token Usage and Cost**: By summarizing lengthy conversations, compacting directly reduces the number of tokens sent with each new message, leading to **lower operational costs**.
-- **Improved Focus and Stability**: It helps Claude Code stay on track, preventing it from getting lost in details or deviating from objectives in long conversations. This makes the overall development experience more stable.
-- **Context Preservation**: Unlike clearing the context completely, compacting preserves the essential nuances and key information, allowing you to pick up where you left off without significant disruption.
+Compare that answer with `git diff` and the task plan before continuing.
 
-You can provide specific instructions to customize what Claude summarizes when using `/compact`, such as summarizing only to-do items, the last conversation, or limiting the summary to a certain word count.
+## Hooks Around Compaction
 
-## Compared to using `/clear`
+Claude Code exposes hook events around compaction. Use them sparingly for
+auditing or preserving status, not for hiding critical project state in an
+invisible automation.
 
-Compacting is distinct from the `/clear` command. While `/clear` completely wipes out the chat history and starts a brand new conversation from scratch, `/compact` summarizes the conversation and preloads that summary as the new context. Use `/clear` when you want a completely fresh start, and `/compact` when you need to retain key information from a previous discussion.
+## Large Context Is Not a Replacement
 
-Auto-compacting can sometimes take a while, so manual compacting when you have time is suggested.
+Large-context model aliases such as `sonnet[1m]` and `opus[1m]` can reduce the
+need to compact, but they do not remove the need for clean task state. A million
+tokens of unclear conversation is still unclear.

--- a/courses/ai-development/claude-code-hook-control-flow.md
+++ b/courses/ai-development/claude-code-hook-control-flow.md
@@ -1,75 +1,54 @@
 ---
 title: Claude Code Hook Control Flow
 description: >-
-  Master hook communication through exit codes and JSON output to control
-  Claude's behavior with blocking, approval, and continuation mechanisms
-modified: 2026-03-17
+  Understand how Claude Code hook decisions, permission prompts, exits, and JSON
+  responses influence the agent loop.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Hooks communicate status back to Claude Code primarily through **shell exit codes** and, for more sophisticated control, **structured JSON output** to standard output (stdout). Hooks receive JSON data via standard input (stdin) that provides session and event-specific information, such as `session_id`, `transcript_path`, `tool_name`, `tool_input`, and `tool_response` (depending on the hook event).
+Hook control flow is where [Claude Code](https://code.claude.com/docs/en/hooks)
+stops being "just prompting" and starts looking like a small policy engine.
 
-## Simple Control: Exit Code
+## The Basic Flow
 
-The most fundamental way hooks communicate status is through their **shell exit code**.
+A typical tool action can pass through:
 
-- **Exit Code 0**: Indicates success. The hook ran without issues, and execution continues normally. Any output sent to `stdout` is shown to the user in the transcript view (Ctrl-R) but **is not seen by Claude**.
-- **Exit Code 2**: Signals a **blocking error**. This is a critical signal that tells Claude Code to **halt the current action** (especially for `PreToolUse` hooks) and process the feedback provided by the hook. This feedback is read from the **`stderr` stream**, not `stdout`. Claude uses this feedback as new input to understand the error and adjust its plan.
-- **Other Non-Zero Exit Codes**: Indicate a non-blocking error. The hook failed, but the agent's execution continues. An error message from `stderr` is shown to the user, but it is **not fed back to Claude**.
+1. Prompt expansion or instruction hooks.
+2. Pre-tool hooks.
+3. Permission checks.
+4. Tool execution.
+5. Post-tool or failure hooks.
+6. Agent response.
 
-A common pitfall is that many standard CLI tools write error messages to `stdout` by default, requiring developers to explicitly redirect their output to `stderr` (e.g., `command >&2`) for Claude to receive blocking error feedback.
+Different hook types can observe, add context, block, or request a decision.
 
-## Advanced Control: JSON Output
+## Deny Clearly
 
-Beyond simple exit codes, hooks can return **structured JSON** to `stdout` for more granular control over Claude's flow.
+When a hook blocks an action, return a message that tells the agent and human
+what happened:
 
-### Common JSON Fields (for All Hook types)
+```text
+Denied: generated files under applications/website/.generated must not be edited
+directly. Change the source generator and rerun the content build.
+```
 
-- `"continue"`: A boolean (default `true`). If set to `false`, **Claude stops all processing after the hook runs**. This is the ultimate override and takes precedence over any `"decision": "block"` output.
-- `"stopReason"`: A string message that accompanies `continue: false`. This reason is shown to the user, but **not to Claude**.
-- `"suppressOutput"`: A boolean (default `false`). If `true`, the hook's `stdout` is hidden from the user's transcript view.
+A vague denial causes loops. A precise denial creates the next step.
 
-**Specific Decision Control Fields (depending on hook event):**
+## Prefer Declarative Permission Rules First
 
-## `PreToolUse` Decision Control
+If a permission rule can express the policy, use the permission rule. Reach for a
+hook when the decision depends on logic: file contents, command parsing, current
+branch, changed files, or external state.
 
-- `"decision": "approve"`: Bypasses the standard permission prompt and allows the tool call to proceed. The `reason` is shown to the user but not to Claude.
-- `"decision": "block"`: **Prevents the tool call from executing**. The `reason` field is crucial here, as its content is **fed back to Claude**, explaining why the action was blocked and guiding it on how to proceed.
-- `"decision": undefined`: Leads to the existing permission flow. The `reason` is ignored.
+## Avoid Hidden Retries
 
-## `PostToolUse` Decision Control
+Do not use hooks to silently retry failing commands, raise timeouts, or suppress
+warnings. A failed hook should surface the issue. Hidden retries make the session
+harder to reason about and can hide real bugs.
 
-- `"decision": "block"`: **Automatically prompts Claude with the `reason` provided**. Note that for `PostToolUse` hooks, the tool has already run successfully, so this cannot prevent the action but can provide feedback for future actions.
-- `"decision": undefined`: Does nothing. The `reason` is ignored.
+## Test Hook Scripts
 
-## `Stop`/`SubagentStop` Decision Control
-
-- `"decision": "block"`: **Prevents Claude from stopping**. The `reason` field **must be provided** for Claude to know how to proceed and continue its work. This provides a powerful mechanism for ensuring complex tasks are fully completed.
-- `"decision": undefined`: Allows Claude to stop. The `reason` is ignored.
-
-The layered system has a clear priority: `continue: false` overrides everything, followed by a JSON `"decision": "block"`, then the simpler exit code 2 mechanism.
-
-## Practical Examples of Returning JSON and Providing Reasons
-
-Using `decision: "block"` with a `reason` is highly effective for enforcing rules and guiding Claude:
-
-- **Enforcing Project Conventions (PreToolUse)**: If Claude tries to use a disallowed package manager like `npm` in a `bun`-only project.
-  - **Hook Logic**: A `PreToolUse` hook matching `Bash` commands could check the command input for "npm". If found, it would output JSON with `"decision": "block"` and a `reason` like: `"Project convention violation: Do not use npm. This project uses the bun package manager."`.
-  - **Outcome**: Claude receives this explicit, machine-driven feedback and corrects its subsequent commands to use `bun` instead, without relying on prompt instructions.
-- **Security Boundaries (PreToolUse)**: Preventing modifications to sensitive files.
-  - **Hook Logic**: A `PreToolUse` hook matching `Edit` tool calls for file paths like `.env` or `.git/`. The hook would exit with code `2` (or JSON `decision: "block"`) and output to `stderr` a `reason` such as: `"Error: Direct modification of sensitive configuration files (.env) is blocked by policy."`.
-  - **Outcome**: The edit is blocked, and Claude receives clear instructions to reconsider its plan.
-- **Quality Gates (PreToolUse)**: Preventing pull requests if tests are failing.
-  - **Hook Logic**: A `PreToolUse` hook matching the `mcp__github__create_pr` tool (if using MCP GitHub integration). The hook would execute the project's test suite (e.g., `pytest`). If tests fail, it outputs JSON with `"decision": "block"` and a `reason` detailing the test failures.
-  - **Outcome**: PR creation is blocked, and Claude is instructed to fix the failing tests before proceeding.
-- **Forcing Task Continuation (Stop/SubagentStop)**: Ensuring complex tasks are fully completed.
-  - **Hook Logic**: A `Stop` hook that checks for a specific condition (e.g., all tasks in a checklist are marked done). If the condition is not met, it outputs JSON with `"decision": "block"` and a `reason` like: `"The main task is not yet complete. Please continue working on the remaining items in the checklist."`.
-  - **Outcome**: Claude is prevented from stopping and receives a clear instruction to continue its work.
-
-## Configuration and Debugging
-
-Hooks are configured in Claude Code's settings files, typically `~/.claude/settings.json`, `.claude/settings.json`, or `.claude/settings.local.json`. They are organized by matchers (which can be tool names, regex patterns, or empty for all events) and an array of commands to execute.
-
-To debug hooks, you can use the `/hooks` slash command to verify configuration, test commands manually, check exit codes, ensure `stdout` vs. `stderr` expectations are met, and use `claude --debug` for verbose output.
-
-Using hooks for control flow is like setting up a **smart, automated gatekeeper** in your development pipeline. Instead of just letting your AI agent run freely and hoping it follows all your complex instructions, you're placing intelligent checkpoints. If the agent tries to do something you don't want (like modify a crucial file) or something that isn't ready (like create a PR with failing tests), the gatekeeper springs into action, not only stopping the problematic action but also telling the agent _exactly why_ it was stopped and _what it needs to do next_ to get back on track. This ensures consistency, quality, and security, allowing you to "steer" the AI effectively without constant manual oversight.
+If a hook calls a script, test the script directly with captured input fixtures.
+The hook configuration should be boring; the tested script should own the
+policy.

--- a/courses/ai-development/claude-code-hook-control-flow.md
+++ b/courses/ai-development/claude-code-hook-control-flow.md
@@ -27,12 +27,13 @@ Different hook types can observe, add context, block, or request a decision.
 
 For command hooks, the output stream and exit behavior matter:
 
-| Hook response       | What it means                                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Exit `0`            | Continue. Use `stdout` only for intentional structured output.                                                           |
-| Exit `2`            | Block or steer the action when the event supports blocking. Put the reason in `stderr` so the user and agent can see it. |
-| Other non-zero exit | Treat as hook failure. Surface the failure instead of silently continuing.                                               |
-| JSON on `stdout`    | Use documented fields such as `decision`, `reason`, and `continue` when a hook needs structured control.                 |
+| Hook response               | What it means                                                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Exit `0`                    | Continue. Use `stdout` only for intentional structured output.                                                           |
+| Exit `2`                    | Block or steer the action when the event supports blocking. Put the reason in `stderr` so the user and agent can see it. |
+| Other non-zero exit         | Treat as hook failure. Surface the failure instead of silently continuing.                                               |
+| PreToolUse JSON on `stdout` | Put permission decisions under `hookSpecificOutput.permissionDecision`.                                                  |
+| Other hook JSON on `stdout` | Use documented top-level fields such as `decision`, `reason`, and `continue` when that event supports them.              |
 
 Not every event can block the same way. Pre-tool and permission-oriented hooks
 are the right place for guardrails. Post-tool hooks are better for logging,

--- a/courses/ai-development/claude-code-hook-control-flow.md
+++ b/courses/ai-development/claude-code-hook-control-flow.md
@@ -23,6 +23,21 @@ A typical tool action can pass through:
 
 Different hook types can observe, add context, block, or request a decision.
 
+## The Blocking Contract
+
+For command hooks, the output stream and exit behavior matter:
+
+| Hook response       | What it means                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Exit `0`            | Continue. Use `stdout` only for intentional structured output.                                                           |
+| Exit `2`            | Block or steer the action when the event supports blocking. Put the reason in `stderr` so the user and agent can see it. |
+| Other non-zero exit | Treat as hook failure. Surface the failure instead of silently continuing.                                               |
+| JSON on `stdout`    | Use documented fields such as `decision`, `reason`, and `continue` when a hook needs structured control.                 |
+
+Not every event can block the same way. Pre-tool and permission-oriented hooks
+are the right place for guardrails. Post-tool hooks are better for logging,
+auditing, and follow-up context.
+
 ## Deny Clearly
 
 When a hook blocks an action, return a message that tells the agent and human

--- a/courses/ai-development/claude-code-hook-examples.md
+++ b/courses/ai-development/claude-code-hook-examples.md
@@ -19,8 +19,13 @@ Use a pre-tool hook to deny edits under a generated directory:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit",
-        "command": "bun scripts/deny-generated-edits.ts"
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun scripts/deny-generated-edits.ts"
+          }
+        ]
       }
     ]
   }

--- a/courses/ai-development/claude-code-hook-examples.md
+++ b/courses/ai-development/claude-code-hook-examples.md
@@ -1,121 +1,18 @@
 ---
-title: Claude Code Hook Examples
+title: Claude Code Hook Cookbook
 description: >-
-  Practical examples and cookbook for implementing custom hooks to automate
-  workflows and enforce development policies
-modified: 2026-03-17
+  Examples of small Claude Code hooks for generated files, dangerous shell
+  commands, compaction notes, and subagent audit.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-This cookbook shows copy-ready hook configurations and shell scripts for common guardrails and automations. Hooks run shell commands on specific events (see Hook Control Flow) and can block actions in PreToolUse by exiting with code 2 and writing the explanation to stderr.
+Hooks should be small enough that you can explain them in one sentence. The
+examples here are patterns, not copy-paste production policy.
 
-## Conventions
+## Block Generated File Edits
 
-- Place project-scoped settings in `.claude/settings.json` and scripts in `.claude/hooks/` (mark scripts executable).
-- Exit codes: `0` = allow/ok; `2` = block (PreToolUse only, message to stderr for Claude); other non‑zero = non‑blocking error shown to user.
-- Keep messages short and actionable; Claude will read stderr on blocks and adjust its plan.
-
-## Firewall: Block Dangerous Bash Commands
-
-Blocks `rm -rf`, `git reset --hard`, and network curls in PreToolUse for `Bash`.
-
-`.claude/settings.json` (excerpt)
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/pre-bash-firewall.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-`.claude/hooks/pre-bash-firewall.sh`
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-# stdin: JSON with .tool_input.command
-cmd=$(jq -r '.tool_input.command // ""')
-
-# Block list (add as needed)
-deny_patterns=(
-  'rm\s+-rf\s+/'
-  'git\s+reset\s+--hard'
-  'curl\s+http'
-)
-
-for pat in "${deny_patterns[@]}"; do
-  if echo "$cmd" | grep -Eiq "$pat"; then
-    echo "Blocked command: matches denied pattern '$pat'. Use a safer alternative or explain why it's necessary." 1>&2
-    exit 2
-  fi
-done
-
-exit 0
-```
-
-## Policy: Enforce Package Manager
-
-Blocks `npm` in repos that use `pnpm` and suggests the replacement.
-
-`.claude/hooks/pre-bash-enforce-pnpm.sh`
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-cmd=$(jq -r '.tool_input.command // ""')
-
-if [ -f pnpm-lock.yaml ] && echo "$cmd" | grep -Eq '\bnpm\b'; then
-  echo "This repo uses pnpm. Replace 'npm' with 'pnpm' (e.g., 'pnpm install', 'pnpm run <script>')." 1>&2
-  exit 2
-fi
-
-exit 0
-```
-
-Add it alongside the firewall in `PreToolUse` for `Bash`.
-
-## Protect Sensitive Files on Edit
-
-Blocks edits to protected paths and binaries.
-
-`.claude/hooks/pre-edit-protect-paths.sh`
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-file=$(jq -r '.tool_input.path // ""')
-
-deny_globs=(
-  ".env*"
-  ".git/*"
-  "package-lock.json"
-  "node_modules/*"
-  "*.png" "*.jpg" "*.gif" "*.mp4"
-)
-
-for g in "${deny_globs[@]}"; do
-  if printf '%s\n' "$file" | grep -Eiq "^${g//\*/.*}$"; then
-    echo "Edits to '$file' are blocked by policy. Propose changes elsewhere or explain why this is required." 1>&2
-    exit 2
-  fi
-done
-
-exit 0
-```
-
-`settings.json` matcher for Edit tool:
+Use a pre-tool hook to deny edits under a generated directory:
 
 ```json
 {
@@ -123,124 +20,40 @@ exit 0
     "PreToolUse": [
       {
         "matcher": "Edit",
-        "hooks": [{ "type": "command", "command": ".claude/hooks/pre-edit-protect-paths.sh" }]
+        "command": "bun scripts/deny-generated-edits.ts"
       }
     ]
   }
 }
 ```
 
-## Auto‑Format, Lint, and Typecheck After Edits
+The script should inspect the hook input and return a clear denial when the file
+is generated. Keep the path policy in the script so it can be tested.
 
-Runs formatting and quality checks after successful edits. If checks fail, writes a concise summary for Claude.
+## Warn on Dangerous Bash Commands
 
-`.claude/hooks/post-edit-quality.sh`
+Use a permission or pre-tool hook to require approval for commands that deploy,
+delete, force-push, or print secrets. The hook should block the command and tell
+the user exactly why.
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-msg()
-{
-  echo "$*"
-}
-
-if [ -f package.json ]; then
-  # Adjust commands to your stack
-  npx prettier -w . || true
-  if ! pnpm -s lint; then msg "Lint failed. Please fix lint errors."; fi
-  if ! pnpm -s typecheck; then msg "Typecheck failed. Please resolve TS errors."; fi
-fi
-
-exit 0
+```text
+Denied: command matches a production deployment pattern. Ask the user for
+explicit approval with the exact command.
 ```
 
-`settings.json` matcher for PostToolUse on Edit:
+## Preserve Compaction State
 
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit",
-        "hooks": [{ "type": "command", "command": ".claude/hooks/post-edit-quality.sh" }]
-      }
-    ]
-  }
-}
+A pre-compact hook can write a short status file:
+
+```text
+goal, changed files, completed checks, remaining checks, blockers
 ```
 
-## Auto‑Commit After Successful Edit
+Do not use this as the only state store. It is a safety net for long sessions.
 
-Creates small commits to keep a trail of agent work. Consider pairing with a pre-commit hook that enforces formatting.
+## Audit Background Subagents
 
-`.claude/hooks/post-edit-commit.sh`
+A subagent stop hook can record the subagent name, tools used, and returned
+summary. That is useful when background work affects a main implementation.
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-git add -A
-if ! git diff --cached --quiet; then
-  # Simple commit message; or generate with a script summarizing the diff
-  git commit -m "chore(ai): apply Claude edit"
-fi
-
-exit 0
-```
-
-Append this command to the `PostToolUse` Edit list after quality checks.
-
-## Block PR Creation if Tests Fail
-
-Prevents `mcp__github__create_pull_request` unless tests pass.
-
-`.claude/hooks/pre-pr-requires-tests.sh`
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-if pnpm -s test -- --reporter=dot; then
-  exit 0
-else
-  echo "Tests are failing. Fix tests before creating a PR." 1>&2
-  exit 2
-fi
-```
-
-Matcher example:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "mcp__github__create_pull_request",
-        "hooks": [{ "type": "command", "command": ".claude/hooks/pre-pr-requires-tests.sh" }]
-      }
-    ]
-  }
-}
-```
-
-## Log Bash Commands for Audit
-
-Writes each Bash command to a log file with timestamps.
-
-`.claude/hooks/pre-bash-log.sh`
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-cmd=$(jq -r '.tool_input.command // ""')
-printf '%s %s\n' "$(date -Is)" "$cmd" >> .claude/bash-commands.log
-exit 0
-```
-
-## Tips
-
-- Test scripts directly in your shell first; then wire into hooks.
-- Keep block messages specific and constructive so Claude can self‑correct.
-- Prefer PreToolUse for policy guards; PostToolUse for cleanup and feedback.
-- Quote variables; avoid unsafe expansions; use absolute paths for critical tools.
+Keep audit logs local unless the team has agreed on retention and privacy.

--- a/courses/ai-development/claude-code-hooks.md
+++ b/courses/ai-development/claude-code-hooks.md
@@ -7,9 +7,11 @@ modified: 2026-06-24
 date: 2025-07-29
 ---
 
-[Claude Code hooks](https://code.claude.com/docs/en/hooks) let you run command,
-HTTP, LLM prompt, or agent hooks around the session lifecycle. Hooks are powerful
-because they can influence tool use and decisions. That also makes them risky.
+I reach for [Claude Code hooks](https://code.claude.com/docs/en/hooks) when I've
+told an agent the same safety rule twice and I want the repository to enforce it
+the third time. Hooks let you run command, HTTP, LLM prompt, or agent hooks
+around the session lifecycle. They are powerful because they can influence tool
+use and decisions. That also makes them risky.
 
 ## Common Events
 

--- a/courses/ai-development/claude-code-hooks.md
+++ b/courses/ai-development/claude-code-hooks.md
@@ -1,147 +1,53 @@
 ---
-title: Claude Code Hooks
+title: Claude Code's Hooks
 description: >-
-  Learn how to use event-driven hooks to provide deterministic control over
-  Claude's behavior and automate development workflows
-modified: 2026-03-17
+  Use Claude Code hooks for observable, testable integration points around
+  prompts, tools, permissions, compaction, files, and subagents.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Claude Code Hooks are **user-defined shell commands that trigger automatically based on specific events** within a Claude Code session. They provide a **deterministic control layer** over the agent's behavior, ensuring that certain actions or rules are _always_ enforced, rather than relying on the Large Language Model (LLM) to remember or choose to run them. This deterministic enforcement is a key distinction from mere prompting instructions.
+[Claude Code hooks](https://code.claude.com/docs/en/hooks) let you run command,
+HTTP, LLM prompt, or agent hooks around the session lifecycle. Hooks are powerful
+because they can influence tool use and decisions. That also makes them risky.
 
-## Why Use Hooks?
+## Common Events
 
-Hooks are crucial for building robust, efficient, and semi-autonomous development workflows. Their benefits include:
+Claude Code exposes many hook events, including:
 
-- **Enforcing Rules and Standards**: Hooks transform suggestions into application-level policies, guaranteeing that best practices like running linters or adhering to security policies are executed every time, without fail.
-- **Automation**: They enable automated tasks such as running code formatters, executing tests, or sending notifications.
-- **Quality Control**: Hooks can act as quality gates, preventing actions (like creating a Pull Request) if certain criteria (e.g., passing tests) are not met.
-- **Security Enforcement**: They allow for custom permissions and can **block modifications to sensitive files** or prevent dangerous shell commands, acting as a firewall.
-- **Feedback**: Hooks can provide automated feedback to Claude when it produces code that doesn't follow conventions.
-- **Workflow Integration**: They seamlessly integrate Claude Code with existing toolchains and services.
+- Session start and end.
+- User prompt submission and expansion.
+- Pre-tool and post-tool use.
+- Permission requests and denials.
+- Tool failure.
+- Subagent start and stop.
+- Task creation and completion.
+- Pre-compact and post-compact.
+- File changes.
+- Working directory changes.
+- Configuration changes.
 
-## Hook Lifecycle and Events
+Use the narrowest event that fits. A broad hook that fires on every tool call
+should be very small and very fast.
 
-Hooks are triggered by several distinct lifecycle events, each offering different control capabilities:
+## Hook Locations
 
-- **PreToolUse**: This hook runs _before_ a tool (like `edit_file` or `Bash`) is executed. It is the **most powerful point of control for preventative measures** and is the _only_ event that can proactively **block a tool's execution**.
-- **PostToolUse**: This hook runs _after_ a tool has successfully completed. It's ideal for reactive tasks like automatic formatting, running tests, or logging. It cannot block execution but can provide feedback to Claude.
-- **Notification**: This hook triggers whenever Claude Code sends a notification to the user, for example, when it's waiting for input or has completed a long task. It is purely informational and cannot block execution.
-- **Stop**: This hook runs when the **main Claude Code agent finishes responding**. It can be configured to **prevent the agent from terminating**, forcing it to continue working until a specific condition is met.
-- **SubagentStop**: This hook runs when a sub-agent task completes its work. Like the `Stop` hook, it can block the sub-agent from stopping.
+Hooks can come from user, project, local, managed, plugin, skill, and agent
+configuration. That means a hook might be inherited from a place other than the
+repository you are currently reading.
 
-## Configuration
+When diagnosing surprising behavior, inspect the hook sources before blaming the
+model.
 
-Hooks are configured in Claude Code's settings files, typically in JSON format. These files can be:
+## Good Hook Uses
 
-- `~/.claude/settings.json`: For **user-scoped settings** that apply to all Claude Code sessions for a given user.
-- `.claude/settings.json`: For **project-specific shared settings** within a project's root directory, intended to be version-controlled and shared with a team.
-- `.claude/settings.local.json`: For **local, git-ignored settings** specific to a user's environment within a project.
+Good hooks are deterministic:
 
-Hook configurations are organized by **matchers**, where each matcher can have multiple hooks. Matchers filter when a hook should run, based on criteria like `tool_name` (e.g., `Edit`, `Bash`), `file_paths` (using glob patterns), or the query passed to a tool.
+- Block edits to generated files.
+- Add a required instruction when a file pattern is touched.
+- Log tool use for local audit.
+- Deny shell commands that target production.
+- Run a fast formatter check after a specific tool action.
 
-An example of a hook configuration in `settings.json` might look like this (though actual syntax can vary):
-
-```ts
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '\\(.tool_input.command) - \\(.tool_input.description // \"No description\")' >> ~/.claude/bash-command-log.txt"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-This example logs Bash commands before they are executed.
-
-## Hook Input and Output
-
-Hooks receive JSON data via standard input (stdin) that provides session information and event-specific data, such as `session_id`, `transcript_path`, and `tool_name`. They communicate status back to Claude Code primarily through **shell exit codes** and, for more advanced control, **structured JSON output** to stdout.
-
-- **Exit Code 0**: Indicates success. Any output to stdout is shown to the user in the transcript, but _not_ to the model.
-- **Exit Code 2**: Signals a **blocking error**. This tells Claude Code to halt the current action (for `PreToolUse` hooks) and processes the feedback from `stderr` as new input for Claude to understand the error and adjust its plan. It is crucial that error messages for blocking errors are sent to `stderr`.
-- **Other Non-Zero Exit Codes**: Indicate a non-blocking error. The hook failed, but execution continues. The error message from `stderr` is shown to the user, but not to Claude.
-
-Structured JSON output allows for more granular control with fields like `decision` (e.g., "block", "approve"), `reason` (explaining the decision to Claude), `continue` (to stop all processing), and `suppressOutput`.
-
-## Practical Use Cases and Examples
-
-Hooks enable a wide range of automations and policy enforcements:
-
-### Automatic Formatting and Linting
-
-- **Use Case**: Ensure consistent code style and quality after Claude modifies files.
-- **Example**: A `PostToolUse` hook that triggers on edits to Python files (`*.py`) and runs `black` and `ruff` to enforce style consistency.
-
-### Security Guardrails/File Protection
-
-- **Use Case**: Prevent Claude from modifying sensitive files or executing dangerous commands.
-- **Example**: A `PreToolUse` hook matching `Edit` tool calls for file paths containing `.env`, `.git/`, or `package-lock.json`. The hook exits with code 2 to **block the edit** and provides an error message to Claude, forcing it to reconsider.
-
-### Enforcing Conventions and Corrective Feedback
-
-- **Use Case**: Guide Claude towards correct project-specific behaviors (e.g., using a specific package manager).
-- **Example**: A `PreToolUse` hook matching `Bash` commands. If the command contains `npm` in a project that uses `bun`, the hook exits with code 2 and an error message like "Error: This project uses bun, not npm. Please use bun install." Claude receives this feedback and corrects its subsequent commands.
-
-### Automated Test Execution/Quality Gates
-
-- **Use Case**: Automatically run tests after code changes or prevent pull requests if tests are failing.
-- **Example**: A `PostToolUse` hook that triggers on edits to source or test files and runs `pytest` (for Python). Alternatively, a `PreToolUse` hook matching the `mcp__github__create_pr` tool could execute the project's test suite and block PR creation if tests fail.
-
-### Custom Notifications
-
-- **Use Case**: Integrate with external notification systems to be alerted when Claude needs input or finishes a long task.
-- **Example**: A `Notification` hook that uses a tool like `ntfy` to send a push notification to a user's device when Claude requires attention.
-
-### Automated Git Operations
-
-- **Use Case**: Automatically create git commits after successful file modifications, providing a detailed history of the agent's work.
-- **Example**: A `PostToolUse` hook configured to automatically commit changes with a descriptive message after Claude performs an edit.
-
-### Session Management
-
-- **Use Case**: Automate processes at the beginning or end of a Claude Code session.
-- **Example**: `session-start` hooks to restore previous context or `session-end` hooks to generate summaries and persist state.
-
-## Advanced Hook Implementation
-
-For complex scenarios, such as managing monorepos with specific tooling requirements, hooks can become quite sophisticated. Developers might need to handle mismatches in exit codes or output streams between their custom scripts and Claude Code's expectations (e.g., ensuring error messages are directed to `stderr` for blocking errors).
-
-## Integration with MCP Tools
-
-Claude Code Hooks work seamlessly with Model Context Protocol (MCP) tools. MCP provides Claude Code with access to external tools and services (e.g., databases, web browsers, project management systems), while hooks provide the policies that govern how Claude uses these tools. For example, a `PreToolUse` hook can be configured to block specific MCP tool calls that target sensitive resources, like `mcp__prod-db__*`.
-
-## Debugging Hooks
-
-Troubleshooting hooks is essential for effective use:
-
-- **Verify Loading**: Use the `/hooks` slash command in Claude Code to display all loaded hook configurations and confirm the settings file was parsed correctly.
-- **Test in Isolation**: Run the hook's shell command directly in your terminal to ensure it works as expected outside Claude Code.
-- **Check Permissions**: Ensure any scripts called by the hook have necessary execute permissions (e.g., `chmod +x`).
-- **Enable Debug Logging**: Launch Claude Code with the `--debug` flag (`claude --debug`) to get verbose output, including details on hook execution and errors.
-- **Review `stdout` and `stderr`**: Pay attention to where your hook's output is being directed, especially for blocking errors (exit code 2 needs `stderr`).
-
-## Security Considerations
-
-Since Claude Code hooks execute arbitrary shell commands with your full user permissions without confirmation, **security is paramount**. Users are solely responsible for the commands they configure. Best practices include:
-
-- **Principle of Least Privilege**: When integrating external services or databases via MCP, configure them with the minimum necessary permissions.
-- **Secure Hook Authoring**: Treat hook scripts as production code. Always quote shell variables (e.g., `"$VAR"`), validate and sanitize all inputs, and use absolute paths for executables to prevent common vulnerabilities.
-- **Use PreToolUse Hooks as a Firewall**: Implement these hooks to create a deny-list for dangerous Bash commands (e.g., `rm`, `curl`) or to block sensitive MCP tool calls.
-- **Vet MCP Servers**: Only use MCP servers from trusted providers or after a thorough code audit.
-
-## Community and Future Outlook
-
-The development of hooks is fostering a growing "hook ecosystem," with users creating and sharing installable hook packages and custom behaviors. This trend suggests the emergence of community-driven marketplaces for composable, deterministic control modules, which will significantly enhance the power and reliability of the Claude Code platform. Hooks are considered a core component of advanced orchestration frameworks like Claude-Flow v2, which uses them to automate coordination and enforce workflow rules.
-
----
-
-**Analogy:** Think of Claude Code Hooks as the **"immune system"** of your AI-powered development workflow. Just as an immune system automatically detects and responds to threats or maintains the body's internal balance without explicit instructions for every single cell, hooks automatically enforce your coding standards, security policies, and testing requirements. They provide a vital layer of automated defense and consistent operation, ensuring your code remains healthy and your development process stays on track, even when the AI agent is given more freedom.
+Bad hooks try to run the whole development process invisibly. Put real quality
+gates in scripts and continuous integration.

--- a/courses/ai-development/claude-code-mcp.md
+++ b/courses/ai-development/claude-code-mcp.md
@@ -7,9 +7,10 @@ modified: 2026-06-24
 date: 2025-07-29
 ---
 
-[Claude Code MCP](https://code.claude.com/docs/en/mcp) connects Claude to
-external tools and data. Use it when the agent needs authoritative context or
-must interact with another system through a structured interface.
+[Claude Code](https://code.claude.com/docs/en/mcp) connects to
+[MCP](https://modelcontextprotocol.io/) servers for external tools and data. Use
+it when the agent needs authoritative context or must interact with another
+system through a structured interface.
 
 ## Add and Inspect Servers
 
@@ -34,9 +35,9 @@ is part of the repository workflow. Use user scope for personal tools.
 
 ## Prefer HTTP for New Remote Servers
 
-Claude Code supports `stdio`, HTTP, WebSocket, and SSE transports. For new remote
-servers, prefer HTTP where possible. SSE remains supported for compatibility, but
-the current documentation marks it as deprecated.
+Claude Code supports `stdio`, HTTP, and SSE transports. For new remote servers,
+prefer HTTP where possible. SSE remains supported for compatibility, but the
+current documentation marks it as deprecated.
 
 ## Permissions
 

--- a/courses/ai-development/claude-code-mcp.md
+++ b/courses/ai-development/claude-code-mcp.md
@@ -1,101 +1,63 @@
 ---
-title: Claude Code and MCP
+title: Using MCP Servers with Claude Code
 description: >-
-  Extend Claude Code's capabilities with Model Context Protocol servers for
-  database access, cloud services, and specialized development tools
-modified: 2026-03-17
+  Configure Claude Code MCP servers with stdio, HTTP, OAuth login, scopes,
+  permissions, and security review.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-MCP is an **open protocol** designed to standardize how AI applications, including Claude Code, connect with external tools and data sources. Unlike traditional AI coding assistants that might offer advanced autocompletion or chatbot features, Claude Code, when combined with MCP servers, transforms into an active, autonomous development partner that can manage complex workflows.
+[Claude Code MCP](https://code.claude.com/docs/en/mcp) connects Claude to
+external tools and data. Use it when the agent needs authoritative context or
+must interact with another system through a structured interface.
 
-## Benefits of Using MCP Servers with Claude Code Include
+## Add and Inspect Servers
 
-- **Extending capabilities**: They enable Claude Code to use specialized development tools, access a wide range of APIs and SaaS platforms, and integrate with custom workflows.
-- **Real-time information**: They solve the problem of static training data by allowing Claude to access real-time information from databases, documentation, and monitoring systems, grounding its responses in reality and preventing "hallucinations".
-- **Enhanced reasoning and interaction**: Claude can reason about, query, or even modify external systems (like a PostgreSQL database) by interacting with them through the structured interface provided by an MCP server.
-- **Automation**: MCP servers can be integrated into custom slash commands and hooks for advanced automation.
+Use the command line interface:
 
-## MCP Architecture and Types of Servers
+```bash
+claude mcp add
+claude mcp list
+claude mcp get
+claude mcp remove
+```
 
-The MCP architecture operates on a **client-server model**. Claude Code acts as the **host** and **client**, managing client instances and enforcing security policies, while **servers** are independent programs exposing specific capabilities (tools, resources, or prompts) from external systems. Servers are isolated and only receive necessary context for their tasks, enhancing security and privacy.
+For OAuth-backed servers, use:
 
-The MCP ecosystem is diverse, categorizing servers by their function:
+```bash
+claude mcp login
+claude mcp logout
+```
 
-- **Core Utility Servers** provide foundational capabilities for local interaction:
-  - **Filesystem** allows reading, writing, creating, and listing files and directories within the sandboxed project scope.
-  - **Sequential Thinking** helps Claude break down complex problems into logical steps.
-  - **Memory** enables persistent storage and retrieval of information across sessions, allowing Claude to build long-term understanding.
-- **Development & DevOps Servers** integrate Claude Code into the Software Development Lifecycle (SDLC):
-  - **Version Control** (e.g., GitHub, Azure DevOps) enables managing repositories, issues, and pull requests.
-  - **CI/CD and Testing** (e.g., Playwright, Sentry, Codacy) provide capabilities for automated browser testing, real-time error data, and static analysis.
-  - **Framework-Specific Servers** (e.g., shadcn) encapsulate best practices for specific UI frameworks.
-- **Data & Infrastructure Servers** connect Claude Code to backend systems:
-  - **Database Integration** (e.g., Oracle, PostgreSQL) allows querying schemas, retrieving live data, and planning database migrations.
-  - **Cloud Services** (e.g., Azure, AWS, Terraform) enable managing cloud resources and Infrastructure as Code.
-- **Knowledge & Productivity Servers** link Claude to human context and project management:
-  - **Documentation Access** (e.g., Context7, Microsoft Learn) provides real-time, semantic search access to the latest documentation, preventing hallucinations.
-  - **Knowledge Bases** (e.g., Notion, Confluence, Figma) connect Claude to internal wikis, design systems, and notes.
-  - **Project Management** (e.g., Jira, Linear, Asana, Zapier) allows Claude to interact with project management platforms and automate tasks.
+Project-scoped servers can live in `.mcp.json`. Use project scope when the server
+is part of the repository workflow. Use user scope for personal tools.
 
-## Setting Up MCP Servers with Claude Code
+## Prefer HTTP for New Remote Servers
 
-Setting up MCP servers with Claude Code is straightforward.
+Claude Code supports `stdio`, HTTP, WebSocket, and SSE transports. For new remote
+servers, prefer HTTP where possible. SSE remains supported for compatibility, but
+the current documentation marks it as deprecated.
 
-1. **Installation**: You register MCP servers using the `claude mcp add` command. This can be done interactively, by providing a JSON configuration with `claude mcp add-json`, or by importing configurations from Claude Desktop using `claude mcp add-from-claude-desktop` (on macOS and WSL). Often, `npx` (for Node.js servers) or `uvx` (for Python servers) are used to run them.
-2. **Configuration Scopes**: MCP servers can be configured at three scope levels:
-   - **Local (default)**: Temporary and only available in the current session.
-   - **User**: Available across all projects for a given user, stored in `~/.claude.json`. This is recommended for personal utilities.
-   - **Project**: Shared with the entire team and stored in a `.mcp.json` file at the project's root, which can be version-controlled.
-3. **Authentication for Remote Servers**: Many remote MCP servers require authentication. Claude Code supports OAuth 2.0. You add the server, and then use the `/mcp` command within Claude Code to manage authentication. This opens a browser for the OAuth flow, and Claude Code securely stores the access token.
+## Permissions
 
-## Using MCP Servers for Control Flow: Returning JSON and Providing Reasons
+MCP tools run through Claude Code's permission model. Keep write tools behind
+ask rules unless the environment is isolated and the action is low risk.
 
-Hooks are a crucial component for achieving **deterministic control** over Claude Code's behavior, enforcing application-level policies. Hooks communicate status and control flow back to Claude Code primarily through **shell exit codes** and **structured JSON output** to standard output (stdout) [Previous conversation, 81].
+Prompt important tool use explicitly:
 
-### Control Flow with Exit Codes [Previous Conversation, 81, 87]:
+```text
+Use the GitHub MCP server only to read the pull request checks and comments.
+Do not post comments or update labels.
+```
 
-- **Exit Code 0**: Indicates success, and execution continues normally. `stdout` output is shown to the user but not seen by Claude [Previous conversation].
-- **Exit Code 2**: Signals a **blocking error**, halting the current action (especially for `PreToolUse` hooks). The feedback is read from `stderr` and is fed back to Claude as new input for it to adjust its plan [Previous conversation, 87].
-- **Other Non-Zero Exit Codes**: Indicate a non-blocking error. The hook failed, but the agent's execution continues. `stderr` messages are shown to the user but not fed back to Claude [Previous conversation].
+## Security Review
 
-### Advanced Control with JSON Output [Previous conversation]:
+Before adding a server, answer:
 
-Hooks can return structured JSON to `stdout` for more granular control:
+- Which external systems can it access?
+- Which credentials does it receive?
+- Can it write to shared systems?
+- Does it expose logs, prompts, or tool arguments?
+- Can project configuration add or replace the server?
 
-- `"continue": false`: This is the ultimate override; Claude stops all processing after the hook. A `"stopReason"` string can accompany this, shown to the user but not Claude.
-- `"suppressOutput": true`: Hides the hook's `stdout` from the user's transcript.
-
-**Specific `decision` control fields** vary by hook event:
-
-#### `PreToolUse` Hooks
-
-    - `"decision": "approve"`: Bypasses the permission prompt, allowing the tool call to proceed.
-    - **`"decision": "block"`**: **Prevents the tool call from executing**. The `reason` field is critical here, as its content is **fed back to Claude**, explaining why the action was blocked and guiding its next steps [Previous conversation, 106].
-
-#### `PostToolUse` Hooks
-
-    - **`"decision": "block"`**: **Automatically prompts Claude with the `reason` provided**. Since the tool has already run, this provides feedback for future actions, not a prevention of the current one [Previous conversation].
-
-#### `Stop`/`SubagentStop` Hooks
-
-    - **`"decision": "block"`**: **Prevents Claude from stopping**. A `reason` field **must be provided** to instruct Claude on how to proceed and continue its work [Previous conversation].
-
-#### Practical Examples of JSON Control Flow with Reasons
-
-- **Enforcing Project Standards**: A `PreToolUse` hook could block Claude from using a disallowed package manager (`npm` in a `bun`-only project) by returning `"decision": "block"` and a `reason` like: `"Project convention violation: Do not use npm. This project uses the bun package manager."` [Previous conversation]. Claude would then receive this feedback and adapt to use `bun`.
-- **Security Policies**: A `PreToolUse` hook could prevent modifications to sensitive files (e.g., `.env`) by returning `"decision": "block"` and a `reason`: `"Error: Direct modification of sensitive configuration files (.env) is blocked by policy."` [Previous conversation].
-- **Quality Gates**: A `PreToolUse` hook could prevent creating a pull request (`mcp__github__create_pr`) if tests are failing, returning `"decision": "block"` with a `reason` detailing test failures [Previous conversation, 106].
-- **Ensuring Task Completion**: A `Stop` hook could prevent Claude from stopping until a checklist is fully completed, returning `"decision": "block"` with a `reason` like: `"The main task is not yet complete. Please continue working on the remaining items in the checklist."` [Previous conversation].
-
-## Debugging and Advanced Workflows
-
-To verify MCP server configuration and debug issues, you can use `claude mcp list` or `claude --mcp-debug`. The `/mcp` command within Claude Code displays the connection status of each MCP server. For general Claude Code issues, `/doctor` checks the installation health.
-
-**Advanced workflows** often combine MCP servers, hooks, and other features:
-
-- **Custom Slash Commands**: These are user-defined, reusable prompts stored as Markdown files in `.claude/commands/`. They can leverage MCP tools and effectively become codified expertise for frequent or complex tasks, initiated by typing `/command_name`. MCP servers can even expose their own prompts as slash commands, prefixed with `/mcp__servername__promptname`.
-- **CLAUDE.md**: This special file is automatically pulled into Claude's context at the start of every session in a directory, providing persistent, project-specific memory. It's ideal for documenting project architecture, coding standards, and known pitfalls.
-- **Multi-Agent Systems**: MCP is the fundamental communication backbone for coordinating multiple AI agents. Specialized MCP servers, like "Claude Swarm," can orchestrate teams of agents with defined roles, enabling intelligent handoffs and shared contexts. Hooks can automate coordination and enforce workflow rules in these systems.
-
-Using MCP servers with Claude Code is akin to giving a highly skilled artisan a **toolkit of specialized instruments**. While Claude Code is already a powerful craftsman, the MCP servers provide it with a wide array of precision tools—from a magnifying glass for inspecting database schemas (PostgreSQL server) to a sturdy hammer for building web UI components (shadcn server), or even a security scanner for checking vulnerabilities (Codacy server). When you add hooks into the mix, you're not just handing the artisan the tools; you're also providing a **blueprint with strict quality checks and clear instructions**. This blueprint dictates exactly when and how certain tools should be used, and if any step deviates from the plan, it immediately signals the artisan, providing a detailed reason and guiding them back on track, ensuring every piece of work meets your exact standards.
+MCP is a capability boundary. Review it like one.

--- a/courses/ai-development/claude-code-model-selection.md
+++ b/courses/ai-development/claude-code-model-selection.md
@@ -25,10 +25,13 @@ Claude Code supports aliases such as:
 - `opus[1m]`
 - `opusplan`
 
-As of the current documentation, `opus` maps to Opus 4.8 on the Claude Platform
-API, `sonnet` maps to Sonnet 4.6, and Fable 5 is available for explicit use when
-the account and retention policy allow it. Provider routing can differ on
-[Amazon Bedrock](https://aws.amazon.com/bedrock/),
+As of the current documentation, `opus` maps to
+[Opus 4.8](https://code.claude.com/docs/en/model-config) on the Claude Platform
+API, `sonnet` maps to
+[Sonnet 4.6](https://code.claude.com/docs/en/model-config), and
+[Fable 5](https://code.claude.com/docs/en/model-config) is available for explicit
+use when the account and retention policy allow it. Provider routing can differ
+on [Amazon Bedrock](https://aws.amazon.com/bedrock/),
 [Google Vertex AI](https://cloud.google.com/vertex-ai), and
 [Microsoft Foundry](https://azure.microsoft.com/products/ai-foundry/), so check
 the provider documentation before making a team-wide rule.

--- a/courses/ai-development/claude-code-model-selection.md
+++ b/courses/ai-development/claude-code-model-selection.md
@@ -1,146 +1,70 @@
 ---
 title: Claude Code Model Selection
 description: >-
-  Choose the right Claude model (Opus, Sonnet, Haiku) for your development tasks
-  based on complexity, cost, and performance requirements
-modified: 2026-03-17
+  Choose Claude Code models with aliases, defaults, Opus planning, effort,
+  one-million-token context, fallback chains, and provider differences.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-**Claude Opus** and **Claude Sonnet** represent different points on an "agency spectrum" for AI coding systems. I guess there is also Haiku.
+[Claude Code model configuration](https://code.claude.com/docs/en/model-config)
+changes quickly. As of June 23, 2026, the important durable idea is to use
+aliases and task shape rather than hardcoding exact model identifiers everywhere.
 
-## Claude Opus: The "Development Partner" for Complexity
+## Useful Aliases
 
-Opus is considered the **highest capability model** and demonstrates **genuine development partnership**, capable of internalizing objectives, working persistently, and proactively identifying and resolving obstacles. It's ideal for tasks requiring **maximum reasoning** and **complex trade-offs**.
+Claude Code supports aliases such as:
 
-### Key Use Cases for Opus
+- `default`
+- `best`
+- `fable`
+- `sonnet`
+- `opus`
+- `haiku`
+- `sonnet[1m]`
+- `opus[1m]`
+- `opusplan`
 
-- **Creative tasks requiring nuanced understanding**.
-- **Code reviews requiring architectural judgment**.
-- **Complex refactoring across multiple systems**.
-- **Large-scale system design**.
-- **Complex algorithm development**.
-- **Research and advanced analysis**.
-- **Multi-system integration**.
-- **Advanced problem solving**.
-- **Machine Learning architecture**.
-- **Advanced technical writing**.
-- **High-level planning and final review**.
-- **Initial builds based on project plans in `CLAUDE.md`**.
-- **Adding entire new modules**.
-- **Thorough codebase analysis and architectural understanding**.
-- **Complex root cause analysis for debugging**.
-- **Integrating disparate information sources for comprehensive understanding**.
-- **Creating final integrated reports and strategic proposals**.
+As of the current documentation, `opus` maps to Opus 4.8 on the Claude Platform
+API, `sonnet` maps to Sonnet 4.6, and Fable 5 is available for explicit use when
+the account and retention policy allow it. Provider routing can differ on
+[Amazon Bedrock](https://aws.amazon.com/bedrock/),
+[Google Vertex AI](https://cloud.google.com/vertex-ai), and
+[Microsoft Foundry](https://azure.microsoft.com/products/ai-foundry/), so check
+the provider documentation before making a team-wide rule.
 
-Opus excels at **strategic-level analysis** and makes more **cautious and iterative approaches**, often using more turns (interactions) to complete a task. For instance, Claude Opus 4 needed only two follow-up prompts to create a fully functional OmniFocus plugin and proactively enhanced it with configuration interfaces, error handling, input validation, and progress indicators. It can even **autonomously decide tradeoffs** and dynamically adjust resource allocation and review cycles for quality.
+## Defaults
 
-## Claude Sonnet: The "Collaborative Agent" and Production Workhorse
+Claude Code defaults vary by account type and provider. That means "use the
+default model" is a reasonable personal workflow but a weak reproducibility
+claim. For team processes, specify the alias and date the guidance.
 
-Sonnet is seen as a **production standard model** and acts as a **collaborative agent** that balances instruction-following with initiative, working semi-autonomously with periodic guidance. It is a **great workhorse** suitable for **standard feature implementation and development tasks**. Many users find Sonnet perfectly adequate for most coding tasks.
+```text
+As of 2026-06-23, use `sonnet` for routine implementation and `opusplan` for
+planning complex changes before execution.
+```
 
-### Key Use Cases for Sonnet
+## Opus Plan
 
-- **Standard feature implementation and development tasks**.
-- **Most debugging and troubleshooting scenarios**.
-- **Code generation with moderate complexity**.
-- **Documentation writing and editing**.
-- **Task coordination and workflow management**.
-- **Enterprise applications**.
-- **Security-critical code**.
-- **Standard system architecture**.
-- **Code reviews requiring adherence to standards**.
-- **Compliance audits**.
-- **Customer-facing projects and open-source projects**.
-- **Creating secure user authentication systems**.
-- **General implementation tasks**.
-- **Structural analysis (directory structure, configuration files)**.
-- **Pattern extraction (code conventions, naming rules)**.
-- **Data transformation (CSV generation, mapping creation)**.
-- **Routine investigation tasks**.
-- **Small, specific tasks that require less "thinking" or "creativity"**.
-- **Debugging production issues**.
+`opusplan` uses Opus for planning and Sonnet for implementation. It is a good fit
+when the hard part is design, not typing code. Ask for the plan first and review
+it before allowing broad edits.
 
-Sonnet is generally **faster and cheaper** than Opus, making it the **default choice for most users**. It can handle complex tasks but might require more explicit guidance at the development stage compared to Opus.
+## Effort and Context
 
-## Claude Haiku: The "Responsive Assistant" for Simple, Fast Tasks
+Claude Code also supports effort controls such as `/effort` and large-context
+aliases such as `sonnet[1m]` and `opus[1m]`. Larger context is not automatically
+better. It is useful when the task depends on many files, long logs, or generated
+artifacts. It is wasteful when a targeted test and two source files define the
+answer.
 
-While not the main focus, **Haiku** is the **cheapest and fastest** model, best suited for **simple, routine tasks** that do not require complex reasoning or extensive context. It is recommended for:
+## Fallback Chains
 
-- **Simple file reads and basic content extraction**.
-- **Routine formatting and style corrections**.
-- **Basic syntax validation and linting**.
-- **Simple text transformations and data parsing**.
-- **Quick status checks and basic analysis**.
-- **Simple utility scripts or throwaway code**.
+Use fallback models for reliability:
 
-Haiku provides the **most compact output** and generally uses the **fewest turns**.
+```bash
+claude --model opus --fallback-model sonnet
+```
 
-## Quick Choice Matrix
-
-- High risk or ambiguous architecture changes: Prefer Sonnet; escalate to Opus for deep design trade‑offs or unknown unknowns.
-- Multi‑file refactor with tests: Sonnet (agent mode); Opus for plan/review if the refactor spans boundaries.
-- One‑off edits, small scripts, formatting, or conversions: Haiku.
-- PR review with judgment calls: Sonnet; Opus for final review on critical code.
-- Exploration or doc writing: Sonnet → Haiku for summarization passes.
-- Cost pressure: default to Haiku, promote to Sonnet when you hit uncertainty.
-
-## Performance and Cost Implications
-
-Using Claude Code, especially Opus, can be **expensive**.
-
-- **Cost**: Opus is approximately **5 times more expensive than Sonnet**, and about **20 times more expensive than Haiku**.
-- **Speed**: Haiku is the fastest (27 seconds for a test task), followed by Opus (76 seconds), and then Sonnet (86 seconds). However, some sources suggest Sonnet can be faster for quick answers.
-- **Output Detail**: Sonnet often provides the most detailed output in terms of token count, followed by Opus, and then Haiku.
-- **Context Window**: Claude models offer large context windows, like Claude 2 with up to 100k tokens. However, continuously long conversations can lead to degraded responses and increased token usage.
-
-### Cost Optimization Strategies
-
-- **Hybrid Model Approach**: Use the more expensive models (like Opus) only for critical, low-frequency tasks (e.g., high-level planning, final review) and cheaper, faster models (like Sonnet) for the bulk of high-frequency implementation work. For example, use Opus for the foundational understanding phase, then switch to Sonnet for implementation, and back to Opus for review.
-- **Context Management**: Regularly use `/clear` to reset conversation history, especially when switching tasks, to prevent irrelevant context from increasing token usage. The `/compact` command can summarize the conversation, reducing token count while retaining important context. Claude Code can even auto-compact when it reaches 95% capacity.
-- **Prompt Caching / Foundation Session**: Utilizing a "foundation session" can drastically reduce token costs by caching the initial large context prompt and reusing it across subsequent calls. This can lead to **60-90% token cost reduction** and faster execution.
-- **Fixed-Cost Subscription Plans**: Plans like Anthropic's Claude Max offer predictable costs, de-risking experimentation with large-scale agent usage.
-- **Safeguards**: For automated workflows, configure limits on maximum turns (`--max-turns`) or runtime to prevent runaway costs.
-
-## How to Choose Which Model to Use
-
-The choice of model depends on the **task complexity**, **quality requirements**, and **cost considerations**.
-
-### General Guidelines (5-Second Rule)
-
-- If you spend more than 5 seconds thinking about which model to use:
-  - For **complex design/research**: **Use `opus`**.
-  - For **everything else**: **Use `sonnet`**.
-- The quality difference can be significant, so when in doubt, choose the higher capability model.
-
-### Decision Tree / Scenarios
-
-- **Highest complexity/scale work, research, advanced analysis, architectural judgment**: `Opus`.
-- **Production use, security/auth, standard enterprise applications, code reviews, compliance audits**: `Sonnet`.
-- **Simple utilities/scripts, basic file operations, routine formatting, personal/throwaway code**: `Haiku`.
-- **Red Flags**: Always use `Sonnet` if user data, money/payments, authentication/authorization, external API integration, database operations, concurrent operations, file uploads, email sending, cryptographic operations, or third-party dependencies are involved.
-
-**Migration Checklist** from Haiku to Sonnet (or higher): Upgrade from `claude-3-5-haiku-20241022` to `Sonnet` when:
-
-- Adding authentication.
-- Connecting to a database.
-- Handling user input.
-- Going to production.
-- Others will use the code.
-- Security matters.
-- Performance matters.
-
-## How to Switch Models in Claude Code
-
-You can switch models using the `/model` slash command within an interactive Claude Code session. For example, type `/model` and then select from the available options (e.g., Opus, Sonnet, or a specific full model name like `claude-sonnet-4-20250514` or `claude-3-5-haiku-20241022`). Alternatively, you can specify the model directly when starting Claude Code using the `--model` flag: `claude --model claude-opus-4-20250514`.
-
-## Leveraging `CLAUDE.md` for Enhanced Model Performance
-
-Regardless of the model chosen, providing **relevant context significantly improves Claude Code's output quality**. The `CLAUDE.md` file is a **special Markdown file** that Claude automatically reads at the start of every session, serving as a persistent, project-specific memory and instruction manual.
-
-- **Adherence Hierarchy**: `CLAUDE.md` instructions are treated as **immutable system rules** that define operational boundaries, taking precedence over user prompts, which are interpreted as flexible requests. This ensures consistent process execution and persistent context.
-- **Content**: Use `CLAUDE.md` to document project architecture, coding standards, common commands, core files, project workflows, and any unexpected behaviors or warnings.
-- **Modularity**: For larger projects, link to other Markdown files (e.g., `@docs/testing.md`) within your `CLAUDE.md` to keep the main file concise and prevent "instruction bleed". This allows Claude to pull in specific files only when relevant, optimizing token usage.
-- **Refinement**: Treat `CLAUDE.md` as a living document that you constantly refine based on Claude's performance. You can quickly add instructions by typing `#` at the start of your input, which prompts Claude to store it in `CLAUDE.md`.
-- **Hierarchical Memory**: Claude reads `CLAUDE.md` files from your user directory (`~/.claude/CLAUDE.md`) for global preferences, and then from the project root (`./CLAUDE.md`) for project-specific guidelines, and also from subdirectories. This allows for granular control.
-- **Clarity and Specificity**: Be explicit and detailed in your instructions, using Markdown headings and bullet points for organization. Avoid vague requests.
+Fallbacks are operational policy. They should preserve the intent of the task,
+not silently downgrade a security review into a cheap rewrite.

--- a/courses/ai-development/claude-code-model-selection.md
+++ b/courses/ai-development/claude-code-model-selection.md
@@ -26,15 +26,16 @@ Claude Code supports aliases such as:
 - `opusplan`
 
 As of the current documentation, `opus` maps to
-[Opus 4.8](https://code.claude.com/docs/en/model-config) on the Claude Platform
-API, `sonnet` maps to
-[Sonnet 4.6](https://code.claude.com/docs/en/model-config), and
-[Fable 5](https://code.claude.com/docs/en/model-config) is available for explicit
-use when the account and retention policy allow it. Provider routing can differ
-on [Amazon Bedrock](https://aws.amazon.com/bedrock/),
+[Opus 4.8](https://code.claude.com/docs/en/model-config) on the Anthropic API,
+while Claude Platform on AWS, [Amazon Bedrock](https://aws.amazon.com/bedrock/),
 [Google Vertex AI](https://cloud.google.com/vertex-ai), and
-[Microsoft Foundry](https://azure.microsoft.com/products/ai-foundry/), so check
-the provider documentation before making a team-wide rule.
+[Microsoft Foundry](https://azure.microsoft.com/products/ai-foundry/) can resolve
+the same alias differently. `sonnet` maps to
+[Sonnet 4.6](https://code.claude.com/docs/en/model-config) on the Anthropic API
+and Claude Platform on AWS, and
+[Fable 5](https://code.claude.com/docs/en/model-config) is available for explicit
+use when the account and retention policy allow it. Check provider-specific
+model routing before making a team-wide rule.
 
 ## Defaults
 

--- a/courses/ai-development/claude-code-permissions.md
+++ b/courses/ai-development/claude-code-permissions.md
@@ -25,6 +25,10 @@ Edit(src/**)
 Agent(model:opus)
 ```
 
+Parameter-specific rules such as `Agent(model:opus)` are for deny and ask rules,
+not blanket allow rules. An allow rule for one parameter value does not prove the
+whole tool call is safe.
+
 Use narrow rules where possible. "Allow all Bash" is a very different policy
 from "allow the targeted test command."
 

--- a/courses/ai-development/claude-code-permissions.md
+++ b/courses/ai-development/claude-code-permissions.md
@@ -1,66 +1,58 @@
 ---
-title: Claude Code Permissions
+title: Claude Code's Permission System
 description: >-
-  Configure and manage Claude Code's permission system to balance safety and
-  productivity while maintaining security boundaries
-modified: 2026-03-17
+  Configure Claude Code permissions with allow, ask, deny, permission modes,
+  tool-specific rules, and explicit safety boundaries.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-By default, Claude Code takes a **conservative approach to safety**, requiring your permission for actions that could modify your system, such as writing files, executing many bash commands, or using Model Context Protocol (MCP) tools. When Claude Code attempts one of these actions, it will pause and prompt you for approval.
+[Claude Code permissions](https://code.claude.com/docs/en/permissions) decide
+what the agent can do without asking. They are one of the most important parts
+of a safe setup.
 
-Claude Code recognizes and allows you to configure permissions for four main types of tools:
+## Permission Outcomes
 
-- **Bash Commands**: These are terminal instructions like running scripts, searching files, editing text, or installing packages. You can allow specific commands using exact matches or wildcards (e.g., `npm run test:*`).
-- **Read and Edit**: These permissions control which files Claude Code can read from and write to. They often follow `.gitignore` filters.
-- **Web Fetch**: Claude Code can fetch information from the web. You can allow it to access specific websites without prompting you for permission each time.
-- **MCP Tools**: These permissions manage access to external tools and services integrated via the Model Context Protocol. You can allow or restrict specific tools within an MCP server.
+Rules can allow, ask, or deny. Deny wins over ask, and ask wins over allow. That
+means a broad allow rule can still be constrained by a narrower deny rule.
 
-## Managing Permissions and Best Practices
+Rules can target tools and parameters:
 
-To optimize your workflow and manage costs, it's crucial to proactively configure Claude Code's permissions. Here are several methods and best practices:
+```text
+Bash(bun test:*)
+Read(src/**)
+Edit(src/**)
+Agent(model:opus)
+```
 
-### Interacting with Permission Prompts
+Use narrow rules where possible. "Allow all Bash" is a very different policy
+from "allow the targeted test command."
 
-- When prompted during a session, you can **select "Always allow"** for that specific action to add it to your allowlist.
-- You can interrupt Claude Code's autonomous operations at any time (e.g., by pressing `Esc`) to course-correct its actions or clarify instructions, preventing it from going down the wrong path and potentially saving tokens.
+## Permission Modes
 
-### Using the `/permissions` Command
+Claude Code supports modes such as:
 
-- The `/permissions` command allows you to **add or remove tools from the allowlist**. For example, you can add `Edit` to always allow file edits or `Bash(git commit:*)` to allow Git commits.
-- This command helps you specify which commands Claude is allowed to run automatically without asking for manual approval, and which still require it.
+- `default`
+- `acceptEdits`
+- `plan`
+- `auto`
+- `dontAsk`
+- `bypassPermissions`
 
-### Configuring via Settings Files
+Use `plan` when you want research without edits. As of June 23, 2026, treat
+`auto` as a research-preview mode and review its behavior carefully. Reserve
+bypass-style modes for isolated environments where the risk is understood.
 
-- Permissions can be **manually edited in your `.claude/settings.json` (project-specific) or `~/.claude.json` (user-specific) files**. It is recommended to check project-level `settings.json` files into source control to share with your team, ensuring consistent behavior across developers.
-- You can set a **`defaultMode`** within `settings.json` to define the default permission behavior when opening Claude Code. For instance, `acceptEdits` will approve most plain file edits automatically.
+## A Practical Team Default
 
-### Using CLI Flags for Session-Specific Permissions
+For most repositories:
 
-- The `--allowedTools` CLI flag allows you to specify a **list of tools that should be allowed without prompting** for a specific session.
-- Conversely, the `--disallowedTools` flag allows you to **explicitly deny certain tools** for a session.
+- Allow read-only inspection.
+- Ask before editing files.
+- Ask before running shell commands that are not test or lint commands.
+- Deny production deployment commands.
+- Deny commands that print secrets.
+- Keep MCP write tools behind ask rules.
 
-### Understanding "YOLO Mode" and Its Risks
-
-The `--dangerously-skip-permissions` flag, often referred to as "YOLO mode," **bypasses all permission checks**, allowing Claude Code to execute all operations (including file modifications and command execution) without any prompts.
-
-**This mode should be used with extreme caution** and is generally reserved for trusted local development or controlled environments like CI/CD pipelines, where safeguards like `max_turns` and `timeout_minutes` can prevent runaway costs. Using it on your main development machine is not recommended for most cases due to the risk of unintended consequences, including potential damage to your development environment.
-
-**The `allowedTools` configuration is superior** to "YOLO mode" because it offers granular control and transparency, allowing you to explicitly specify safe operations while retaining oversight for risky ones.
-
-### Security and Isolation Considerations
-
-**Principle of Least Privilege**: Claude Code is sandboxed by default, only accessing the directory where it was launched and its subfolders. Extend this principle to all integrations; for example, give MCP servers connecting to a database only the minimum necessary permissions (e.g., read-only access).
-
-- **Threats and Mitigations**:
-  - **Prompt Injection**: Malicious prompts could trick the agent into executing harmful commands or exfiltrating data.
-  - **Untrusted MCP Servers**: Compromised external servers could introduce malware or data theft. **Only use MCP servers from trusted providers** or audit open-source server code. Claude Code requires explicit user trust verification for new MCP servers.
-  - **Insecure Hooks**: Poorly written hook scripts can lead to command injection vulnerabilities. **Always quote shell variables** (e.g., `"$VAR"`) and **validate/sanitize all inputs** in hook scripts to prevent attacks.
-
-**PreToolUse Hooks as a Firewall**: These hooks execute _before_ a tool is used and are the most powerful mechanism for enforcing custom security policies, such as blocking dangerous bash commands or preventing modifications to sensitive files.
-
-### Leveraging Context and Automation for Efficiency
-
-- **`CLAUDE.md` Files**: These special Markdown files, automatically loaded at the start of a session, provide **persistent, project-specific memory**. By documenting coding standards, architectural patterns, and known pitfalls in `CLAUDE.md`, you can guide Claude's behavior, reduce repetitive instructions, and enhance consistency, which in turn **reduces token consumption**.
-- **Custom Slash Commands**: Create reusable prompt templates in `.claude/commands/`. These can encapsulate complex multi-step workflows into a single command, reducing repetitive instructions and saving tokens.
-- **Hooks**: User-defined shell commands that execute automatically at specific lifecycle events (e.g., `PreToolUse`, `PostToolUse`) provide **deterministic control** over Claude's behavior. This allows you to enforce code quality (e.g., running linters or tests after file edits) or custom permissions without relying on the LLM to remember and follow instructions, leading to more efficient and reliable automation.
+Permissions should match the repository's blast radius. A personal toy project
+and a payment system should not have the same policy.

--- a/courses/ai-development/claude-code-plan-mode.md
+++ b/courses/ai-development/claude-code-plan-mode.md
@@ -1,69 +1,50 @@
 ---
 title: Claude Code Plan Mode
 description: >-
-  Use strategic planning phases to improve code quality and reduce iterations by
-  having Claude create detailed implementation plans before coding
-modified: 2026-03-17
+  Use Claude Code plan mode for research, option comparison, permission
+  boundaries, and implementation handoff.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Claude Code excels when given a clear, verifiable target. For complex problems, simply asking Claude to "write code" can lead to inefficiencies, context loss, and a higher chance of incorrect outputs. A dedicated planning phase serves to:
+Plan mode in [Claude Code](https://code.claude.com/docs/en/permissions) is a
+permission boundary. It lets Claude inspect and reason without immediately
+editing files.
 
-- **Establish a Shared Understanding**: It helps both the user and Claude align on the goals, constraints, and requirements of the project or feature.
-- **Break Down Complexity**: Claude can break down intricate technical challenges into sequential, manageable tasks, making the development process more structured.
-- **Reduce Guesswork and Iterations**: By thoroughly analyzing requirements and proposing strategies upfront, planning eliminates much of the trial-and-error that leads to wasted tokens and time.
-- **Improve Quality and Success Rate**: Forcing a planning phase significantly enhances the quality and success rate of the final code output.
+Use it when the task is unclear, risky, or broad.
 
-## How to Initiate a Planning Phase
+## What Plan Mode Should Produce
 
-There are several ways to direct Claude Code into a planning mindset:
+A useful plan includes:
 
-### Explicit Instruction
+- The files Claude inspected.
+- The implementation options.
+- The chosen path and why it is smallest.
+- The files expected to change.
+- The verification commands.
+- The stop conditions.
 
-- **Direct Command**: Ask Claude to create a plan. For instance, "Think hard and create a detailed, step-by-step plan to implement this feature".
-- **No Code Yet**: Explicitly tell Claude **not to write any code yet** during this phase. This ensures it focuses purely on strategic thinking.
-- **Problem-Solving Focus**: For challenging problems, prompt Claude to "think," "ultrathink," or "deep think" to encourage a more in-depth, structured analytical process, breaking down the problem into smaller parts and considering different approaches.
+Prompt:
 
-### Using "Plan Mode" (Shift+Tab)
+```text
+Enter plan mode. Research the smallest safe way to add refresh-token rotation.
+Compare at most two implementation paths. Do not edit files.
+```
 
-- Claude Code features an interactive "plan mode" that you can cycle to by pressing `Shift+Tab`.
-- In this mode, Claude will **only generate a plan** and **will not write any files** or make code edits, staying in a read-only state. It waits for your approval of the plan before proceeding to auto-edit execution mode.
-- This is useful for focusing conversations purely on planning and design.
+## Approving the Plan
 
-### Custom Slash Commands
+Before switching from planning to implementation, check the file list and
+verification command. If either is missing, the plan is not ready.
 
-- You can create a **custom slash command** (e.g., `/plan`) that automates the planning process based on a predefined prompt stored in a Markdown file, such as `.claude/plan.md`. This allows you to quickly initiate a structured planning session.
+Good handoff:
 
-### Initial Project Setup (`/init`)
+```text
+Implement option B only. Write the regression test first. Run the targeted test
+and bun run lint. Stop on unrelated failures.
+```
 
-- When starting a new project, run the `/init` command in Claude Code. This command scans your entire codebase and automatically generates a `CLAUDE.md` file in your project's root directory.
-- This `CLAUDE.md` file acts as a persistent summary of your project, including its overview, architecture, key workflows, and tech stack. Claude automatically reads this file at the start of every session, giving it initial context for planning and subsequent development.
+## Plan Mode Versus Opus Plan
 
-## The Planning Process with Claude Code
-
-Once a planning phase is initiated, Claude Code will typically:
-
-1. **Read and Analyze Context**: Claude will analyze relevant files, existing documentation (like design docs, UI mockups, or URLs), and project-specific `CLAUDE.md` files to gather information.
-2. **Propose a Detailed Plan**: Based on its understanding, Claude will generate a comprehensive, step-by-step implementation plan. This plan might include task breakdowns, proposed data storage, libraries, architectural patterns, and testing procedures.
-
-### Iterative Refinement (Human-in-the-Loop)
-
-- **Review and Feedback**: The user's role is crucial here. **You must review Claude's proposed plan carefully** and provide feedback.
-- **Course Correction**: If Claude's plan goes off track or makes unwanted assumptions, you can interrupt it (by pressing `Esc`) and clarify or revise your instructions (by double-tapping `Esc` to edit the previous prompt).
-- **Collaborative Dialogue**: Engage in a dialogue with Claude to refine the plan, discuss technical trade-offs, and clarify any ambiguities before coding begins.
-
-**Commit the Plan**: It's a good practice to have Claude save the refined plan into a Markdown file (e.g., `PLAN.md`) and commit it to your repository. This creates a structured roadmap and persistent reference for the subsequent coding phase.
-
-## Tips for Effective Planning with Claude Code
-
-- **Be Explicit and Specific**: Provide very clear, direct, and specific instructions for what you want in the plan. Avoid ambiguity.
-- **Leverage `CLAUDE.md`**: Use your `CLAUDE.md` file to document high-level project information, coding standards, and other guidelines that should consistently influence Claude's planning. This "system thinking" helps Claude operate within defined boundaries.
-- **Custom Slash Commands for Planning**: For recurring planning needs (e.g., sprint planning), define custom slash commands that embed specific planning prompts and refer to relevant project documentation.
-- **Utilize "Think" Triggers**: When facing particularly complex problems, explicitly ask Claude to "think hard," "ultrathink," or "deep think" to encourage a more profound and structured thought process.
-- **Consider Multi-Agent Planning**: For large, intricate projects, you can orchestrate a "team" of Claude Code agents (e.g., Architect, Builder, Validator, Scribe) to collaborate on the planning process, communicating through shared planning documents.
-- **Save and Version Control Plans**: Treat your generated plans as valuable assets. Save them as Markdown files and commit them to your repository. This allows for review, persistence, and referencing across different sessions or by other agents.
-- **Model Selection for Planning**: While Claude Code automatically uses models like Opus 4 for reasoning and Sonnet 4 for production-ready code, some users leverage Opus or Gemini 2.5 models specifically for the planning/discussion phase due to their strong reasoning capabilities.
-- **Cost Efficiency**: Although planning involves iterations and consumes tokens, it generally leads to significant cost savings and higher quality outcomes by reducing wasted effort in the coding and debugging phases.
-- **Context Priming**: For large codebases, use the `/context-prime` command to proactively load an overview of the project and key design documents, giving Claude a "warm start" before diving into planning.
-
-Think of **planning with Claude Code** like designing a custom house before laying a single brick. Instead of just telling the builder (Claude Code) to "build a house," you first collaborate on a **detailed blueprint** (your plan). This blueprint outlines every room, material, and structural detail. Even if the builder is highly skilled, having a clear, agreed-upon plan ensures the final house meets your exact specifications, avoids costly rework, and results in a more robust and beautiful structure.
+Plan mode controls permissions. `opusplan` controls model routing. They combine
+well for complex tasks, but they solve different problems. Plan mode says "do
+not edit yet." `opusplan` says "use a stronger model for planning."

--- a/courses/ai-development/claude-code-session-management.md
+++ b/courses/ai-development/claude-code-session-management.md
@@ -1,80 +1,56 @@
 ---
 title: Claude Code Session Management
 description: >-
-  Manage Claude Code sessions, memory, context, and permissions for optimal
-  development workflows and cost efficiency
-modified: 2026-03-17
+  Manage Claude Code sessions across terminal, IDE, desktop, web, compaction,
+  continuation, and remote workflows.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-To begin a session, simply open your terminal in your project directory and type `claude`. You can also start a session with an initial prompt directly from the command line, for example, `claude "explain this project"`. It is recommended to open Claude Code within a specific project folder where you are writing code, rather than your root directory, to ensure it has the correct context.
+[Claude Code](https://code.claude.com/docs/en/overview) sessions are working
+memory plus tool state. Treat them as useful but temporary. Durable project
+knowledge belongs in files such as `CLAUDE.md`, `.claude/rules/*.md`, skills,
+tests, and scripts.
 
-## Managing Session Context and Memory
+## Start with Orientation
 
-Claude Code's ability to retain information and understand your project is fundamental to its effectiveness. This is primarily managed through `CLAUDE.md` files and various commands.
+For a new repository, begin with a read-only request:
 
-- **CLAUDE.md Files: The Project's Memory**
-  - `CLAUDE.md` is a special Markdown file that Claude Code automatically reads and includes in its context at the start of every session in that directory. It acts as a **persistent, project-specific memory**.
-  - **Purpose**: These files are ideal for documenting common bash commands, core files and utility functions, code style guidelines, testing instructions, repository etiquette, developer environment setup, and any project-specific behaviors or warnings you want Claude to remember.
-  - **Locations**:
-    - **Project Memory (`./CLAUDE.md`)**: Located in the root of your project, this is the most common place for `CLAUDE.md` and should be checked into version control to share with your team.
-    - **User Memory (`~/.claude/CLAUDE.md`)**: Located in your home directory, its contents are loaded for _all_ your projects, making it suitable for personal preferences like coding style or custom tool shortcuts.
-    - **Parent/Child Directory Memory**: Claude recursively looks for `CLAUDE.md` files up the directory tree, loading context from parent directories (e.g., in a monorepo) and child directories on demand.
-    - `CLAUDE.local.md` (Deprecated): This file, stored locally and git-ignored, was previously used for personal project-specific notes or sandbox URLs.
-  - **Creation and Updates**:
-    - You can bootstrap a `CLAUDE.md` file for your codebase by running the `/init` command in the Claude Code CLI. This command scans your codebase and generates a high-level summary of your project's architecture, key components, and functions.
-    - To quickly add new memories or instructions during a session, you can start your prompt with the `#` symbol, and Claude will ask you which `CLAUDE.md` file to update.
-    - For more extensive edits, use the `/memory` command to open the `CLAUDE.md` file in your default editor. Claude can also help maintain documentation by being prompted to update the `CLAUDE.md` file (e.g., "Please update CLAUDE.md to note that we now use library X for logging").
-  - **Best Practices for `CLAUDE.md`**: Keep them concise and human-readable, use Markdown headings and bullet points for organization, and explicitly define code style, common commands, and project workflows. You can use `@` syntax to import other Markdown files for modularity, which helps keep the main file clean and prevents context overload.
+```text
+Read this repository and summarize the build, test, lint, and release commands.
+Do not edit files. Cite the files you used.
+```
 
-### Clearing Conversation History (`/clear`)
+That gives you a quick signal on whether Claude understands the project shape.
+If it invents commands, fix the context before asking it to change code.
 
-- The `/clear` command resets the current chat conversation, effectively wiping the agent's short-term memory.
-- **Why it's important**: Large language models are stateless; they reprocess the entire conversation history with every message in the same window, which quickly consumes tokens and can make responses less focused or accurate.
-- **When to use it**: Use `/clear` as often as possible, ideally whenever you finish a task, to reduce unnecessary token usage and prevent unrelated tasks from piling up in the same chat.
+## Keep Sessions Bounded
 
-### Compacting Conversation History (`/compact`)
+Long sessions accumulate assumptions. When the task changes, start a new session
+or compact deliberately. A good session has one goal, one verification path, and
+one final diff.
 
-- The `/compact` command allows you to reduce token usage by summarizing your current conversation and starting a new chat with that summary preloaded.
-- **Automatic Compaction**: Claude Code will auto-compact your conversation when it reaches 95% capacity. This setting can be toggled via `/config`.
-- **Customization**: You can provide specific instructions for how Claude should summarize, such as "summarize just the to-do items" or "keep the summary to a max of 500 words".
-- **Techniques for Long Context Recall**: Beyond `CLAUDE.md` and compaction, effectively utilizing Claude's long context involves summarizing key information or asking Claude to perform targeted searches within your codebase (e.g., "grep and list results").
+Use continuation when you are still inside the same goal. Start fresh when you
+are changing goals, reviewing unrelated code, or switching repositories.
 
-## Resuming and Continuing Sessions
+## Surfaces
 
-Claude Code provides commands to continue or resume past conversations, allowing for persistence across work periods.
+Claude Code is available in more places than the terminal: IDE integrations,
+desktop, web, remote control workflows, and automation surfaces. The same
+principle applies everywhere: the session can help you work, but the repository
+files must remain the source of truth.
 
-- **Continue Most Recent Conversation**: Use `claude -c` or `claude --continue`.
-- **Resume by Session ID**: Use `claude -r "abc123"` or `claude --resume abc123` to pick up a specific session by its ID.
-- **Conversation Picker**: Simply type `claude --resume` to view a list of recent conversations and select one.
+## Session Handoff
 
-## Permissions and Security
+When you hand work between Claude Code and another tool, summarize the filesystem
+state, not the chat:
 
-By default, Claude Code prioritizes safety and will ask for permission before performing actions that might modify your system, such as file writes or many bash commands.
+```bash
+git status --short
+git diff --stat
+git diff
+```
 
-- **Managing Allowed Tools**: You can manage permissions in four ways:
-  1. Select "Always allow" when prompted during a session.
-  2. Use the `/permissions` command in Claude Code to add or remove tools from the allowlist (e.g., `/permissions add Edit` or `/permissions add "Bash(git commit:*)"`).
-  3. Manually edit your `.claude/settings.json` (for project-specific shared settings) or `~/.claude.json` (for global user settings).
-  4. Use the `--allowedTools` CLI flag for session-specific permissions.
-- **"Accept all" mode**: You can toggle auto-accept mode (sometimes referred to as "YOLO mode") with `Shift+Tab` to let Claude work autonomously without requesting explicit permission for each action.
-- **`--dangerously-skip-permissions`**: This flag, enabled when starting Claude Code from the command line, bypasses all permission barriers, allowing Claude to execute any operation without confirmation. This mode is primarily recommended for CI/CD pipelines or well-controlled development container setups due to the inherent security risks.
-
-## Advanced Session Management Concepts
-
-- **Multi-Agent Collaboration**: Claude Code excels at coordinating multiple AI agents within a single project. By setting up shared communication files (like `coms.md` and `cloth.md`), different agents can be assigned specific roles such as debugging, testing, or documentation, ensuring efficient task division and high-quality outcomes. This fosters both efficiency and precision, making it a cornerstone of effective project management.
-- **Git Worktrees**: For working on multiple tasks simultaneously with complete code isolation, developers can use Git worktrees. You can launch separate Claude Code instances in each worktree, maintaining one terminal tab per worktree for better organization.
-- **Headless Mode (`claude -p`)**: This non-interactive mode is designed for automation in contexts like CI/CD, pre-commit hooks, and build scripts. It can be used for tasks like issue triage or as a linter. Headless mode does not persist between sessions, so it must be triggered each time.
-- **Custom Slash Commands**: For repeated workflows, you can store prompt templates as Markdown files in the `.claude/commands` folder. These become available as slash commands (e.g., `/project:fix-github-issue`) and can be version-controlled and shared with your team.
-- **Model Context Protocol (MCP)**: MCP allows Claude Code to connect to external tools and services, vastly extending its capabilities beyond its built-in functionalities. MCP servers can provide access to databases, web browsers, project management tools (like Jira), documentation, and more.
-
-## Troubleshooting and Pro Tips
-
-- **Course Correct Early and Often**: While auto-accept mode allows autonomy, being an active collaborator yields better results. You can interrupt Claude at any time (Ctrl+C or Esc) if it's going off track and then clarify instructions or correct its misunderstanding. You can also double-Esc to revise your previous prompt.
-- **Commit Often**: It is a best practice to commit your code changes frequently, especially with Claude Code, as this helps with version control and reviewing changes.
-- **Structured Workflows**: Adopt workflows like "explore, plan, code, commit" where Claude first gathers information, then creates a detailed plan for your approval before implementing the solution. This "strategic planning" significantly improves the quality of the final output.
-- **Prompt Specificity**: Be explicit and direct in your prompts. Clearly describe the task, constraints, and desired output to guide Claude effectively.
-- **Cost Efficiency**: Use memory files (like `CLAUDE.md`) to provide persistent context and reduce repetitive prompting, which saves tokens. The `/cost` command can help monitor token usage if you're concerned about API costs.
-- **IDE Integration**: Integrate Claude Code with your IDE (like VS Code or Cursor) for a smoother experience, allowing quick launch, diff viewing, and automatic sharing of selection context.
-
-Think of managing Claude Code sessions like conducting an orchestra. Each `CLAUDE.md` file is a sheet of music, providing the foundational score for the entire performance (your project). Clearing a session is like resetting the stage for a new act, ensuring the musicians aren't distracted by previous melodies. Compacting is like a skilled editor, refining the score to keep it concise and focused, while `MCP` servers introduce new instruments and sounds, allowing the orchestra to play a wider range of compositions. The conductor (you) guides the entire performance, making sure each section plays its part precisely, leading to a harmonious and successful creation.
+The next tool should be able to continue from the branch, tests, and files. If it
+needs the chat transcript to understand correctness, the work is not packaged
+well enough yet.

--- a/courses/ai-development/claude-code-sub-agents.md
+++ b/courses/ai-development/claude-code-sub-agents.md
@@ -1,188 +1,63 @@
 ---
-title: Claude Code Sub-Agents
+title: Claude Code Subagents
 description: >-
-  Create and manage specialized sub-agents for parallel task execution, code
-  review, debugging, and multi-agent development workflows
-modified: 2026-03-17
+  Use Claude Code subagents for isolated exploration, planning, implementation,
+  background work, memory, and specialized tool access.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-The primary goal of using sub agents is to parallelize work and leverage specialized expertise, leading to increased efficiency, precision, and throughput in complex development workflows.
+[Claude Code subagents](https://code.claude.com/docs/en/sub-agents) are agents
+with their own context, tools, model, permissions, and optional memory. They are
+useful when one part of the task can be isolated from the main conversation.
 
-Key benefits include:
+## Built-In Agents
 
-- **Accelerated Development**: Sub agents allow for efficient task division, such as debugging, testing, and documentation. By executing tasks in parallel, they can make certain workflows significantly faster.
-- **Specialized Expertise**: Sub agents can be fine-tuned with detailed instructions and specific roles (e.g., `code-reviewer`, `debugger`), leading to higher success rates on designated tasks and allowing multiple expert perspectives to analyze problems.
-- **Context Preservation**: Each sub agent operates in its own isolated context, preventing pollution of the main conversation. This keeps the main thread focused on high-level objectives, reduces context-switching overhead, and can lead to more efficient token usage.
-- **Enhanced Quality Assurance**: Using a separate "Validator" sub agent in a clean context to scrutinize the output of a "Builder" agent creates a built-in, unbiased peer review loop, improving code quality and catching issues early.
-- **Reusability and Consistency**: Once created, sub agents can be saved, reused across different projects, and shared with a team, ensuring consistent workflows.
-- **Flexible Permissions**: Each sub agent can be granted access to a specific set of tools, allowing you to limit powerful or sensitive tools to only the agents that require them for their designated function.
-- **Scalability**: Sub agents enable the system to handle large-scale, complex projects by breaking down massive tasks into smaller, manageable components that can be executed concurrently.
+Claude Code includes built-in agents such as Explore, Plan, and
+general-purpose. Explore is useful for read-only investigation. Plan is useful
+for design. The general-purpose agent can take on broader work when you need a
+helper with tool access.
 
-## Some High-Level Advice
+Pick the agent by job, not by novelty.
 
-I should probably put this in a slide, but here it is for now so I don't forget to say it out loud:
+## Custom Agents
 
-1. **Start Simple**: Begin with 3-4 core agents, add more as needed
-2. **Clear Boundaries**: Each agent should have a distinct, non-overlapping role
-3. **Structured Output**: Define expected output formats for easy handoffs
-4. **Iterative Refinement**: Adjust system prompts based on results
-5. **Context Preservation**: Pass relevant context between agents
+Project agents can live in `.claude/agents/`:
 
-## How to Create and Manage Sub Agents
+```md
+---
+name: regression-finder
+description: Find the closest missing regression test for a described bug.
+tools:
+  - Read
+  - Grep
+  - Glob
+model: sonnet
+permissionMode: plan
+---
 
-Sub agents are stored as Markdown files and can be managed through a command-line interface or by editing the files directly.
-
-### Using the `/agents` Command
-
-The `/agents` command provides a comprehensive, interactive interface for all sub agent management tasks.
-
-```ts
-/agents
+Inspect the changed files and closest tests. Return missing coverage with file
+references. Do not edit files.
 ```
 
-This opens a menu where you can:
+Agent frontmatter can also control disallowed tools, MCP servers, hooks, maximum
+turns, skills, effort, background behavior, and isolation.
 
-- View all available sub agents (built-in, user, and project-level).
-- Create new sub agents with a guided setup.
-- Edit existing custom sub agents, including their prompts and tool access.
-- Delete custom sub agents.
-- Easily manage tool permissions with a complete list of available tools.
+## Background Subagents
 
-### Sub Agent Configuration
+Background subagents are useful for independent research. Current Claude Code
+surfaces background subagent permission prompts in the main session, which makes
+their actions easier to audit.
 
-Sub agents are defined in Markdown files with YAML frontmatter, stored in one of two locations:
+Give background agents a tight return contract:
 
-| Type        | Location            | Scope                                 | Priority |
-| ----------- | ------------------- | ------------------------------------- | -------- |
-| **Project** | `.claude/agents/`   | Available only in the current project | Highest  |
-| **User**    | `~/.claude/agents/` | Available across all your projects    | Lower    |
-
-When a project-level and user-level sub agent have the same name, the project-level agent takes precedence.
-
-#### File Format
-
-Each sub agent is defined in a `.md` file with the following structure:
-
-Markdown
-
-```ts
----
-name: your-sub-agent-name
-description: A clear description of when this sub agent should be used.
-tools: tool1, tool2 # Optional - inherits all tools from the main agent if omitted.
----
-
-Your sub agent's system prompt goes here.
-
-This section should clearly define the sub agent's role, capabilities, personality, and approach to solving problems. Include specific instructions, best practices, and any constraints the sub agent should follow.
+```text
+Return only confirmed findings, file references, and whether the main task
+should stop.
 ```
 
-| Field         | Required | Description                                                                                                                                                 |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`        | Yes      | A unique identifier for the agent, using lowercase letters and hyphens.                                                                                     |
-| `description` | Yes      | A natural language description of the agent's purpose, used by Claude for automatic delegation.                                                             |
-| `tools`       | No       | A comma-separated list of specific tools the agent can use. If omitted, it inherits all tools from the main agent, including any connected via MCP servers. |
+## Agent Memory
 
-## How to Use Sub Agents
-
-### Automatic Delegation
-
-Claude Code can proactively delegate tasks to the most appropriate sub agent based on the `description` field in its configuration file. To encourage this, use action-oriented phrases in the description, such as "Use proactively to run tests and fix failures."
-
-### Explicit Invocation
-
-You can directly instruct Claude to use a specific sub agent or to parallelize a task.
-
-- **By Name**: Mention the agent in your prompt.
-
-  ```ts
-  > Use the code-reviewer sub agent to check my recent changes.
-  ```
-
-- **By Task**: Instruct Claude to use multiple agents for a general task.
-
-  ```ts
-  > Use 5 agents in parallel to analyze this codebase for duplicates, complexity, and dead code.
-  ```
-
-## Multi-Agent Workflows and Coordination
-
-For complex projects, structuring agent collaboration is key. This often involves mirroring real-world agile teams.
-
-- **Defining Distinct Roles**: Assign specialized roles to each agent. Common roles include:
-  - **Architect/Planner**: Performs high-level system analysis and design (often uses a powerful model like Claude Opus).
-  - **Builder/Developer**: Translates plans into functional code (can use a cost-effective model like Claude Sonnet).
-  - **Validator/Tester**: Scrutinizes the Builder's output, runs tests, and reviews for quality.
-  - **Scribe/Documenter**: Maintains project documentation like `README` files.
-- **Shared Communication Files**: Agents can coordinate through shared planning documents like `PLAN.md` or `ISSUE.md`. These files act as a central source of truth and persistent memory for the agent team.
-- **Git Worktrees for Isolation**: To prevent conflicts when running multiple agents on the same codebase, using **Git worktrees is highly recommended**. This allows each agent to work in its own isolated branch without interference.
-- **Chaining Sub Agents**: For multi-step workflows, you can instruct agents to execute in sequence.
-
-```markdown
-> First use the code-analyzer to find performance issues, then use the optimizer to fix them.
-```
-
-## Best Practices and Tips
-
-- **Start with Claude-Generated Agents**: Use the `/agents` command to have Claude generate an initial sub agent configuration. Then, customize the prompt and settings to fit your exact needs.
-- **Plan Diligently**: For complex tasks, always start with a detailed plan. Instruct the main agent _not to write code yet_ and use "Plan Mode" (Shift+Tab) to focus its efforts on creating a roadmap.
-- **Write Detailed Prompts**: Include specific instructions, examples, and constraints in your sub agent system prompts. The more guidance you provide, the better the agent will perform.
-- **Limit Tool Access**: For security and focus, only grant the tools that are necessary for the sub agent's purpose.
-- **Version Control Sub Agents**: Check your project-level agents (`.claude/agents/`) into Git so your team can benefit from and improve them collaboratively.
-- **Leverage `CLAUDE.md`**: This special file is automatically read by Claude and serves as a persistent, project-specific memory for coding standards, architecture, and key workflows.
-- **Frequent Context Clearing**: Use the `/clear` command frequently to wipe the current chat conversation (short-term memory) and start fresh, especially when switching between unrelated tasks.
-- **Commit Often**: Regularly commit changes with Git. This creates checkpoints to revert to if an agent goes off track and provides a clear history of the agent's work.
-- **Utilize Hooks and MCP Servers**: Integrate Claude Code with external tools, APIs, and real-time documentation using Model Context Protocol (MCP) servers. Use Claude Code Hooks to execute custom scripts at key lifecycle events (e.g., `PreToolUse`, `PostToolUse`, `SubagentStop`) to enforce standards or automate testing.
-- **Debug Systematically**: Use `/debug` for verbose output on Claude's thought process, `/doctor` to check your installation's health, and `/hooks` to confirm loaded hook configurations.
-
-## Example Sub Agents
-
-### Code Reviewer
-
-```markdown
----
-name: code-reviewer
-description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code.
-tools: Read, Grep, Glob, Bash
----
-
-You are a senior code reviewer ensuring high standards of code quality and security.
-
-When invoked:
-
-1. Run git diff to see recent changes.
-2. Focus on modified files.
-3. Begin review immediately.
-
-Review checklist:
-
-- Code is simple and readable
-- No duplicated code
-- Proper error handling
-- No exposed secrets or API keys
-- Good test coverage
-
-Provide feedback organized by priority: Critical, Warning, and Suggestion. Include specific examples of how to fix issues.
-```
-
-### Debugger
-
-```markdown
----
-name: debugger
-description: Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.
-tools: Read, Edit, Bash, Grep, Glob
----
-
-You are an expert debugger specializing in root cause analysis.
-
-When invoked:
-
-1. Capture error message and stack trace.
-2. Identify reproduction steps.
-3. Isolate the failure location and implement a minimal fix.
-4. Verify the solution works.
-
-For each issue, provide a root cause explanation, evidence, the specific code fix, and prevention recommendations. Focus on fixing the underlying issue, not just symptoms.
-```
+Subagents can maintain memory. Use that for repeated specialist behavior, not for
+facts that should be committed to the repository. If the memory affects future
+correctness, move it into a rule, skill, test, or documentation file.

--- a/courses/ai-development/claude-code-sub-agents.md
+++ b/courses/ai-development/claude-code-sub-agents.md
@@ -11,6 +11,9 @@ date: 2025-07-29
 with their own context, tools, model, permissions, and optional memory. They are
 useful when one part of the task can be isolated from the main conversation.
 
+I use them when isolation makes the main thread simpler, not when I want the task
+to look more advanced than it is.
+
 ## Built-In Agents
 
 Claude Code includes built-in agents such as Explore, Plan, and

--- a/courses/ai-development/claude-code-thinking.md
+++ b/courses/ai-development/claude-code-thinking.md
@@ -1,44 +1,63 @@
 ---
-title: Claude Code Thinking
+title: Encouraging Claude Code to Think
 description: >-
-  Leverage extended thinking modes and Ultrathink capabilities for complex
-  problem-solving, strategic planning, and architectural decisions
-modified: 2026-03-17
+  Use plan mode, effort controls, opusplan, and explicit tradeoff questions
+  instead of relying on magic prompting phrases.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Claude Code leverages an advanced "thinking" mode, including the super poweful **Ultrathink** capability, to enhance its problem-solving, planning, and code generation processes. This feature allows Claude to allocate additional computational resources for deeper analysis, moving beyond superficial responses to deliver more comprehensive and accurate results.
+The goal is not to make [Claude Code](https://code.claude.com/docs/en/overview)
+"think harder" in the abstract. The goal is to make it expose the reasoning that
+affects the next action.
 
-## What is Thinking Mode?
+## Use Plan Mode for Real Decisions
 
-[Extended thinking mode](https://www.anthropic.com/news/visible-extended-thinking) in Claude Code is a mechanism that allows the AI to perform **extended reasoning** and evaluate alternatives more thoroughly before producing an output. Instead of immediately generating code or an answer, Claude takes an "analytical pause" to understand the complete context and develop robust strategies. This process is particularly beneficial for complex problems where multiple factors need to be balanced.
+When a task has multiple plausible designs, start in plan mode:
 
-When Claude is in a thinking mode, its internal thought process is often displayed as **italic gray text** in the terminal, providing transparency into its reasoning. This visibility can be invaluable for developers to understand Claude's approach and guide it effectively.
+```text
+Plan the smallest change that adds account-level rate limits.
+Compare middleware and service-layer implementations. Name the files each path
+would touch. Do not edit files.
+```
 
-## How to Trigger Thinking Modes
+That prompt forces the decision into the open before edits begin.
 
-You can activate different levels of thinking by incorporating specific keywords into your prompts:
+## Use Effort Controls
 
-- **"think"**: This triggers an initial level of extended thinking, allocating approximately **4,000 tokens** for reasoning.
-- **"think hard"** or **"megathink"**: These phrases prompt Claude to engage in deeper consideration, allocating around **10,000 tokens**.
-- **"think harder"** or **"ultrathink"**: These are the most intense thinking modes, providing Claude with a significant thinking budget of approximately **31,999 tokens** to thoroughly evaluate alternatives. "Ultrathink" is considered a powerful prompting technique for particularly challenging problems.
+Claude Code supports effort controls such as `/effort`. Increase effort when the
+task has high reasoning cost: architecture, security, migration planning, or
+review. Lower effort for routine edits where latency matters more than deep
+analysis.
 
-These intensifying phrases direct Claude to dedicate progressively more computational time to its thought process.
+Effort is not a substitute for context. A high-effort model with the wrong files
+will still solve the wrong problem.
 
-## Benefits and Use Cases
+## Use Opus Planning Deliberately
 
-Employing thinking modes, especially "Ultrathink," offers several significant advantages for development workflows:
+The `opusplan` alias uses Opus for planning and Sonnet for implementation. It is
+a useful default for larger changes because it spends the expensive reasoning
+where it matters most.
 
-- **Improved Instruction Adherence and Reasoning**: Extended thinking directly improves Claude's ability to follow instructions, enhance its reasoning capabilities, and increase overall efficiency.
-- **Strategic Planning**: It is highly recommended to ask Claude to **make a plan** for approaching a specific problem, utilizing "think" or "think hard" during this phase. This methodical approach ensures alignment between requirements and execution, significantly improving results on complex tasks.
-- **Complex Problem-Solving and Architectural Decisions**: Thinking modes are invaluable for designing scalable architectures, balancing multiple constraints, and making informed decisions in intricate scenarios. Claude 4 models, in particular, show transformative improvement in strategic planning and extended thinking for challenging technical problems.
-- **Debugging and Refactoring**: These modes excel when applied to debugging complex issues and formulating refactoring strategies for large files, improving code maintainability, scalability, and readability.
-- **Multi-Agent Collaboration**: The lead agent in a multi-agent system can use thinking mode to plan its approach, assessing which tools fit the task, determining query complexity, and defining each subagent’s role. Subagents also utilize interleaved thinking after tool results to evaluate quality, identify gaps, and refine their next queries. Combining "Ultrathink" with parallel task execution can dramatically accelerate complex tasks, making workflows much faster.
-- **Cost Optimization**: While extended thinking consumes more tokens initially, it can lead to cost efficiency by reducing the need for repetitive instructions or corrective prompts that arise from Claude going off-track or producing superficial code. A well-thought-out plan derived from thinking mode can ensure consistent and accurate output from the first attempt, saving tokens in the long run.
+Review the plan before implementation:
 
-## Best Practices and Considerations
+```text
+Use opusplan. Produce the plan first and wait for approval before editing.
+```
 
-- **Context is Key**: Claude Code performs significantly better when provided with relevant context. Thinking modes leverage this context to make informed decisions.
-- **"Explore, Plan, Code, Commit" Workflow**: Thinking modes are a critical part of this versatile workflow, particularly during the "Plan" phase, where Claude develops a detailed, step-by-step approach before writing code.
-- **Human Oversight**: Even with advanced thinking, human oversight remains necessary for broader architectural decisions and to "reel Claude back in" if it goes off on tangents.
-- **Cost Implications**: While beneficial, extended thinking is more expensive in terms of token usage. Users with Max plans have more access to powerful models like Opus 4, which is often used with these modes. Some community-driven frameworks like SuperClaude also aim to incorporate token optimization even within thinking modes.
+## Ask Better Tradeoff Questions
+
+Weak:
+
+```text
+Think carefully and make this better.
+```
+
+Better:
+
+```text
+List the two smallest implementation paths, the failure modes of each, and the
+verification command that would prove the chosen path works.
+```
+
+The second prompt gives thinking a job.

--- a/courses/ai-development/claude-dot-md.md
+++ b/courses/ai-development/claude-dot-md.md
@@ -16,7 +16,7 @@ permissions, hooks, or continuous integration.
 
 `CLAUDE.md` is the main human-written project instruction file. It can live at
 the repository root or under `.claude/`. User-level instructions can live at
-`~/.claude/CLAUDE.md`, and local-only notes can live in `CLAUDE.local.md`.
+`~/.claude/CLAUDE.md`.
 
 Use `CLAUDE.md` for durable project guidance:
 
@@ -30,6 +30,9 @@ Use `CLAUDE.md` for durable project guidance:
 
 Keep it short. Link to deeper documentation instead of turning the file into a
 manual.
+
+Do not rely on local-only memory for shared project policy. If the next person
+needs the instruction, put it in a versioned file.
 
 ## Imports and AGENTS.md
 

--- a/courses/ai-development/claude-dot-md.md
+++ b/courses/ai-development/claude-dot-md.md
@@ -37,8 +37,8 @@ needs the instruction, put it in a versioned file.
 ## Imports and AGENTS.md
 
 Claude Code supports imports with `@path` references. As of the current
-documentation, Claude Code does not read `AGENTS.md` directly. If a repository
-uses `AGENTS.md`, create a `CLAUDE.md` that imports it:
+documentation, Claude Code does not read [`AGENTS.md`](https://agents.md/)
+directly. If a repository uses `AGENTS.md`, create a `CLAUDE.md` that imports it:
 
 ```md
 @AGENTS.md

--- a/courses/ai-development/claude-dot-md.md
+++ b/courses/ai-development/claude-dot-md.md
@@ -1,300 +1,76 @@
 ---
-title: CLAUDE.md
+title: CLAUDE.md, Rules, and Memory
 description: >-
-  Create and maintain CLAUDE.md files as persistent project memory and
-  authoritative system rules for consistent AI behavior
-modified: 2026-03-17
+  Use CLAUDE.md, .claude/rules, auto memory, AGENTS.md imports, and skills as
+  distinct instruction layers in Claude Code.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-`CLAUDE.md` files are fundamental to Claude Code's operation and are treated as **authoritative system rules** that define operational boundaries, taking precedence over user prompts.
+[Claude Code](https://code.claude.com/docs/en/memory) has two broad memory
+systems: human-written memory and Claude-written auto memory. Both are context,
+not enforcement. If something must be enforced, encode it in tests, lint,
+permissions, hooks, or continuous integration.
 
-- **Automatic Loading**: Claude Code automatically loads the contents of `CLAUDE.md` files into its context at the start of every session within a given directory. This provides Claude with immediate project context and helps it remember information across different chat sessions.
-- **Hierarchical Memory System**: Claude recursively looks for `CLAUDE.md` files in multiple locations, merging their contexts. This layered approach allows for granular control and shared settings:
-  - **User Memory (`~/.claude/CLAUDE.md`)**: Located in your home directory, its contents are loaded for _all_ your projects, ideal for personal preferences, coding styles, or custom tool shortcuts you use everywhere.
-  - **Project Memory (`./CLAUDE.md`)**: Placed in the root of your project, this is the most common location. It should be checked into Git to share project-specific instructions, commands, and style guides with your entire team.
-  - **Parent/Child Directory Memory**: Claude can load `CLAUDE.md` files from parent directories (useful for monorepos) and also discovers them in subdirectories on demand when interacting with files within those subtrees.
-  - **Local Overrides (`CLAUDE.local.md`)**: This file, usually `.gitignore`'d, allowed for personal project-specific preferences not committed to source control. It has been deprecated in favor of using imports, which work better across multiple Git worktrees.
-- **Contextual Persistence**: `CLAUDE.md` ensures context is maintained throughout the session, leading to consistent execution of process steps. It helps prevent "instruction bleed" and reduces context pollution by controlling file access.
+## CLAUDE.md
 
-## Purpose and Content of `CLAUDE.md`
+`CLAUDE.md` is the main human-written project instruction file. It can live at
+the repository root or under `.claude/`. User-level instructions can live at
+`~/.claude/CLAUDE.md`, and local-only notes can live in `CLAUDE.local.md`.
 
-Think of `CLAUDE.md` as the **central source of truth** and a dynamic task board for your AI team. It helps Claude align with the overall project vision and provides persistent memory across sessions.
+Use `CLAUDE.md` for durable project guidance:
 
-You should use `CLAUDE.md` to document:
+```md
+# Project Instructions
 
-- **Project Architecture and Overview**: High-level descriptions of your project's structure, key components, and what it does.
-- **Coding Standards and Style Guidelines**: Explicitly state conventions like indentation, naming, use of ES modules, or type annotations.
-- **Common Commands**: List frequently used build, test, and lint commands, or even developer environment setup commands (e.g., `npm run build`, `npm run typecheck`, `go install`).
-- **Project Workflows**: Detail processes like Git branching strategies, testing strategies, or how to handle specific issues.
-- **Known Pitfalls and Warnings**: Document any unexpected behaviors, limitations, or specific instructions Claude should be aware of (e.g., "always check documentation for breaking changes").
-- **AI Behavior Rules**: Include specific instructions on how Claude should behave, such as error handling, API conventions, or problem-solving approaches.
-- **Architectural Decision Records (ADRs)**: Keep track of important technical decisions and their rationale.
-
-## Best Practices, Tips, and Tricks for `CLAUDE.md`
-
-1. **Start with `/init`**: When beginning a new project, run the `/init` command in your project root. This command analyzes your codebase and automatically generates a foundational `CLAUDE.md` file with a high-level summary of your project. It's recommended to commit this generated file to version control.
-2. **Be Concise and Structured**: Use Markdown headings and bullet points to keep the file organized and readable. Be explicit and detailed in your instructions, avoiding vague requests.
-3. **Refine Constantly**: Treat your `CLAUDE.md` as a living document and a frequently used prompt that you constantly refine. Experiment to determine what produces the best instruction following from the model.
-4. **Tune Instructions**: Add emphasis (e.g., "IMPORTANT," "YOU MUST") to improve Claude's adherence to critical instructions.
-5. **Use `#` for Quick Additions**: The fastest way to add a memory during a session is by starting your input with the `#` character. Claude will then prompt you to select which memory file (`CLAUDE.md` or `CLAUDE.local.md`) to store it in.
-6. **Edit Directly with `/memory`**: For more extensive additions or organization, use the `/memory` slash command to open the `CLAUDE.md` file in your default editor.
-7. **Modularize with `@` Imports**: For larger documents or to include specific information only when relevant, use the `@path/to/file.md` syntax to import other Markdown files into your `CLAUDE.md`. This keeps your main `CLAUDE.md` clean and prevents overloading Claude's context window with unnecessary information, saving tokens.
-8. **Distinguish Between "Nouns" and "Verbs"**: A good rule of thumb is to use `CLAUDE.md` for "nouns" (where and what things are: project overview, architecture, coding standards) and slash commands for "verbs" (how to do things: specific tasks, workflows). `CLAUDE.md` provides the consistent baseline, while slash commands handle specific tasks within that context.
-9. **Periodically Review and Update**: If Claude repeatedly asks for certain information or makes wrong assumptions, add that clarification to `CLAUDE.md` so it's pre-loaded next time. Claude can even assist with its own maintenance, for example, by updating `CLAUDE.md` to note new library usage.
-
-## Examples and Non-Examples
-
-### Decision Records
-
-Document the "why" behind technical choices:
-
-```markdown
-## Architectural Decision Records
-
-### ADR-001: Chose PostgreSQL over MongoDB
-
-**Date:** 2024-01-15  
-**Status:** Accepted
-**Context:** Need ACID compliance for financial transactions
-**Decision:** PostgreSQL with JSONB for flexible schemas
-**Consequences:** Stronger consistency, slightly more complex queries
-
-### ADR-002: Implemented Soft Deletes
-
-**Date:** 2024-02-01  
-**Status:** Accepted
-**Context:** Legal requirement to retain data for 7 years
-**Decision:** All tables have `deleted_at` timestamp
-**Consequences:** All queries must filter by `deleted_at IS NULL`
+- Use Bun for package management.
+- Run `bun run lint` and the closest test before reporting completion.
+- Do not edit generated files directly.
 ```
 
-### Performance Notes
+Keep it short. Link to deeper documentation instead of turning the file into a
+manual.
 
-Help AI write efficient code:
+## Imports and AGENTS.md
 
-```markdown
-## Performance Considerations
+Claude Code supports imports with `@path` references. As of the current
+documentation, Claude Code does not read `AGENTS.md` directly. If a repository
+uses `AGENTS.md`, create a `CLAUDE.md` that imports it:
 
-### Database Queries
-
-- **N+1 Prevention:** Always use Prisma's `include` for relations
-- **Pagination:** Use cursor-based pagination for large datasets
-- **Indexes:** See `prisma/indexes.sql` for custom indexes
-
-### Frontend Optimization
-
-- **Bundle Splitting:** Dynamic imports for routes and heavy components
-- **Image Loading:** Use next/image with explicit dimensions
-- **State Updates:** Batch React state updates in event handlers
-- **Memoization:** useMemo for expensive computations > 1ms
-
-### Caching Strategy
-
-- **Redis:** User sessions (24h), API responses (5 min)
-- **CDN:** Static assets, immutable with hash names
-- **Browser:** API calls with Cache-Control headers
-- **React Query:** 5 minute stale time, 10 minute cache time
+```md
+@AGENTS.md
 ```
 
-### Troubleshooting Guide
+That keeps one shared instruction source without pretending every agent discovers
+files the same way.
 
-Help your AI companion diagnose common issues:
+## .claude/rules
 
-```markdown
-## Common Issues and Solutions
+Rules in `.claude/rules/*.md` are useful for scoped context. They can include
+frontmatter such as `paths` so the rule attaches to relevant files.
 
-### "Cannot connect to database"
+Use rules for constraints:
 
-1. Check Docker is running: `docker ps`
-2. Verify `.env` has correct DATABASE_URL
-3. Run migrations: `pnpm db:migrate`
+```md
+---
+paths:
+  - 'src/routes/api/**/*.ts'
+---
 
-### "TypeScript errors after pulling"
-
-1. Clean install: `rm -rf node_modules pnpm-lock.yaml && pnpm install`
-2. Clear TS cache: `pnpm typecheck --force`
-
-### "Tests failing locally but not in CI"
-
-1. Reset test database: `pnpm db:test:reset`
-2. Check timezone: Tests assume UTC
-3. Clear test cache: `pnpm test --clearCache`
+API routes must validate input at the boundary and return the shared error
+shape.
 ```
 
-## Keep CLAUDE.md Living
+## Skills Versus Rules
 
-### Update Triggers
+Use skills for task-specific workflows. If the instruction has phases, scripts,
+references, or assets, it probably belongs in `.claude/skills/<name>/SKILL.md`
+instead of a rule.
 
-Create a checklist for when to update CLAUDE.md:
+Rules shape the session. Skills run a workflow.
 
-```markdown
-## Maintenance Guidelines
+## Auto Memory
 
-Update this file when:
-
-- [ ] Adding new major dependencies
-- [ ] Changing architectural patterns
-- [ ] Modifying directory structure
-- [ ] Adding new environment variables
-- [ ] Changing API response formats
-- [ ] Implementing new testing patterns
-- [ ] Discovering performance bottlenecks
-- [ ] Making security changes
-```
-
-### Version Your Context
-
-Track major changes:
-
-```markdown
-## Recent Changes
-
-### 2024-01-20
-
-- Migrated from REST to tRPC for type safety
-- Added Redis caching layer
-- Implemented event sourcing for audit logs
-
-### 2024-01-15
-
-- Switched from CSS Modules to Tailwind CSS
-- Added Playwright for E2E testing
-- Implemented feature flags system
-```
-
-### Link to Deep Dives
-
-Reference detailed documentation:
-
-```markdown
-## Additional Resources
-
-- **Architecture Diagrams:** `/docs/architecture/`
-- **API Documentation:** `/docs/api/` (OpenAPI spec)
-- **Database Schema:** `/prisma/schema.prisma`
-- **Component Storybook:** Run `pnpm storybook`
-- **Performance Metrics:** `/docs/performance/benchmarks.md`
-```
-
-## Test Your `CLAUDE.md`
-
-### Verify Claude Reads It
-
-```bash
-# Ensure you're in project directory
-cd ~/code/my-sandbox
-
-# Ask Claude to summarize the project
-claude explain "What is this project's architecture?"
-```
-
-Claude should reference specific details from your CLAUDE.md file.
-
-### Test Contextual Understanding
-
-Try increasingly specific prompts:
-
-```bash
-# Generic request
-claude plan "Add user authentication"
-
-# Should use your specific auth patterns, not generic solutions
-```
-
-### Measure Improvement
-
-Compare AI responses before and after CLAUDE.md improvements:
-
-1. Save current CLAUDE.md: `cp CLAUDE.md CLAUDE.md.backup`
-2. Try a complex request and save the response
-3. Enhance CLAUDE.md with more detail
-4. Try the same request and compare quality
-
-## Common Pitfalls and Solutions
-
-### Pitfall 1: Too Generic
-
-This maybe seems nice, but it doesn't really give Claude any context.
-
-```markdown
-This project uses modern web technologies.
-```
-
-Instead, we want to be _really_ specific.
-
-```markdown
-Frontend: Next.js 14.1.0 with App Router, TypeScript 5.3.3
-State: Zustand 4.4.7 for client, TanStack Query 5.17.9 for server
-```
-
-### Pitfall 2: Outdated Information
-
-Add update reminders:
-
-```markdown
-<!-- Last verified: 2024-01-20 -->
-
-## Dependencies
-```
-
-### Pitfall 3: Missing Context
-
-Instead of this:
-
-```markdown
-Run tests with `pnpm test`
-```
-
-Be as specific as possible:
-
-```markdown
-Run tests with `pnpm test`
-
-- Unit tests use Vitest with React Testing Library
-- Integration tests require Docker running
-- E2E tests need `pnpm dev` running on port 3000
-```
-
-### Pitfall 4: No Examples
-
-Always include code examples for patterns you want AI to follow.
-
-## Pro Tips
-
-### Use Markdown Features
-
-- Code blocks with syntax highlighting
-- Tables for structured data
-- Collapsible sections for details
-- Links to relevant files
-
-### Be Explicit About Preferences
-
-```markdown
-**ALWAYS** use named exports, NEVER default exports
-**ALWAYS** handle errors with Result<T, E> pattern
-**NEVER** use try/catch in components
-```
-
-### Include Anti-Patterns
-
-```markdown
-## What NOT to Do
-
-- Don't access database directly from components
-- Don't store sensitive data in localStorage
-- Don't use index as React key in dynamic lists
-```
-
-### Add Quick Reference
-
-```markdown
-## Quick Commands
-
-- Start dev: `pnpm dev`
-- Run specific app: `pnpm dev --filter=web`
-- Database GUI: `pnpm db:studio`
-- Check types: `pnpm typecheck`
-- Update snapshots: `pnpm test -u`
-```
+Auto memory is Claude-written and can help carry preferences forward, but it
+should not become the only place important project behavior lives. If an auto
+memory captures a real team decision, move that decision into a versioned file.

--- a/courses/ai-development/cost-management.md
+++ b/courses/ai-development/cost-management.md
@@ -1,62 +1,51 @@
 ---
-title: Managing Costs and Token Usage in Claude Code
+title: Cost Management in Claude Code
 description: >-
-  Learn strategies for cost-effective Claude Code usage through model selection,
-  context management, and subscription plans.
-modified: 2026-03-17
+  Manage Claude Code cost through model choice, context discipline, plan mode,
+  fallback chains, and verification scope.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-As we've discussed ad nauseum, the primary cost driver when using Claude Code is **token consumption**. Each message sent, and the entire conversation history re-processed, consumes tokens, leading to accumulating costs. Factors that increase token usage and thus cost include:
+Cost management in [Claude Code](https://code.claude.com/docs/en/overview) is
+mostly context management. Expensive models and large context windows are useful,
+but they should be tied to task value.
 
-- **Model Choice**: More powerful models like Claude 4 Opus are significantly more expensive than others, such as Claude 4 Sonnet or Claude Haiku 3.5. For example, Claude 4 Opus can be approximately 5 times more expensive than Claude 4 Sonnet.
-- **Conversation Length and Context Overload**: Claude Code is stateless, meaning it re-processes the entire conversation history with each new message to maintain context. Long, unmanaged chat sessions can quickly lead to high token counts and degraded performance.
-- **Lack of Specificity and Rework**: Ambiguous prompts, repeated mistakes, or the need for extensive back-and-forth clarifications can waste tokens.
-- **Complex Tasks**: While Claude excels at complex tasks, these naturally require more interaction and larger contexts, which translates to higher token usage.
+## Spend on the Hard Part
 
-## Strategies for Cost-Effective Claude Code Usage
+Use stronger models for planning, security review, migration design, and
+high-risk debugging. Use cheaper or default models for routine implementation
+once the plan is clear.
 
-To optimize your Claude Code usage and manage costs, consider the following strategies:
+The `opusplan` alias is a good example: spend more on the plan, then implement
+with a faster model.
 
-### Strategic Model Selection
+## Keep Context Small
 
-- **Hybrid Approach**: A common and highly recommended strategy is to **use a hybrid model approach**. Reserve the most expensive, high-reasoning models (like Claude 4 Opus) for critical, low-frequency tasks such as high-level planning, architectural design, or final code review.
-- **Cheaper Models for Routine Tasks**: For the majority of high-frequency implementation work, basic syntax validation, linting, simple text transformations, data parsing, or quick status checks, opt for faster and cheaper models like Claude 4 Sonnet or Haiku 3.5. This can lead to substantial cost savings. You can switch models using the `/model` command.
+Before using a one-million-token context alias, ask whether the task really
+depends on that much input. A targeted prompt with file references is often
+better:
 
-### Aggressive Context and Memory Management
+```text
+Read @src/lib/server/invitations.ts and the closest tests. Do not scan unrelated
+routes unless the implementation requires it.
+```
 
-- **Clear Chat History Regularly**: Use the `/clear` command **as often as possible** when you complete a task or switch to an unrelated one. This effectively wipes the agent's short-term memory, preventing irrelevant past interactions from influencing the current task and reducing token consumption for subsequent messages.
-- **Summarize Conversations with `/compact`**: For long debugging sessions or conversations where you want to carry forward key information without retaining the entire history, use the `/compact` command. Claude will summarize the conversation, reducing the overall token count, and then start a new chat with that summary preloaded. You can also provide custom summarization instructions (e.g., "summarize just the to-do items"). Claude Code also auto-compacts when it reaches 95% of its context capacity, but manual compacting before this limit is recommended to prevent loss of important context.
-- **Leverage `CLAUDE.md` for Persistent Context**: The `CLAUDE.md` file is automatically read by Claude Code at the start of every session in that directory, providing persistent, project-specific memory. This is an ideal place to document:
-  - Project architecture, coding standards, and conventions.
-  - Common workflows and tool usage examples.
-  - Key decisions and known pitfalls. By investing time in configuring `CLAUDE.md` properly, you eliminate repetitive instructions that waste tokens and ensure consistent output, leading to lower costs and faster results. You can add to `CLAUDE.md` manually or using the `#` key to instruct Claude to incorporate information.
-- **Modular and Hierarchical Documentation**: Avoid making `CLAUDE.md` too large by linking to other relevant documentation files (e.g., `@docs/testing.md`). This helps manage context and prevents "context pollution". Claude Code reads `CLAUDE.md` files recursively up the directory tree.
-- **Be Explicit and Concise**: Provide clear, direct, and structured instructions, using XML tags for clarity. Avoid verbose language; some community-developed frameworks like SuperClaude even use "UltraCompressed Mode" to reduce token usage by up to 70%.
+Large context should solve a real evidence problem, not a prompting habit.
 
-### Structured Planning and Iterative Execution
+## Use Plan Mode Before Expensive Edits
 
-- **Plan Diligently Before Coding**: Always start with a detailed plan. Instruct Claude _not to write code yet_, but rather to analyze existing code or documentation and write out a plan in a Markdown file. This structured roadmap significantly improves results and reduces wasted tokens from misdirected efforts.
-- **Break Down Complex Tasks**: For complex problems, break the work into smaller, manageable steps. This allows you to guide Claude step-by-step, providing feedback and course correction along the way, which is often more effective than letting the AI run autonomously for complex problems.
-- **Human-in-the-Loop Guidance**: Act as an active collaborator, reviewing generated code, running it, and providing corrective feedback. You can interrupt Claude at any time (Esc key) to clarify instructions or fix misunderstandings, preventing long-winded wrong answers and saving tokens.
+Plan mode can prevent wasted implementation turns. If the plan names the wrong
+files, stop before paying for a long edit loop.
 
-### Utilizing Fixed-Cost Subscription Plans
+## Use Fallbacks Deliberately
 
-- For heavy users, shifting from pay-as-you-go API billing to fixed-cost subscription plans like **Anthropic's Claude Max plan** can be the most significant solution. These plans offer virtually unlimited Claude Code usage for a flat monthly fee (e.g., $100 or $200), making costs predictable and de-risking experimentation with large-scale agent swarms.
+Fallback chains improve reliability, but they can also change capability. Do not
+let a fallback silently weaken a task that needs a specific reasoning level or
+retention policy.
 
-### Monitoring and Safeguards
+## Measure by Quality Gates
 
-- **Monitor Token Usage**: Use the `/cost` command to show token usage statistics for your session. This helps you understand your usage patterns and identify opportunities for optimization.
-- **Set Automation Safeguards**: For fully automated workflows (e.g., in CI/CD pipelines), configure safeguards like `max_turns` (maximum number of turns an agent can take) and `timeout_minutes` (total time it can run) to prevent runaway costs.
-- **Curate Allowed Tools**: By default, Claude Code requests permission for actions that modify your system (file writes, bash commands, MCP tools) to prioritize safety. You can customize the allowlist to permit known safe tools or those easy to undo, balancing safety with automation efficiency.
-
-### Leveraging Extensibility and Automation Tools
-
-- **Custom Slash Commands**: Create reusable prompt templates using Markdown files in `.claude/commands/`. These act as shortcuts for common tasks, encapsulating complex multi-step workflows into a single command, reducing repetitive instructions and saving tokens.
-- **Hooks**: Implement user-defined shell commands that execute automatically at specific lifecycle events (e.g., `PreToolUse`, `PostToolUse`, `SubagentStop`). Hooks can enforce code quality (e.g., running linters or tests after file edits), acting as deterministic guardrails and providing immediate feedback, thus reducing the need for costly manual corrections.
-- **MCP Servers**: The Model Context Protocol (MCP) allows Claude Code to connect with external tools and systems (e.g., databases, web search, task management, Git integrations). By exposing functionality in a way Claude can understand, MCP reduces the need for Claude to perform basic operations or complex data handling purely through text, enabling more efficient and cost-effective interactions with external services.
-- **Multi-Agent Workflows and Git Worktrees**: When running multiple Claude Code agents in parallel on the same codebase, Git worktrees are highly recommended for isolation. This prevents conflicts and allows agents to operate in their own isolated branches, which can indirectly save costs by preventing rework due to merge conflicts. Frameworks like Claude-Flow or BMad-Method help orchestrate these multi-agent teams.
-
-## Time for an Analogy
-
-Think of Claude Code's cost management like managing a team of highly skilled contractors. Each contractor (AI model) has a different hourly rate (token cost) and specialized skills. If you assign your most expensive expert to every small task, your budget will quickly vanish. Instead, you'd **strategically deploy** your top expert for critical, complex planning, and assign routine tasks to more affordable, but still capable, specialists. Furthermore, you would provide **clear, concise blueprints** (well-structured `CLAUDE.md` and precise prompts) so they don't waste time on ambiguities. You would also have **regular check-ins** (`/compact`, human-in-the-loop guidance) to ensure they stay on track and don't stray into irrelevant work. For repeatable processes, you'd create **automated workflows** (custom slash commands and hooks) so tasks are done consistently and efficiently without constant oversight. Finally, for large, ongoing projects, a **flat-fee retainer** (Claude Max subscription) provides peace of mind, allowing the team to work without hourly billing anxiety. By applying these principles, you ensure your intelligent coding assistant works efficiently and within budget, just like a well-managed human team.
+The cheapest agent run is the one that ends with a passing targeted test and a
+small diff. The expensive run is the one that edits broadly, fails lint, and
+needs a human to untangle it.

--- a/courses/ai-development/cursor-automations.md
+++ b/courses/ai-development/cursor-automations.md
@@ -1,0 +1,59 @@
+---
+title: Cursor Automations
+description: >-
+  Run Cursor Cloud Agents from schedules and events with explicit prompts,
+  permissions, visibility, and quality gates.
+modified: 2026-06-24
+date: 2026-06-23
+---
+
+[Cursor Automations](https://cursor.com/docs/cloud-agent/automations) run Cloud
+Agents from a schedule or event. As of Cursor 3.8, automations can also be
+created from the `/automate` skill.
+
+Automations are useful for repeatable maintenance: dependency checks, flaky test
+triage, issue grooming, release readiness, and scheduled reports. They are risky
+when the prompt is vague or when the automation can change code without a human
+review path.
+
+## Trigger Sources
+
+Cursor supports triggers from schedules, webhooks, version control events,
+Slack, Linear, Sentry, PagerDuty, and related integrations. GitHub triggers can
+include issue comments, pull request review comments, submitted reviews, review
+thread updates, and workflow runs.
+
+Pick the trigger that matches the workflow. Do not make an automation poll a
+system that can send a precise event.
+
+## Prompt Contract
+
+Every automation prompt should include:
+
+- What it may read.
+- What it may change.
+- The verification commands it must run.
+- Whether it may create a pull request.
+- What counts as blocked.
+- Where it should report results.
+
+Example:
+
+```text
+When a workflow run fails on the main branch, inspect the failing job logs and
+open a pull request only if the fix is confined to test configuration. Run
+bun run lint and the failing test command. If the failure is product code or
+requires a dependency change, report the diagnosis without editing files.
+```
+
+## Visibility and Ownership
+
+Automations can be private, team visible, or team owned. Use team ownership for
+workflows that affect shared repositories. A private automation that opens pull
+requests against a team repository is hard to audit.
+
+## Review the First Runs
+
+Treat the first few automation runs as production tests. Read the branch, pull
+request, logs, and comments. Tighten the prompt when the automation does
+something technically allowed but operationally unhelpful.

--- a/courses/ai-development/cursor-automations.md
+++ b/courses/ai-development/cursor-automations.md
@@ -8,8 +8,9 @@ date: 2026-06-23
 ---
 
 [Cursor Automations](https://cursor.com/docs/cloud-agent/automations) run Cloud
-Agents from a schedule or event. As of Cursor 3.8, automations can also be
-created from the `/automate` skill.
+Agents from a schedule or event. As of
+[Cursor 3.8](https://cursor.com/changelog), automations can also be created from
+the `/automate` skill.
 
 Automations are useful for repeatable maintenance: dependency checks, flaky test
 triage, issue grooming, release readiness, and scheduled reports. They are risky
@@ -19,9 +20,11 @@ review path.
 ## Trigger Sources
 
 Cursor supports triggers from schedules, webhooks, version control events,
-Slack, Linear, Sentry, PagerDuty, and related integrations. GitHub triggers can
-include issue comments, pull request review comments, submitted reviews, review
-thread updates, and workflow runs.
+[Slack](https://slack.com/), [Linear](https://linear.app/),
+[Sentry](https://sentry.io/), [PagerDuty](https://www.pagerduty.com/), and
+related integrations. [GitHub](https://github.com/) triggers can include issue
+comments, pull request review comments, submitted reviews, review thread updates,
+and workflow runs.
 
 Pick the trigger that matches the workflow. Do not make an automation poll a
 system that can send a precise event.

--- a/courses/ai-development/cursor-background-agents.md
+++ b/courses/ai-development/cursor-background-agents.md
@@ -1,78 +1,60 @@
 ---
-title: Using Cursor Background Agents for Asynchronous Coding
+title: Cursor Cloud Agents
 description: >-
-  Master background agents in Cursor for parallel AI-powered code editing and
-  autonomous task execution.
-modified: 2026-03-17
+  Use Cursor Cloud Agents for isolated, remote agent work with explicit
+  environments, verification commands, artifacts, and review boundaries.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Background agents are **asynchronous remote agents** in Cursor that operate in a remote environment, allowing you to **spawn tasks that edit and run code independently in the background**. They function like an AI "multiplier," enabling developers to offload specific, repetitive, or time-consuming tasks and focus their time and mental cycles on more important roadmap items. Unlike traditional AI tools, Cursor integrates directly with your local project and understands your entire codebase contextually.
+[Cursor Cloud Agents](https://cursor.com/docs/cloud-agent) are the current form
+of what earlier material called Background Agents. They run in isolated cloud
+environments, clone the repository, create their own branch, and can continue
+working while you use the editor for something else.
 
-## How Background Agents Work
+Cloud Agents are useful when a task is clear enough to run away from your local
+machine. They are a poor fit for vague product decisions or work that requires
+constant taste-level feedback.
 
-Background agents effectively operate in **Agent Mode** without maximum tool calls, allowing for **multiple parallel tasks** at once. They run in an isolated, Ubuntu-based machine by default, with internet access and the ability to install packages.
+## What the Cloud Environment Contains
 
-The typical workflow involves:
+A Cloud Agent can use:
 
-- **Cloning the Repository**: Background agents clone your repository from GitHub.
-- **Branch Management**: They work on a **separate branch** to make changes and then push to your repository for easy handoff. This ensures PRs remain small and focused, simplifying code review and reducing merge conflicts.
-- **Autonomous Execution**: Once instructed, the agent autonomously handles iterations, testing, linting, and formatting without direct supervision. This includes making file changes, running commands, and searching the web for resources.
-- **Pull Request Generation**: Upon completion, the agent generates a **pull request (PR)**, along with a summary of its work, including changes and features. You can then review and merge these changes into your main codebase. An automated code review can even be performed by another AI agent.
-- **Remote Access**: You can access and manage these agents from anywhere, including desktop, tablet, or mobile browsers, or as a Progressive Web App (PWA).
-- **Parallel Processing**: You can **create and run multiple background agents in parallel** to tackle different tasks or compare results from various models simultaneously. This dramatically parallelizes your work.
+- A cloned repository from a supported version control provider.
+- Installed dependencies and setup commands.
+- Secrets that you explicitly provide.
+- MCP servers configured for the environment.
+- Command-based hooks.
+- Browser, terminal, screenshots, videos, logs, and other artifacts.
 
-## Setup and Configuration
+Environment setup can live in `.cursor/environment.json`. Keep it boring. A
+repeatable environment beats a clever prompt every time.
 
-To use Cursor's background agents, you generally need to:
+## Prompt Shape
 
-1. **Disable Privacy Mode**: In Cursor's settings, you'll need to turn off Privacy Mode. While Cursor claims isolated environments and doesn't train on your code or retain it beyond agent operation when Privacy Mode is enabled, some advanced features like background agents require sending code to remote environments.
-2. **Enable Usage-Based Spending**: Background agents always use usage-based spending, even if you haven't exhausted included requests. You'll need to fund your account with a minimum of $10 or $20.
-3. **Connect to GitHub**: Grant read-write privileges to your GitHub repository (and any dependent repos or submodules) so the agent can clone and push changes. Cursor supports GitHub connection, with plans for other providers like GitLab and BitBucket.
-4. **Configure Environment**: Background agents run in a configurable environment. You can specify a Dockerfile for the base environment (e.g., Ruby, Node, Postgres, Redis versions) and a `setup.sh` script for post-checkout installations and configurations. The `environment.json` file can specify snapshot settings, install commands (e.g., `npm install`), and terminal commands to run (e.g., `npm run dev`).
-5. **Select a Model**: Only Max Mode-compatible models are available for background agents. Cursor often recommends using a Max model, which can be pricier but provides a larger context window for complex tasks.
+Use cloud prompts that define scope, verification, and stop conditions:
 
-## Real-World Use Cases and Applications
+```text
+Update the invite-token validation path only.
 
-Background agents are ideal for tasks you don't want to "babysit".
+Acceptance criteria:
+- Expired tokens return the same public error shape as revoked tokens.
+- A regression test fails before the implementation and passes afterward.
+- Run bun test:unit -- src/lib/server/invitations.test.ts and bun run lint.
 
-- **Codebase Analysis and Documentation**: An agent can go through every page of your codebase and add detailed comments at the top of files, explaining what the file does, why it exists, how it works, what other files it references, and opportunities for refactoring or security considerations. This helps in understanding the codebase and provides more context for the AI.
-- **Codebase-Wide Chores and Maintenance**: Perfect for tedious tasks such as updating documentation, fixing typos, or standardizing comments across a monorepo, as agents leverage full repository context without demanding active developer attention.
-- **Bug Fixes and Design Tweaks**: Delegate smaller, more predictable bug fixes, simple design adjustments (e.g., button styling, centering text), or accessibility tasks (e.g., adding dark mode support).
-- **Automated Testing Workflows**: Background agents can autonomously handle tasks that result in merge-ready PRs, including running tests, linting, and formatting. The future roadmap aims for a self-correcting test loop where the AI edits, runs tests, and fixes until green.
-- **Feature Development**: They can build new features, such as creating a multi-step sign-up form, from scratch.
-- **Continuous Integration/Delivery**: They can be used for automating support tickets (bug reports, change requests), pulling tickets, attempting fixes, and making pull requests with MCP. There's a strong community desire for programmatic API access to trigger agents for full SWE automation.
-- **Refactoring and Migrations**: Initiate code refactors, test suites, or migrations and let the agent work in the background.
+Stop and report the blocker if dependency installation fails or if an unrelated
+test failure appears.
+```
 
-## Advantages and Benefits
+That prompt can be judged from a branch diff and command output. "Improve the
+authentication flow" cannot.
 
-- **Increased Productivity**: By offloading tasks, developers can massively parallelize their work, focusing on complex problems while agents handle background tasks. This can make a developer 2-3x faster.
-- **Efficiency Gains**: Delegating easier, smaller, more predictable tasks allows for significant efficiency gains as these tasks can be "crushed in one shot" by the agent, freeing up developer time for higher-value work.
-- **Seamless Collaboration**: Team members can review agent-generated diffs and pull requests, and even create pull requests directly from the web interface. Slack integration allows for notifications on task completion and triggering agents via `@Cursor`.
-- **Always-On Capability**: Agents can run tasks while you're away, accessible from any device.
-- **Deep Context Awareness**: Cursor's agents benefit from deep context awareness due to codebase indexing, which allows them to understand local variables, imported libraries, and project structure. You can also provide specific context using `@` symbols (files, folders, code, documentation, web searches, past chats, rules).
+## Handoff Back to the Editor
 
-## Limitations and Considerations
+Inspect the Cloud Agent branch before merging or continuing locally. Review the
+diff, artifacts, command output, and any created pull request. If you continue
+locally, treat the branch as untrusted work from another developer: run the tests
+again and read the changed files.
 
-- **Cost**: Background agents are generally pricier than using a normal AI agent because they use Max Mode-compatible models. An easy PR might cost around $4.63 during the preview phase.
-- **Task Complexity**: While powerful, it's advised to **delegate easier, smaller, more predictable tasks** to background agents. Larger, more complex tasks are less likely to be 100% perfect in one shot and might still require foreground agent feedback and manual tweaks.
-- **Privacy Trade-offs**: For advanced features like background agents, Privacy Mode needs to be temporarily turned off, meaning your code is sent to remote environments. This presents a balance between maximum privacy and full functionality. Cursor is SOC 2 Type II certified for security.
-- **Inconsistent Edits**: Some users report inconsistent code edits with certain models, requiring multiple retries or manual intervention, or the AI claiming completion when it hasn't.
-- **Human Oversight Still Needed**: Despite automation, human oversight is still crucial for proper PR formatting and adherence to project-specific conventions. It's like having a fast junior developer who needs supervision; you remain responsible for ensuring the code works correctly.
-- **No Official API (Currently)**: While there's a strong community demand for an official API to programmatically trigger background agents and integrate with other systems like Jira or custom MCP servers, it is not currently planned. Unofficial reverse-engineered solutions exist but may be unstable.
-
-## Management and Interaction
-
-- **Control Panel**: You can access the background agent control panel (by pressing `Ctrl+Shift+B` or `⌘B`) to list agents, spawn new ones, and view their status.
-- **Monitoring Progress**: You can monitor the agent's progress, reasoning, and "to-do list" by observing the `workflow_state.md` file (in specific autonomous setups).
-- **Intervention**: You can send follow-up instructions, or even "take over" the agent's work at any time. If an agent goes astray, you can stop or correct it.
-- **Review and Merge**: Once a task is complete, you can review the generated pull request and merge the changes into your project. Cursor provides a built-in diff viewer for every AI suggestion.
-
-## Future Outlook
-
-Cursor's roadmap indicates a clear trajectory toward even more powerful and autonomous AI agents. Future enhancements include:
-
-- **Structured Planning**: Improved "to-do lists" and planning capabilities for the agents.
-- **Enhanced Context Management**: Features like "Memories" and PR indexing for better continuity and understanding across tasks.
-- **Deeper Workflow Integrations**: Potential for automated merge conflict resolution and triggering agents via Slack or other CI/CD hooks.
-- **Self-Correcting Test Loops**: An anticipated feature where the AI can iteratively fix errors by running tests and refining code until all tests pass.
+Cloud Agents are an execution surface. They do not remove your review
+responsibility.

--- a/courses/ai-development/cursor-bugbot-and-security-review.md
+++ b/courses/ai-development/cursor-bugbot-and-security-review.md
@@ -1,0 +1,54 @@
+---
+title: Cursor Bugbot and Security Review
+description: >-
+  Use Cursor Bugbot and Security Agents as review aids while keeping human
+  ownership over correctness, risk, and merge decisions.
+modified: 2026-06-24
+date: 2026-06-23
+---
+
+[Cursor Bugbot](https://cursor.com/docs/bugbot) and
+[Cursor Security Agents](https://cursor.com/docs/security-agent) add automated
+review surfaces around code changes. They are useful because they look at the
+diff with a different set of eyes. They are not a replacement for ownership.
+
+## Bugbot
+
+Bugbot reviews changes and flags likely defects. Use it as a second reviewer for
+pull requests, especially when a change touches edge cases, error handling, or
+cross-file behavior.
+
+Good Bugbot follow-up asks for evidence:
+
+```text
+For each Bugbot finding, verify whether the issue is real by reading the changed
+code and the closest tests. Fix only confirmed issues. If a finding is invalid,
+explain why with file references.
+```
+
+Do not accept a bot finding blindly. Do not dismiss it blindly either.
+
+## Security Review
+
+Security Agents focus on risk: secrets, authorization, injection, dependency
+surface, dangerous commands, and similar concerns. They are most valuable when
+the prompt names the threat model:
+
+```text
+Review this pull request for authorization bypasses and secret exposure.
+Ignore style issues. Cite exact files and propose the smallest fix for confirmed
+security issues.
+```
+
+## Security and MCP
+
+MCP servers can expose powerful tools and data. A review agent should treat MCP
+configuration as part of the application surface, not editor decoration. Look for
+untrusted servers, broad permissions, environment variable leaks, and tools that
+can write to external systems.
+
+## Merge Discipline
+
+Automated review output is input. The merge decision still belongs to a human.
+Before merging, make sure findings are resolved, tests are green, and the final
+diff is understandable without the bot conversation.

--- a/courses/ai-development/cursor-checkpoints.md
+++ b/courses/ai-development/cursor-checkpoints.md
@@ -1,48 +1,56 @@
 ---
-title: Understanding Cursor Checkpoints for Safe AI Edits
+title: Cursor Checkpoints
 description: >-
-  Learn how Cursor's automatic checkpoints provide a safety net for AI-driven
-  code changes and modifications.
-modified: 2026-03-17
+  Use Cursor checkpoints to inspect, compare, and recover from agent edits
+  without confusing rollback with review.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-In Cursor, **checkpoints are automatic snapshots of the Agent's changes to your codebase**. They serve as a **disposable safety net** for AI-driven edits, allowing you to **undo Agent modifications if needed**.
+[Cursor](https://cursor.com) creates checkpoints during agent work. A checkpoint
+is a recoverable snapshot of the workspace state around an agent turn. It gives
+you a practical escape hatch when an agent takes a wrong turn.
 
-## How They Work
+## What Checkpoints Are Good For
 
-- **Automatic Snapshots**: Checkpoints are automatically created by Cursor. Every time the Agent modifies your code, Cursor zips up the pre-change state into a checkpoint. In Agent mode, checkpoints are created before every code edit.
-- **Local and Separate from Git**: Checkpoints are stored locally on your machine, in a hidden directory, and are **separate from your Git history**. This means they won't clutter your commit log with experimental or undone changes.
-- **Agent-Specific Tracking**: Checkpoints **only track changes made by the AI Agent**. Manual edits you make by hand are not captured, so it's important to use Git for those.
-- **Automatic Cleanup**: Checkpoints are kept for the current session and recent history, and are **automatically cleaned up**. This implies they are ephemeral and not intended for long-term version control.
+Use checkpoints to:
 
-## Restoring Checkpoints
+- Compare the current result with an earlier step.
+- Restore a file or workspace state after a bad edit.
+- Understand which prompt caused a change.
+- Recover quickly from an agent loop.
 
-You have a couple of ways to restore to a previous checkpoint:
+They are especially useful during exploratory refactors because you can let the
+agent try a path without committing to it.
 
-- **From the Input Box**: You can click the "Restore Checkpoint" button on previous requests in the chat interface.
-- **From the Message History**: When hovering over a message in the chat, a small "+" button appears, allowing you to click it to restore to that specific point.
-- **Behavior**: Restoring a checkpoint will **reset all files to that point in the conversation**. If you want to continue from that reverted state, you can then write a new message to the AI agent.
+## What Checkpoints Are Not
 
-## Purpose and Advantages
+A checkpoint is not a code review, a test run, or a version control strategy.
+Cursor can restore an earlier state, but it cannot tell you whether the earlier
+state was correct.
 
-- **Safety Net for AI Edits**: Checkpoints provide an "Oh-crap button" for when the AI Agent makes unintended or "overzealous" changes, allowing you to easily roll back. This is crucial because AI can sometimes introduce errors or go "off the rails".
-- **Facilitates Experimentation**: They enable fearless experimentation with AI-driven modifications without risking your main codebase or polluting Git history with temporary changes.
-- **Cost Efficiency (Indirect)**: By allowing you to revert to a previous state, you might avoid re-running prompts that already worked correctly, potentially saving on token costs for regenerating lost work.
-- **Granular Control**: They offer better control and command directives with the AI, especially useful when working with the Composer agent for multi-file changes.
+Keep using [Git](https://git-scm.com/) for durable history:
 
-## Limitations and Considerations
+```bash
+git status --short
+git diff
+bun run lint
+bun run test:unit
+```
 
-- **Not a Replacement for Git**: Checkpoints are **not version control** and should not be used as a substitute for Git for permanent history. Git offers durable, audited history, whereas checkpoints are disposable and for short-term use.
-- **Manual Edits Not Tracked**: As mentioned, any changes you make manually will **not be included in the checkpoints**.
-- **Ephemeral Nature**: Checkpoints are "wiped once they're no longer useful" and vanish after the session. If a folder is renamed, they may be lost.
-- **Potential Token Costs**: While restoring itself doesn't cost, if you need to re-run prompts after restoring, it can still incur API costs.
-- **UI/UX Challenges**: Some users have reported confusion and frustration with the checkpoint restoration UI, noting that its behavior can be unintuitive or "detrimental". The "Restore checkpoint" button may appear to restore to when the question was completed, not started, and getting fine-grained control to revert specific intermediate steps can be awkward. There have been instances where users felt compelled to downgrade Cursor versions due to these UI changes.
-- **Community Solutions**: Due to some of these limitations, some users have created their own checkpoint scripts (e.g., saving project tree diffs) to have more robust local snapshotting capabilities that complement Git.
+Checkpoints help you recover within an agent session. Commits help your team
+understand the project history.
 
-## Best Practices Related to Checkpoints
+## A Practical Pattern
 
-- **Commit Frequently with Git**: Always **commit your work to Git** before initiating any significant agentic task and immediately after a successful change. This creates reliable, documented "safe points" that can be instantly reverted if the agent goes awry.
-- **Restore Early, Restore Often**: If you notice the AI Agent veering off course, **don't wait for a major disaster**. Roll back to a previous checkpoint as soon as you identify a problem to avoid more extensive issues and potentially save costs.
-- **Treat as Scratch Space**: Use checkpoints liberally during exploratory refactoring or proofs-of-concept, treating them as temporary "scratch space" without cluttering your Git branches.
-- **Combine with Rules and Notepads**: Leveraging Cursor Rules and Notepads can help guide the AI more effectively from the outset, potentially reducing the need for frequent rollbacks.
+Before a risky agent task:
+
+1. Start from a clean working tree when possible.
+2. Ask Cursor for a plan before edits.
+3. Let the agent implement one bounded unit.
+4. Inspect the diff.
+5. Run the verification command.
+6. Commit only after the result is understandable without the chat transcript.
+
+If the agent makes a broad, hard-to-review change, roll back to the checkpoint
+and ask for a smaller unit of work.

--- a/courses/ai-development/cursor-cli.md
+++ b/courses/ai-development/cursor-cli.md
@@ -33,7 +33,7 @@ agent --continue
 
 ## Print Mode
 
-Print mode runs a prompt and exits:
+[Print mode](https://cursor.com/docs/cli/headless) runs a prompt and exits:
 
 ```bash
 agent -p "Summarize the staged diff and list test gaps."

--- a/courses/ai-development/cursor-cli.md
+++ b/courses/ai-development/cursor-cli.md
@@ -1,0 +1,62 @@
+---
+title: Cursor Command Line Interface
+description: >-
+  Use Cursor's agent command for terminal workflows, print mode, session resume,
+  cloud handoff, and scripted review.
+modified: 2026-06-24
+date: 2026-06-23
+---
+
+[Cursor's command line interface](https://cursor.com/docs/cli/overview) uses the
+`agent` command. It is useful when the task belongs in the terminal or when you
+want a scriptable agent surface.
+
+## Interactive Sessions
+
+Run `agent` inside a repository:
+
+```bash
+agent
+```
+
+The terminal interface supports Agent, Plan, and Ask modes. It can resume
+sessions, continue the latest session, and hand work to the cloud when you append
+`&` to an agent request.
+
+Useful session commands include:
+
+```bash
+agent ls
+agent resume
+agent --continue
+```
+
+## Print Mode
+
+Print mode runs a prompt and exits:
+
+```bash
+agent -p "Summarize the staged diff and list test gaps."
+```
+
+By default, print mode is safest for read-only work. If you allow file
+modification, do it explicitly with the documented flags and only inside a clean
+working tree.
+
+## Automation Pattern
+
+Use print mode for narrow checks:
+
+```bash
+agent -p "Review this diff for missing tests. Output only findings with file paths."
+```
+
+Do not build hidden release systems out of agent prompts. If a step must always
+run, put it in a script or continuous integration. Use the agent to reason about
+the result.
+
+## Local Permissions Still Matter
+
+The command line interface can run shell commands and edit files. The same
+approval rules apply as in the editor: know what the agent is allowed to do,
+review the diff, and run the verification command yourself before shipping.

--- a/courses/ai-development/cursor-cli.md
+++ b/courses/ai-development/cursor-cli.md
@@ -20,8 +20,12 @@ agent
 ```
 
 The terminal interface supports Agent, Plan, and Ask modes. It can resume
-sessions, continue the latest session, and hand work to the cloud when you append
-`&` to an agent request.
+sessions, continue the latest session, and hand work to the cloud when you
+prepend `&` to an agent request:
+
+```bash
+& refactor the auth module
+```
 
 Useful session commands include:
 

--- a/courses/ai-development/cursor-context.md
+++ b/courses/ai-development/cursor-context.md
@@ -1,95 +1,72 @@
 ---
-title: Mastering Context Management in Cursor
+title: Context is King in Cursor
 description: >-
-  Comprehensive guide to providing effective context to Cursor's AI using @
-  symbols, rules, and notepads.
-modified: 2026-03-17
+  Give Cursor the right files, rules, skills, documentation, and external tools
+  without flooding the model with stale context.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Cursor's design is based on providing the LLM with two fundamental types of context: "intent context" (what the user wants to achieve) and "state context" (the current state of the environment, such as code snippets, error messages, or project structure). Effectively combining both intent and state in your prompts is crucial for optimal results, as providing one without the other can lead to guesswork, hallucinations, or inefficient code.
+[Cursor](https://cursor.com) is only as useful as the context you give it. More
+context is not automatically better. The goal is **relevant context**: the files,
+constraints, examples, and tools that change the answer.
 
-Cursor aims to make your codebase "known" to the AI, rather than just glimpsed. This project-wide contextual awareness allows the AI to reason about dependencies, structures, and patterns, dramatically accelerating development and enabling effortless navigation of unfamiliar codebases.
+## Context Sources
 
-## Automatic Context Gathering
+Cursor can draw from several places:
 
-Behind the scenes, Cursor automatically augments your requests with a rich composite of information that defines the AI's role, behavioral rules, and available tools. This "invisible" context includes:
+- Open files, selected code, and recently edited files.
+- Mentioned files, folders, symbols, images, and documentation.
+- Semantic repository search.
+- Project Rules, User Rules, Team Rules, and `AGENTS.md`.
+- Skills in `.cursor/skills`, `.agents/skills`, `.claude/skills`, or
+  `.codex/skills`.
+- Memories that capture reusable preferences.
+- MCP servers that expose external data and tools.
+- Web search and fetched pages when allowed.
 
-- The **full content of the current file**.
-- A list of **recently viewed files**.
-- Results from a **semantic search** of the codebase.
-- **Active linter or compiler errors**.
-- The **recent edit history**.
+The agent will often find the obvious files itself. You should still name the
+files that define correctness.
 
-## Explicit Context Provisioning (The @ Symbol System)
+## Tell Cursor What Matters
 
-While automatic context is powerful, precision often requires explicit guidance. The `@` symbol is Cursor's primary mechanism for providing surgical context, allowing you to direct the AI's attention accurately and prevent incorrect assumptions or "hallucinations".
+Use a short context contract at the top of bigger prompts:
 
-Here's how to use various `@` symbols effectively:
+```text
+Relevant context:
+- The public API is in @src/lib/server/invitations.ts.
+- Existing validation tests are in @src/lib/server/invitations.test.ts.
+- Follow @.cursor/rules/testing.mdc.
 
-- **`@Files`**: References one or more **specific files** as context. This is far more precise than letting the AI guess and is useful for general file-level edits or questions.
-  - _Example:_ "Using the patterns in `@src/components/Button.tsx`, create a new Link.tsx component".
-- **`@Folders`**: References an **entire directory's structure and contents**. This is handy for providing broad context, such as a large-scale refactor where most files in a folder are relevant.
-  - _Example:_ "Review the `@src/api/v1` folder and identify any missing authentication middleware".
-- **`@Code` / `@Symbols`**: Provides granular control by referencing a **specific function, class, or variable** within the project. This focuses the AI on a very specific piece of logic.
-  - _Example:_ "Refactor the `@useUserData hook` to use React Query instead of a local state".
-- **`@Docs`**: Extends the AI's knowledge beyond the local codebase by referencing **official documentation** for libraries and frameworks. You can even add your own documentation by URL for Cursor to index, which is invaluable when using unfamiliar libraries.
-  - _Example:_ "Using the `@React Router Docs`, create a protected route that requires authentication".
-- **`@Web`**: Empowers the agent to perform a **live web search** to retrieve up-to-date information or answers to general questions. It acts like a research assistant built into Cursor, adding search results to your query's context.
-  - _Example:_ "What is the latest stable version of Node.js? `@Web`".
-- **`@Git`**: References **Git information** like commit history or diffs. It can be used for tasks like generating descriptive Git commit messages based on staged changes or assisting with code reviews.
-  - _Example:_ "Write a commit message for the changes in `@Commit (Diff of Working State)`".
-- **`@Linter Errors`**: Provides the **current linter errors** as context, allowing the agent to focus on fixing validation issues.
-  - _Example:_ "Fix all issues listed in `@Linter Errors`".
-- **`@Past Chats` / `@Recent Changes`**: Helps maintain continuity in a long-running task.
-- **`@pr`**: An experimental feature that allows you to reference a **GitHub pull request** for AI-powered reviews, requiring local scripts and GitHub CLI setup.
+Goal:
+Reject expired invite tokens with the same error shape used by revoked tokens.
+```
 
-## Persistent Context (Rules and Notepads)
+This does two things. It saves search time, and it tells the model what evidence
+you expect it to respect.
 
-For consistent, project-specific guidance, Cursor provides ways to define persistent context:
+## Rules, Skills, and Markdown References
 
-- **Project Rules and User Rules**: These files act as a "constitution" for how the AI should behave within a specific project, enforcing consistent code style, language preferences, and quality guidelines.
-  - **Project Rules (`.cursor/rules`)**: Stored as Markdown files within the project's repository, these are version-controlled and shared with the entire team. They can specify preferred frameworks, style guidelines, or persistent instructions (e.g., "always write docstrings"). They can be configured to apply "always," "auto-attach" based on file patterns, be "agent requested," or invoked "manually".
-  - **User Rules**: Global rules configured in Cursor's settings that apply to all projects, best for personal preferences like tone of response.
-  - `.cursor/rules` (Legacy): A single-file system located at the project root, still supported but newer project rules are recommended for flexibility.
-  - **Best Practices for Rules**: Start small and add to your rules file when you notice Cursor making the same mistake twice. Define them clearly and concisely. You can find examples at `cursor.directory` or `awesome-cursorrules` GitHub repository.
-- **Notepads**: These are "supercharged sticky notes" that allow you to store frequently used prompts, file references, and explanations for quick reuse. They can bridge the gap between composer and chat interactions, and a key advantage is their ability to contain and reference `@` symbols themselves, creating reusable context bundles. Notepads can be used for documenting project architecture, development guidelines, reusable code templates, or team-specific rules.
+Use the smallest durable container that fits the job:
 
-## Context in Different AI Interaction Modes
+- Use **Rules** for behavior that should apply automatically.
+- Use **Skills** for reusable workflows with instructions, scripts, references,
+  or assets.
+- Use ordinary Markdown files for longer explanations that a human should review
+  and version.
+- Use Memories for preferences that are useful across sessions but do not belong
+  in source control.
 
-Cursor's AI features are designed to use context differently depending on the interaction mode:
+Do not hide architectural truth in chat history. If a future contributor needs
+it, put it in the repository.
 
-- **Tab (Predictive Autocomplete and Smart Rewrites)**: This advanced system uses contextual understanding of recent changes and surrounding code to offer multi-line edits and automatically correct minor errors. It helps you code at "the speed of thought" by anticipating your intent.
-- **Inline Edit (Cmd/Ctrl+K)**: This tool is for "surgical, in-place code modifications". When used without selection, it generates new code from a natural language prompt, leveraging its understanding of your project. When a code block is selected, it uses the selected code as direct context for targeted refactoring or editing. The proposed changes are shown as a diff.
+## Avoid Context Rot
 
-### AI Chat (Cmd/Ctrl+L) and Agent Mode (Cmd/Ctrl+I)
+Stale context is worse than missing context because it sounds authoritative. When
+Cursor makes the same mistake twice, fix the durable instruction source instead
+of writing a longer prompt. When a rule or skill no longer matches the codebase,
+delete or update it in the same change that updates the code.
 
-- **AI Chat (Cmd/Ctrl+L)**: Opens a "project-aware collaborator" interface. It's aware of the current file by default, but you can explicitly include the entire codebase by clicking the **"Codebase" button or typing `@codebase`**. This mode is ideal for high-level questions, brainstorming, understanding complex codebases, and generating larger code segments.
-- **Agent Mode (Cmd/Ctrl+I)**: This mode is for **complex, multi-file tasks**, where you describe a high-level goal, and the AI plans and executes changes across the entire project. It builds its understanding by employing custom retrieval models to analyze the codebase for relevant files, functions, and patterns without manual input. The agent can autonomously run terminal commands, create/modify files, and iterate to fix errors or linting issues. Agent mode is now often the default chat mode.
-
-## Context Optimization and Limitations
-
-While Cursor aims for comprehensive context, LLM context windows have limitations. Cursor employs strategies to manage this:
-
-- **Partial File Reading**: In Agent mode, Cursor defaults to reading the first 250 lines of a file, occasionally extending by another 250 lines if needed. For specific searches, it returns a maximum of 100 lines. This is a trade-off to conserve context length and reduce costs.
-- **Summarization**: In `@codebase` mode, Cursor may use a smaller model to analyze and summarize each file, potentially leading to incomplete coverage of necessary code, especially for detailed "trap" questions.
-- **User Management**: For complex projects with files exceeding 600 lines, it's more effective to explicitly `@` relevant files in Cursor rather than relying on `@codebase` for full file understanding.
-- **Shortening Conversations**: Keeping chat conversations short and focused helps prevent long contexts from polluting the project and reduces the risk of losing context. Restarting conversations after completing a feature or fixing a bug can be beneficial.
-- **Project Documentation**: Regularly documenting your project's state and structure in files like `README.md` allows Cursor to quickly understand its status when conversations are restarted, minimizing unnecessary context.
-
-## Best Practices for Context Management
-
-To maximize Cursor's effectiveness, consider these practices:
-
-- **Review Diffs**: Always **review the diff preview** before accepting AI-generated changes, as the AI might add or modify more than expected.
-- **Use Version Control**: Commit early and often, especially before any significant AI-driven tasks. Git serves as your essential safety net.
-- **Be Specific and Detailed in Prompts**: Avoid vague prompts. Explicitly state intent, constraints, and desired outcomes. Providing examples helps the AI emulate desired patterns.
-- **Break Down Problems**: For complex tasks, ask the AI to first provide a step-by-step plan and reasoning (Chain-of-Thought or Plan-and-Act), then instruct it to execute. This helps avoid flawed strategies.
-- **Iterative Refinement**: Treat interactions as a dialogue. Start broad, then refine prompts based on the AI's output, providing specific feedback.
-- **Manage Open Files**: Only open relevant files in the editor to keep the AI focused, or use "Reference Open Editors" to quickly add them to context.
-- **Keep Files Small**: Keep code files under 500 lines where possible, making it easier for Cursor's Agent mode to read them completely.
-- **Document Functions Clearly**: Document the function and implementation logic in the first 100 lines of files to help the Agent index and understand the purpose.
-- **Use Inline Comments**: Guide edits by placing comments like `// AI: Add error handling without breaking existing logic` directly in your code.
-- **Adjust Rules as Project Evolves**: Update your `.cursor/rules` as your project changes to ensure continued adherence to standards.
-- **Test Your Changes**: The AI can help write tests, which can be run in YOLO mode for automated iteration until tests pass.
-- **Understand Models**: Choose the right AI model for the task, as different models have different strengths (e.g., Claude for refactoring, GPT for complex reasoning).
+For code review prompts, ask Cursor to cite the files it inspected. If the answer
+does not mention the file that defines the behavior, the context set is not good
+enough yet.

--- a/courses/ai-development/cursor-context.md
+++ b/courses/ai-development/cursor-context.md
@@ -18,7 +18,8 @@ Cursor can draw from several places:
 - Open files, selected code, and recently edited files.
 - Mentioned files, folders, symbols, images, and documentation.
 - Semantic repository search.
-- Project Rules, User Rules, Team Rules, and `AGENTS.md`.
+- Project Rules, User Rules, Team Rules, and
+  [`AGENTS.md`](https://agents.md/).
 - Skills in `.cursor/skills`, `.agents/skills`, `.claude/skills`, or
   `.codex/skills`.
 - Memories that capture reusable preferences.

--- a/courses/ai-development/cursor-environment-configuration.md
+++ b/courses/ai-development/cursor-environment-configuration.md
@@ -1,64 +1,57 @@
 ---
-title: Configuring Cursor Environments with environment.json
+title: Cursor Environment Configuration
 description: >-
-  Set up reproducible cloud development environments for Cursor's background
-  agents using environment.json configuration.
-modified: 2026-03-17
+  Configure Cursor Cloud Agent environments with reproducible setup commands,
+  dependencies, secrets, and verification expectations.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-`environment.json` in Cursor serves as the **definitive configuration file for Cursor Environments**, which are **reproducible, cloud-hosted development boxes**. It acts as a canonical "recipe" that defines the setup and runtime behavior of these remote environments, primarily powering Cursor's **Background Agents** and facilitating **remote IDE sessions**.
+[Cursor Cloud Agents](https://cursor.com/docs/cloud-agent) need a reproducible
+environment. If the setup depends on your laptop, the cloud agent will fail or
+invent a workaround.
 
-## What `environment.json` is Used For
+## What to Configure
 
-`environment.json` is crucial for creating consistent and isolated development environments for AI-driven coding tasks. Its main applications include:
+Use `.cursor/environment.json` for cloud-specific setup. Keep these concerns
+explicit:
 
-- **Asynchronous Remote Agents (Background Agents)**: It enables the spawning of asynchronous agents that edit and run code in a remote environment. This allows you to offload long-running tasks, like code refactors, test suites, or migrations, to a remote machine while you continue coding locally. When a background agent starts, it creates its own branch to make changes, which can then be merged back.
-- **Reproducible Dev Boxes**: Each agent or remote-SSH window can spin up its own Ubuntu box (or a custom Docker image if specified) based on this configuration. This ensures that every team member and continuous integration (CI) process works with an **identical and disposable workspace**, minimizing "it works on my machine" issues.
-- **Remote IDE Sessions**: It supports remote IDE connections, allowing you to access and work on your code hosted in the cloud.
+- Dependency installation.
+- Build and test commands.
+- Required system packages.
+- Environment variables and secrets.
+- Startup commands for services.
+- Repository-specific notes that a cloud agent needs before work begins.
 
-## How to Take Advantage of `environment.json`
+Do not put secrets in the repository. Use Cursor's secret management for values
+that should be available to the cloud environment.
 
-To leverage `environment.json` effectively, you define the environment's specifications, allowing Cursor to provision and manage the remote workspace:
+## Make Setup Verifiable
 
-- **Location**: The `environment.json` file should typically be stored in the `.cursor/environment.json` directory at the root of your project.
-- **Configuration as Code**: All runtime details are defined within this JSON file. Committing it to your repository makes the setup **portable across teammates and CI**.
+The best environment setup ends with a command that proves the repository is
+ready:
 
-### Base Environment Setup
+```bash
+bun install
+bun run content:validate
+```
 
-- You can set up your machine, install tools and packages, and then **take a snapshot**.
-- For advanced scenarios, you can use a **Dockerfile** to define system-level dependencies, such as specific compiler versions, debuggers, or the base operating system image. It's important _not_ to copy the entire project into the Dockerfile, as Cursor manages the workspace and checks out the correct commit.
+Use the same command in prompts:
 
-### Key Fields/Specifications
+```text
+Before editing, verify the cloud environment by running bun run content:validate.
+If setup fails, stop and report the failing command and output.
+```
 
-- `snapshot`: References a cached disk image for faster boot times after the initial build.
-- `install`: Specifies an idempotent dependency installation script (e.g., `npm install`, `bazel build`) that runs once before an agent starts. Its disk state is cached for subsequent runs.
-- `start`: A command to run when the environment starts up.
-- `terminals`: Defines background processes that run while the agent works, such as starting a web server or compiling files. You can specify the `name` and `command` for each terminal, and optionally `ports`.
-- `env`: Allows you to set environment variables within the remote environment.
-- `persistedDirectories`: Specifies directories that should be persisted across sessions.
-- `baseImage`: Lets you define the base Docker image (e.g., `ghcr.io/cursor-images/node-20:latest`).
+That instruction prevents the agent from spending an hour debugging code in a
+broken environment.
 
-## Tasing Notes
+## Keep Local and Cloud Close
 
-- **Secrets and Git Wiring**: You can inject encrypted secrets, which are stored securely (encrypted-at-rest using KMS) in Cursor's database and provided in the background agent environment. This also allows linking the VM to your GitHub repository for branch and pull request (PR) workflows.
-- **Snapshotting Workflow**: After the initial setup and running your development bootstrap commands (e.g., `bun install`, `pipenv sync`), you can click "Snapshot disk" in Cursor, which writes the ID back to `environment.json`. This allows later jobs to boot from that image, skipping package installs.
-- **Starting Branch for Background Agents**: When initiating a background agent, you need to be aware of and set the starting branch. The agent will then create its own branch for the changes before a PR can be merged back into the main branch.
+Cloud setup should mirror the repository's normal local setup. If local
+development uses [Bun](https://bun.sh/), configure Bun in the cloud environment.
+If tests require a database, use the same migration and seed path the team uses
+locally.
 
-## Best Practices
-
-- **Commit `environment.json`**: Always commit your `.cursor/environment.json` file to your repository. This ensures that every developer on your team inherits the identical development box, promoting consistency.
-- **Treat as Mini-Dockerfile**: Think of `.cursor/environment.json` as a small Dockerfile for your entire AI workflow.
-- **Clean Install Step**: Keep your `install` script clean and idempotent to ensure effective caching and faster boot times for subsequent agent runs.
-- **Leverage Snapshots**: Utilize the snapshot feature to cache your environment's disk state after initial setup and dependency installation, making subsequent agent boots nearly instantaneous.
-
-## Common Pitfalls and Limitations
-
-Despite its benefits, `environment.json` and Cursor's environment management have some reported issues and limitations:
-
-- **Privacy Mode Requirement**: To use advanced features like Background Agents, you **must temporarily disable privacy mode**, as these features need to send your code to remote environments to work. This can be a tricky trade-off for sensitive or proprietary projects, as it requires allowing "limited retention" of your code.
-- **Documentation Link Issues**: The formal JSON schema endpoint for `environment.json` has been reported to be broken, sometimes leading to 404 errors.
-- **Port Auto-forwarding Flakiness**: There have been reports of flaky port auto-forwarding for terminals, particularly on macOS and WSL 2.
-- **"Failed to Start VM" Errors**: These errors often indicate missing snapshot IDs or temporary capacity issues.
-- **Windows Host Specifics**: Windows hosts may require a Cursor-patched VS Code server, as vanilla Remote-SSH might fail.
-- **Secret Management Nuances**: While `environment.json` can inject encrypted secrets, some users have found the management of Rails master keys or similar secrets across environments to be "annoying" or globally applied, requiring careful handling outside the standard Dockerfile process.
+When local and cloud setup diverge, agents learn the wrong lessons. They fix the
+environment they can see, not the one your team actually uses.

--- a/courses/ai-development/cursor-ghost-mode.md
+++ b/courses/ai-development/cursor-ghost-mode.md
@@ -42,9 +42,10 @@ For sensitive repositories, decide explicitly:
 
 Some models or providers can have retention behavior that differs from the
 default privacy posture. Cursor's enterprise controls can require approval before
-using models with retention exceptions. As of June 23, 2026, Claude Fable 5 is
-called out in Cursor documentation as requiring approval in contexts where model
-retention matters.
+using models with retention exceptions. As of June 23, 2026,
+[Claude Fable 5](https://cursor.com/docs/models-and-pricing) is called out in
+Cursor documentation as requiring approval in contexts where model retention
+matters.
 
 Do not write a team rule that blindly selects a model for every task. Write a
 governance rule that names who can approve retention exceptions.

--- a/courses/ai-development/cursor-ghost-mode.md
+++ b/courses/ai-development/cursor-ghost-mode.md
@@ -1,52 +1,62 @@
 ---
-title: Cursor Ghost Mode for Maximum Privacy
+title: Cursor Privacy Mode and Data Governance
 description: >-
-  Enable Cursor's Ghost Mode to ensure zero data leaves your machine while using
-  AI coding features.
-modified: 2026-03-17
+  Replace older Ghost Mode language with Cursor Privacy Mode, indexing behavior,
+  Cloud Agent storage, and model-retention governance.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Ghost mode is a stringent privacy feature in Cursor that ensures **zero data leaves your local machine**, operating as a "Local / No-Storage Mode".
+Older Cursor material sometimes referred to "Ghost Mode." The current product
+language is [Privacy Mode](https://cursor.com/help/security-and-privacy/privacy).
+Use the current term when documenting security and governance.
 
-## Core Functionality
+## What Privacy Mode Means
 
-- When activated, **every chat message, code snippet, agent diff, telemetry ping, and trace that would typically go to Cursor's backend is intercepted locally and discarded**.
-- Minimal headers, like `x-ghost-mode=true`, are sent to the server, but **no payload containing your code or prompts is persisted or used for model training by Cursor**.
-- Your code and prompts are sent **directly to the Large Language Model (LLM) provider** (e.g., OpenAI), subject to that provider's data retention policies (e.g., typically a 30-day retention window), but Cursor itself does not store this data.
+When Privacy Mode is enabled, Cursor says your code is not used to train Cursor
+or third-party models. That is the central promise. It does not mean no data ever
+leaves your machine.
 
-## How it Works Under the Hood
+Model requests still need the prompt and relevant code context. Repository
+indexing can store embeddings, obfuscated paths, and line-number metadata so
+Cursor can search the codebase without storing raw code. The practical security
+question is not "local or remote?" It is "what data is sent, stored, retained,
+and governed?"
 
-- The Cursor client disables internal features that rely on server-side state, such as telemetry, chat storage, and memory/index syncing.
-- This strict isolation means that **cloud-dependent conveniences are unavailable**, including background agents and cloud snapshots, as they require remote server-side state to function.
+## Cloud Agents Change the Storage Story
 
-## Why and When to Use Ghost Mode
+Cloud Agents require a remote execution environment. That means Cursor
+temporarily stores enough repository data to clone, build, test, and operate in
+that environment. The storage should be treated as part of your vendor risk
+review.
 
-- **Regulated and Ultra-Confidential Codebases**: It's the safest way to use Cursor for projects with sensitive intellectual property (e.g., health, defense), ensuring no off-device storage and potentially meeting "on-prem only" policies.
-- **Corporate Security Audits**: Security teams can use it to verify that Cursor's traffic only hits model endpoints, as it guarantees local data processing.
-- **Air-gapped Development**: Ghost mode supports fully offline development, especially when combined with local LLMs (like those served by Ollama/Llama.cpp) or your own OpenAI proxy, ensuring no external network calls for data.
-- **Paranoid Side Projects**: If you want absolute control over your data, using Ghost mode means that deleting your local repository erases all traces of your work and chat history within Cursor, as nothing was ever logged remotely.
+For sensitive repositories, decide explicitly:
 
-## Feature Trade-offs
+- Whether Cloud Agents are allowed.
+- Which repositories they can access.
+- Which secrets can be mounted.
+- Which MCP servers can be used.
+- Which model providers and retention policies are allowed.
 
-- **Features that _work_ in Ghost mode**: Inline editing, refactoring, AI chat, local Composer and Notepads, locally run Model Context Protocol (MCP) tools, keyboard shortcuts, and CLI operations.
-- **Features that are _disabled_ or _degraded_**: Background Agents (which require cloud Virtual Machines), memory synchronization, team knowledge sharing, cloud environment snapshots, Bugbot Pull Request (PR) reviews, and cross-device chat history.
+## Model Retention Exceptions
 
-## Enabling and Verifying Ghost Mode
+Some models or providers can have retention behavior that differs from the
+default privacy posture. Cursor's enterprise controls can require approval before
+using models with retention exceptions. As of June 23, 2026, Claude Fable 5 is
+called out in Cursor documentation as requiring approval in contexts where model
+retention matters.
 
-- You can toggle Ghost mode in Cursor's settings under `Settings → Advanced → Local / Ghost Mode` (in older builds, it might be labeled `Privacy Mode (legacy no-storage)`).
-- A **restart of Cursor is required** for the new sandbox policy to take effect.
-- To verify, you can inspect network traffic (e.g., using DevTools) to confirm that every HTTPS request includes the `x-ghost-mode: true` header and has empty bodies for sensitive data.
-- Attempting to use a cloud action (like starting a background agent) should result in a "Feature unavailable in Ghost mode" notification, confirming that the lockdown is active.
+Do not write a team rule that blindly selects a model for every task. Write a
+governance rule that names who can approve retention exceptions.
 
-## Distinction from "Privacy Mode"
+## Course-Level Guidance
 
-- Cursor also has a default "Privacy Mode". While this mode prevents your code from being used for model training, it still **retains some data necessary for features** like memories, team sharing, and agent logs on Cursor's servers.
-- **Ghost mode is the most restrictive setting**, ensuring _zero_ data retention by Cursor and keeping all data on-device.
-- This distinction is important because some sources mention that "Privacy Mode" needs to be disabled for background agents. This might refer to Cursor's default Privacy Mode, which, while more private than not, still involves some data leaving your machine, making it incompatible with the strict "nothing leaves the laptop" policy of Ghost mode. Sources indicate that background agents _are_ available in the broader "Privacy Mode" context where data is not used for training, but still processed remotely. The key takeaway is that **Ghost mode represents the highest level of local data isolation**.
+For most teams, the working policy is:
 
-## Best Practices and Gotchas
+- Enable Privacy Mode.
+- Keep secrets out of prompts and rules.
+- Use repository-owned rules and skills for auditable instruction.
+- Require explicit approval for Cloud Agents on sensitive repositories.
+- Review MCP servers like production integrations, not editor plugins.
 
-- **Commit Often**: Since Ghost mode doesn't retain snapshots, it's crucial to commit your work frequently to version control (like Git) to avoid losing chat diffs or progress if your local disk encounters issues.
-- **Use Rules, Not Memories**: Rules, which reside in your repository, are suitable for persistent guidance, as Memories do not sync in Ghost mode.
-- **Budget Tokens**: Without Cursor's cloud caching, identical prompts will re-query the LLM every time, which can lead to higher API costs for premium models.
+Security is a workflow. A toggle helps, but it is not the workflow.

--- a/courses/ai-development/cursor-ghost-mode.md
+++ b/courses/ai-development/cursor-ghost-mode.md
@@ -9,7 +9,10 @@ date: 2025-07-29
 
 Older Cursor material sometimes referred to "Ghost Mode." The current product
 language is [Privacy Mode](https://cursor.com/help/security-and-privacy/privacy).
-Use the current term when documenting security and governance.
+Use the current term when documenting security and governance, but do not treat
+old Ghost Mode claims as automatically equivalent to Privacy Mode. Re-check the
+actual data path and retention guarantees instead of assuming a local-only
+posture.
 
 ## What Privacy Mode Means
 

--- a/courses/ai-development/cursor-hooks.md
+++ b/courses/ai-development/cursor-hooks.md
@@ -1,0 +1,55 @@
+---
+title: Cursor Hooks
+description: >-
+  Use Cursor hooks to observe, control, and extend agent behavior locally and in
+  cloud agents without hiding quality gates in chat.
+modified: 2026-06-24
+date: 2026-06-23
+---
+
+[Cursor hooks](https://cursor.com/docs/hooks) let you run logic around the agent
+loop. They can observe events, inject guidance, or block unsafe actions.
+
+Use hooks for small, deterministic guardrails. Do not use them to reimplement a
+continuous integration system inside the editor.
+
+## Where Hooks Live
+
+Cursor supports project and user hooks. Cloud Agents can run command-based hooks
+from `.cursor/hooks.json` when the hook type is supported in the cloud
+environment.
+
+Project hooks are best for repository safety checks. User hooks are best for
+personal workflow preferences.
+
+## Hook Types
+
+Cursor supports command hooks and prompt hooks. Command hooks can run scripts and
+use exit codes to influence the agent. A blocking exit code can stop an unsafe
+action before it happens.
+
+Good hook use cases include:
+
+- Blocking edits to generated files.
+- Warning when a command targets production.
+- Adding repository-specific context at session start.
+- Recording agent activity for local audit.
+
+## Keep Hooks Small
+
+A hook should be fast, readable, and easy to disable during diagnosis. If a hook
+needs complex state, it probably belongs in a checked-in script with tests.
+
+For example, a hook can call:
+
+```bash
+bun scripts/check-generated-file-edit.ts "$CURSOR_FILE"
+```
+
+The script owns the logic. The hook owns the integration point.
+
+## Security Posture
+
+Hooks run code. Review them with the same suspicion you would apply to a build
+script. A malicious or sloppy hook can leak secrets, approve dangerous commands,
+or hide failures from the developer.

--- a/courses/ai-development/cursor-hooks.md
+++ b/courses/ai-development/cursor-hooks.md
@@ -25,8 +25,8 @@ personal workflow preferences.
 ## Hook Types
 
 Cursor supports command hooks and prompt hooks. Command hooks can run scripts and
-use exit codes to influence the agent. A blocking exit code can stop an unsafe
-action before it happens.
+use exit codes to influence the agent. A command hook that exits with code `2`
+can block an unsafe action before it happens and return the reason to the agent.
 
 Good hook use cases include:
 
@@ -47,6 +47,10 @@ bun scripts/check-generated-file-edit.ts "$CURSOR_FILE"
 ```
 
 The script owns the logic. The hook owns the integration point.
+
+Local and cloud support are not identical. If a hook must run in Cloud Agents,
+keep it command-based, check it into the repository, and verify that the cloud
+support matrix covers the event you are using.
 
 ## Security Posture
 

--- a/courses/ai-development/cursor-model-selection.md
+++ b/courses/ai-development/cursor-model-selection.md
@@ -1,74 +1,60 @@
 ---
-title: Choosing the Right AI Model in Cursor
+title: Model Selection Strategy in Cursor
 description: >-
-  Strategic guide to selecting between Claude, GPT, Gemini, and other models for
-  optimal coding results.
-modified: 2026-03-17
+  Choose Cursor models by task shape, context needs, speed, cost, Max Mode, and
+  cloud-agent behavior without hardcoding volatile model claims.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Cursor offers a ton of different AI models from leading providers like OpenAI (GPT series), Anthropic (Claude series), and Google (Gemini), along with its own custom models and support for local models. Different models excel in different areas, and choosing wisely can significantly impact quality, latency, and cost.
+[Cursor](https://cursor.com) changes its model menu frequently. As of June 23,
+2026, the official model documentation lists current families from
+[Anthropic](https://www.anthropic.com/), [OpenAI](https://openai.com/), and
+[Google](https://deepmind.google/). Treat exact model availability, pricing, and
+provider routing as volatile.
 
-Here's a guide to model selection in Cursor, detailing when to use what model for optimal results:
+The durable skill is choosing the right class of model for the work.
 
-## **Model Selection Strategy in Cursor**
+## Start with Auto
 
-### Claude Models (Claude 3.5 Sonnet, Claude 4 Sonnet, Claude 4 Opus)
+Cursor's Auto mode routes work across models based on capability, cost, and
+reliability. Use it for ordinary implementation, refactoring, and bug fixing
+until you have evidence that a specific model is better for the current task.
 
-- **Strengths & Ideal Use Cases:**
-  - **Frontend Development, UI/UX Design:** Frequently praised for these tasks.
-  - **Code Simplification and Refactoring:** Excellent at clarifying and restructuring complex code.
-  - **Complex Architecture and Critical Tasks:** Claude 4 Opus offers top performance for these.
-  - **General Coding Tasks:** Claude 3.5 Sonnet is often considered the "king of AI coding" and integrates best with coding tools, preferred by many advanced users for most coding tasks due to its quality and reliability. It's described as often more "to the point" than GPT models and excellent at understanding large codebases and following complex instructions.
-  - **Architectural Planning:** Claude models can be suitable for this.
-- **Considerations:** Opus can be more expensive. They may occasionally refuse to perform a task that GPT-4 would attempt.
+Auto is also a good default for teaching because it keeps the lesson focused on
+the workflow instead of model trivia.
 
-### GPT Models (GPT-3.5, GPT-4, GPT-4o, o3)
+## Escalate for Hard Reasoning
 
-- **Strengths & Ideal Use Cases:**
-  - **Boilerplate Code:** GPT-3.5 is faster for generating boilerplate.
-  - **Nuanced Refactoring and Logic-Heavy Components:** GPT-4 is good for these.
-  - **Deep Architectural Restructuring and Design Patterns:** GPT models are strong performers for these.
-  - **Simple Debugging Tasks:** Effective for straightforward debugging.
-  - **Complex Logical Reasoning and Brainstorming:** Strong all-around performers.
-  - **Factual Questions:** Less likely to "hallucinate" on factual questions.
-  - **API Documentation:** GPT-4o can be used for this.
-  - **General Default:** GPT-4o balances speed and capability and is often considered a good default choice.
-- **Considerations:** Can sometimes be "lazy" and provide incomplete code. GPT-4/GPT-4o can be more expensive than Sonnet.
+Choose a stronger explicit model when the task has one of these traits:
 
-### Gemini Models (Gemini 2.5 Pro)
+- Ambiguous architecture decisions.
+- Large cross-file refactors.
+- Security-sensitive code.
+- Complex migrations with many edge cases.
+- Reviews where false confidence is expensive.
 
-- **Strengths & Ideal Use Cases:**
-  - **Complex Design Work:** Noted for its effectiveness in this area.
-  - **Deep Bug-Fixing:** Useful for intricate bugs requiring robust reasoning capabilities.
-  - **Rapid Code Completions:** Can be utilized for this purpose.
+Ask for a plan first, then decide whether the plan justifies the slower or more
+expensive model.
 
-### DeepSeek Coder
+## Use Max Mode Deliberately
 
-- **Strengths & Ideal Use Cases:**
-  - **Troubleshooting and Problem Analysis:** Good at analyzing problems and proposing solutions.
-- **Considerations:** Often a cost-effective and more private option as it's hosted by Cursor. May not be as strong as frontier models for complex generation.
+Max Mode gives Cursor access to the model's larger context window and premium
+reasoning path. It is useful when the task genuinely depends on a broad slice of
+the repository. It is wasteful when the task needs three files and a test.
 
-### Local Models (e.g., Llama2 derivatives)
+Cloud Agents always run with Max Mode enabled, so write cloud prompts with the
+same discipline you would use for an expensive local session: exact scope,
+acceptance criteria, and verification commands.
 
-- **Strengths & Ideal Use Cases:**
-  - **Maximum Privacy:** Your code never leaves your machine. Ideal for proprietary or highly sensitive code.
-- **Considerations:** Generally slower and limited to smaller models compared to cloud-based options.
+## Keep Model Claims Dated
 
-## **General Tips for Model Selection**
+If you write a rule, tutorial, or team process that names a model, date the
+claim:
 
-- **Balance Trade-offs:** Model selection requires balancing quality, latency, and cost to suit your use case.
-- **Task Complexity:** For easier or boilerplate tasks, consider using a lighter-weight and faster model. Save more powerful and expensive models for complex problems, such as nuanced refactoring or logic-heavy components.
-- **Iterative Approach:** If a model gets stuck or provides unsatisfactory results, try switching to a different model. Users often swap between GPT-4o and Claude in such cases.
-- **"Auto" Mode:** Cursor offers an "Auto" mode that intelligently selects the most appropriate premium model for a given query based on its complexity, current performance, and server reliability.
-- **Personal API Keys:** For greater control over costs or to leverage enterprise-specific plans, you can configure your own API keys for services like OpenAI or Anthropic. However, remember that requests are still proxied through Cursor's infrastructure.
-- **Cost Management:** Be mindful of usage quotas, especially with premium models. Heavy use can lead to unexpectedly high bills.
+```text
+As of 2026-06-23, use Cursor Auto for default implementation work and escalate to
+the strongest available reasoning model for architecture reviews.
+```
 
-## Quick Choice Checklist
-
-- Small, localized change or boilerplate: pick a lighter model (GPT‑3.5 or Haiku) to draft, then verify.
-- Multi‑file refactor or cross‑module impact: Claude Sonnet or GPT‑4o; enable Agent mode and add @Files.
-- Architecture/design exploration: Claude Opus or GPT‑4(o) with explicit constraints and examples.
-- Docs/screenshot driven work: GPT‑4o (multimodal), optionally pair with NotebookLM for grounding.
-- Privacy‑sensitive code: local model or DeepSeek hosted by Cursor; avoid external tools.
-- If output degrades: switch provider (Claude ↔ GPT) and add @‑context rather than retrying blindly.
+That phrasing survives menu changes. "Always use Model X" usually does not.

--- a/courses/ai-development/cursor-notepads.md
+++ b/courses/ai-development/cursor-notepads.md
@@ -1,52 +1,66 @@
 ---
-title: Using Cursor Notepads for Context Management
+title: Cursor Notepads Migration
 description: >-
-  Create reusable context bundles with Cursor Notepads to streamline prompts and
-  improve AI responses.
-modified: 2026-03-17
+  Replace deprecated Cursor Notepads with Rules, Skills, Memories, and ordinary
+  Markdown references while keeping old lesson links valid.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Cursor Notepads are essentially **drop-in Markdown pads that can bundle prompts, documentation links, file references, and rules**. They extend the capabilities of `.cursor/rules` files by offering reusable contexts for your development process. Notepads accept rich text and can include `@file` mentions, allowing you to pin code or documents directly within the pad. They are accessible by their name using the `@` syntax (e.g., `@NotepadName`).
+[Cursor Notepads](https://forum.cursor.com/t/deprecating-notepads-in-cursor/138305)
+were deprecated by Cursor in 2025. Do not introduce Notepads into a current
+workflow. If you find one in an older course, team process, or personal setup,
+migrate the content into a durable source that matches how the information is
+used.
 
-![Cursor Notepads](assets/cursor-notepad.png)
+This page keeps the old route alive because external links may still point here.
+The current lesson is migration, not usage.
 
-## Why Are Notepads Useful?
+## Where Notepad Content Should Go Now
 
-Notepads offer several significant benefits for developers using Cursor:
+Use this mapping:
 
-- **One-Click Context Reuse**: Instead of manually tagging multiple files for every session, you can tuck them into a Notepad once and simply reference the Notepad, this can be _huge_ time-saver.
-- **Cleaner Mental RAM**: They help keep recurring prompts and complex instructions organized within a tidy module, rather than cluttering your chat history.
-- **Agent Mode Booster**: Cursor's Agent mode respects Notepads, allowing your autonomous refactoring tasks to automatically inherit the standards and context defined within them.
-- **Team Knowledge Hub**: Notepads can function as a "personal dev toolbox" for reusable code snippets, and they can be invaluable for onboarding new team members by providing architectural overviews, style guides, and relevant links in one place.
-- **Dynamic Boilerplate and Templates**: You can create templates for common code patterns, store project-specific scaffolding rules, and ensure consistent code structure across your project. They can also drive Standard Operating Procedures (SOPs) and dynamic boilerplate generation without manual editing.
-- **Centralized Documentation**: They are useful for storing architecture documentation (e.g., frontend specifications, backend design patterns, data models) and development guidelines (coding standards, project-specific rules, best practices, team conventions).
-- **Saving Suggestions and Research**: Notepads can be used to save AI-suggested improvements or research findings, especially when web search results might be outdated. You can also embed `@docs` within notes to create specialized prompts for third-party libraries.
+- Repeated behavioral guidance becomes a Project Rule in `.cursor/rules/*.mdc`.
+- Multi-step workflows become a Skill in `.cursor/skills/<name>/SKILL.md`.
+- Personal preferences that should not live in the repository become Cursor
+  Memories or User Rules.
+- Long explanations, architecture notes, and onboarding material become ordinary
+  Markdown files in the repository.
+- Team-wide policy belongs in Team Rules or repository-owned documentation.
 
-## How To Use Notepads
+The old habit was "bundle whatever I need later." The current habit should be
+"put the information where ownership and review are obvious."
 
-To get started with Cursor Notepads:
+## Migration Example
 
-1. **Create a New Notepad** In the sidebar, locate the "Notepads" section and click the **"+" button**. Give your Notepad a meaningful name.
-2. **Add Content** Populate your Notepad with Markdown text, add `@file` or `@folder` references, include web links, or attach images to provide context.
-3. **Reference in Chat/Composer** To use the content of a Notepad, simply type the `@` symbol followed by the Notepad's name in any chat or Composer prompt (e.g., `@API_Guide`). Cursor will then inject the Notepad's content into the AI's context for that query.
-4. **Synchronization** Notepads automatically sync across your local Cursor workspaces.
+An old Notepad might contain this:
 
-## Best Practices for Using Notepads
+```text
+When editing API routes, use zod validation, return typed errors, update tests,
+and run bun test:unit.
+```
 
-To maximize the effectiveness of Notepads:
+That should become a scoped project rule:
 
-- **Use Descriptive Names** Name your Notepads clearly, like "Auth_Rules" or "API_Guidelines," rather than vague personal notes, to make them easy to find and understand.
-- **Keep Content Atomic** Since Notepads are not (yet) directly editable by the AI, it's best to split large documents into smaller, themed Notepads. This prevents "scroll hell" and keeps context focused.
-- **Version Critical Information in Git** While Notepads are convenient, they are not stored directly in your Git repository. For information requiring version history or team-wide sharing, consider mirroring it in standard Markdown files within your codebase.
-- **Curate and Lint Content** Treat Notepad content like code: use clear headings, bullet points, and avoid unnecessary fluff. Junk context can inflate your token usage and dilute the AI's focus.
-- **Bundle Repeated Prompts** Store frequently used prompts (e.g., "write exhaustive unit tests") in a Notepad. This can lead to faster workflows and reduce AI hallucinations.
-- **Combine with `.cursor/rules`** Use project-level `.cursor/rules` files for always-on constraints (e.g., "always use TypeScript") and Notepads for "sometimes-on" or dynamic context (e.g., "legacy Stripe migration details").
-- **Regularly Audit** Schedule periodic reviews of your Notepads to remove stale links or outdated rules, preventing "context rot".
-- **Avoid Sensitive Data** Do not store temporary notes, version control information, or sensitive credentials directly in Notepads.
+```md
+---
+description: API route testing and validation expectations.
+globs:
+  - 'src/routes/api/**/*.ts'
+alwaysApply: false
+---
 
-## Current Limitations and Caveats
+When editing API routes, validate inputs at the boundary, return the existing
+typed error shape, update the closest regression test, and run the targeted unit
+test command before reporting completion.
+```
 
-- **No In-Place AI Editing**: The AI cannot directly rewrite or modify the content of Notepads.
-- **Token Cost**: Larger Notepads can still contribute to higher token usage, impacting cost and latency.
-- **Storage and Sharing**: Notepads are stored in local SQLite databases (e.g., `AppData/Roaming/Cursor/User/workspaceStorage/{some_uuid}/state.vscdb` on Windows). This makes sharing them across different machines or with teams cumbersome, as they are not version-controlled by Git and lack built-in import/export functionality.
+If the Notepad also included a release checklist, move that checklist into a
+skill instead of making the rule longer.
+
+## What Not to Migrate
+
+Do not preserve stale Notepad content just because it used to exist. Delete
+temporary prompts, old model recommendations, copied documentation, and notes
+that no longer match the repository. Migrating bad context just gives it a new
+folder.

--- a/courses/ai-development/cursor-rules.md
+++ b/courses/ai-development/cursor-rules.md
@@ -1,124 +1,73 @@
 ---
-title: Setting Up Cursor Rules for Consistent AI Behavior
+title: Cursor Rules
 description: >-
-  Configure project and user-level rules to enforce coding standards and guide
-  AI behavior in Cursor.
-modified: 2026-03-17
+  Use Cursor Project Rules, User Rules, Team Rules, and AGENTS.md instructions
+  without turning prompts into a stale style guide.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Cursor Rules are **persistent instructions that you define for the AI to follow every time it edits or interacts with your codebase**. They act as a **built-in, lightweight linter and style guide for the AI collaborator**, helping to enforce coding conventions, architectural guidelines, and specific preferences across your project. These rules ensure the AI provides more relevant and accurate suggestions by deeply understanding your project's context and your desired coding style.
+[Cursor Rules](https://cursor.com/docs/rules) are system-level instructions for
+Cursor's agent. They are the right place for behavior that should apply before a
+specific prompt exists.
 
-## Types and Storage of Cursor Rules
+## Rule Types
 
-Cursor supports different levels of rules:
+Cursor supports four practical instruction sources:
 
-- **Project-Level Rules:** These are the most powerful and are designed for team collaboration and project-specific conventions.
-  - They are stored as **Markdown files within your project's repository**, typically in a `.cursor/rules` folder, allowing them to be version-controlled and shared with the entire team.
-  - Examples include specifying preferred frameworks, code style, or architectural guidelines.
-- **User-Level Rules (Global Rules):** These are personal preferences configured in Cursor's settings that apply to all projects you work on.
-  - They are ideal for individual stylistic choices, such as always preferring functional code over imperative or omitting semicolons in JavaScript/TypeScript.
+- **Project Rules** live in `.cursor/rules/*.mdc` and belong in the repository.
+- **User Rules** live in Cursor settings and follow one developer across
+  projects.
+- **Team Rules** are centrally managed for teams.
+- **AGENTS.md** files can also provide repository instructions.
 
-## Understanding Rule Types
+Project Rules use Markdown with frontmatter. The file extension matters:
+`.mdc` is the Cursor rule format. Plain `.md` files in `.cursor/rules` are not
+treated as project rules.
 
-### Project Rules (`.cursor/rules`)
+## Application Modes
 
-- Live in your repository
-- Shared with your team via version control
-- Define project-specific conventions
-- Examples: testing framework, component patterns, API style
+A project rule can apply in different ways:
 
-### User Rules (Cursor Settings)
+- Always apply.
+- Apply intelligently when its description matches the task.
+- Apply to specific file globs.
+- Apply only when manually referenced.
 
-- Personal preferences across all projects
-- Not shared with others
-- Define your individual coding style
-- Examples: preferred language, formatting style, comment preferences
+Use the weakest mode that is still reliable. Always-on rules are expensive and
+can create conflicting instructions when they try to describe every possible
+task.
 
-## How Cursor Rules Are Applied
+## A Small Useful Rule
 
-Rules can be configured to apply in various ways, offering flexibility in how the AI adheres to them:
+```md
+---
+description: Testing expectations for server-side TypeScript changes.
+globs:
+  - 'src/**/*.ts'
+alwaysApply: false
+---
 
-- **Always:** The rule is applied to every request, though this should be used carefully to avoid consuming unnecessary context tokens.
-- **Auto Attached:** Cursor automatically attaches the rule when editing files that match specific patterns or extensions.
-- **Agent Requested:** The Cursor Agent determines if the rule is relevant and should be applied based on the task description.
-- **Manually:** You can manually add specific rules to the context within your chat window with the AI agent.
+When changing server-side TypeScript, update or add the closest unit test before
+implementation. Run the targeted test command and the repository lint command
+before reporting completion.
+```
 
-## What Makes a Good Rule?
+This is specific enough to act on and small enough to audit.
 
-- **Specific:** "Use `React.FC` for all components" versus "Use TypeScript"
-- **Actionable:** "Add JSDoc comments to exported functions" versus "Document code"
-- **Contextual:** "Use React Query for API calls" versus "Handle async properly"
+## Rules Versus Skills
 
-## Real-World Examples of Cursor Rules
+Use a rule for a constraint. Use a skill for a workflow.
 
-### Personal Coding Preferences
+For example, "prefer typed errors in server code" is a rule. "Run the release
+checklist, update the changelog, build packages, and verify generated exports" is
+a skill because it needs steps, references, and probably scripts.
 
-- Default to TypeScript when language is ambiguous
-- Use 2 spaces for indentation, never tabs
-- Prefer const over let, never use var
-- Add trailing commas in multi-line objects/arrays
-- Use explicit return types for all functions
-- Write concise comments focusing on intent
-- Prefer early returns over nested conditionals
-- Use optional chaining (?.) and nullish coalescing (??)
-- Format: Prettier with single quotes and no semicolons
+Cursor can read skills from `.cursor/skills`, `.agents/skills`, `.claude/skills`,
+and `.codex/skills`, so a well-written skill can serve more than one agent.
 
-Cursor Rules can cover a wide range of instructions, from general coding practices to highly specific project requirements:
+## Maintenance
 
-### Code Style and Quality
-
-- Always write code in TypeScript. Always provide proper type annotations. Do not use `any` unless explicitly allowed.
-- Always respect and follow linting rules. Do not introduce new linting errors.
-- Prefer functional code over imperative where at all possible.
-- Ensure all requested functionality from the plan is fully implemented. Crucially: Leave NO TODO comments, placeholders, or incomplete sections. All code generated must be complete and functional for the planned step.
-- Verify code thoroughly before considering a step complete.
-
-### Styling and Design
-
-- Use Tailwind CSS for all styling. Follow consistent utility-first class conventions.
-- Ensure the UI is responsive and adapts well to different screen sizes.
-- Use consistent color schemes and typography that align with the project using shadcn and tailwind.
-- Do consider darkmode and light mode when you design the ui.
-
-### Naming Conventions
-
-- Use snake_case for filenames and variables.
-- Keep function names and variable names descriptive and readable.
-
-### Project Structure and Dependencies
-
-- New API endpoints go under `src/api/`.
-- For network requests always use fetch instead of a library like axios.
-
-### Commit Messages
-
-- Keep commit messages &lt; 50 chars.
-- Use fix, beep, refactor, chore, etc syntax.
-
-### AI Behavior Guidance
-
-- Be concise in logs… Minimize extraneous prose.
-- Always respond in a concise, technical tone and avoid conversational filler.
-- Ask any and all questions you might have that makes the instructions clearer. (While this is a prompting strategy, it can be embedded within rules to force the AI to seek clarification. **Nota bene**: I have had mixed results on it _actually_ following this one.)
-- DO NOT remove or break any existing code. DO NOT modify current logic unless necessary. Only extend or add new code with minimal, safe changes. (**Nota bene**: Again, mixed results here as well.)
-
-## Best Practices for Using Cursor Rules
-
-To maximize the effectiveness of your Cursor Rules:
-
-1. **Start Small and Iterate:** Begin with a few key rules addressing common issues you encounter, and **add to them whenever you notice Cursor making the same mistake twice**. Over-thinking rules initially is unnecessary, as Cursor's models already possess vast knowledge.
-2. **Commit Project Rules to Version Control:** For team projects, **commit your `.cursor/rules` folder to Git**. This ensures consistency across the team and enhances the AI's understanding of the repository's style and conventions for all developers.
-3. **Be Specific and Concise:** Rules should be focused, actionable, and ideally under 500 lines. The more precise your instructions, the better the AI can deliver.
-4. **Prioritize AI Readability:** Organize your rules simply, keeping in mind that the AI needs to process this context efficiently. The goal is to help both engineers and AI tools navigate your codebases effectively.
-5. **Provide a Technical Overview:** Include a detailed technical overview of your project in your rules file, describing its purpose, how it works, important files, and core algorithms. This acts as a "constitution" for how the AI should behave.
-6. **Combine with Notepads:** Use `.cursor/rules` for "always-on" constraints and Notepads for "sometimes-on" or dynamic context. Notepads can bundle prompts, documentation links, and file references for reusable contexts, but are not currently AI-editable.
-7. **Leverage Community Resources:** Explore community-driven collections like `awesome-cursorrules` and `cursor.directory` for pre-built rule sets for popular frameworks.
-8. **Regularly Audit:** Rules can become stale as your project evolves. Schedule periodic reviews to remove outdated instructions or links to avoid "context rot" and ensure the AI remains focused.
-9. **Use for Agent Mode Directives:** Rules can specify how the AI agent should behave, for example, by outlining a **plan-and-act strategy** where the AI first creates a detailed plan for approval before executing it.
-
-## Resources
-
-- [Awesome Cursor Rules](https://github.com/PatrickJS/awesome-cursorrules)
-- [cursor.directory](https://cursor.directory/)
-- [Steve's TypeScript rules](https://stevekinney.com/writing/cursor-rules-typescript)
+Keep rules under roughly a few hundred lines and split by concern. Remove
+obsolete rules in the same pull request that makes them obsolete. A stale rule is
+not harmless documentation; it is active instruction.

--- a/courses/ai-development/cursor-rules.md
+++ b/courses/ai-development/cursor-rules.md
@@ -22,7 +22,8 @@ Cursor supports four practical instruction sources:
 - **User Rules** live in Cursor settings and follow one developer across
   projects.
 - **Team Rules** are centrally managed for teams.
-- **AGENTS.md** files can also provide repository instructions.
+- **[AGENTS.md](https://agents.md/)** files can also provide repository
+  instructions.
 
 Project Rules use Markdown with frontmatter. The file extension matters:
 `.mdc` is the Cursor rule format. Plain `.md` files in `.cursor/rules` are not

--- a/courses/ai-development/cursor-rules.md
+++ b/courses/ai-development/cursor-rules.md
@@ -11,6 +11,9 @@ date: 2025-07-29
 Cursor's agent. They are the right place for behavior that should apply before a
 specific prompt exists.
 
+I add rules when Cursor makes the same mistake twice. The first time is a prompt
+problem. The second time is a repository problem.
+
 ## Rule Types
 
 Cursor supports four practical instruction sources:

--- a/courses/ai-development/cursor-skills.md
+++ b/courses/ai-development/cursor-skills.md
@@ -1,0 +1,76 @@
+---
+title: Cursor Skills
+description: >-
+  Package reusable Cursor workflows as Agent Skills with instructions, scripts,
+  references, and assets that can also work across compatible agents.
+modified: 2026-06-24
+date: 2026-06-23
+---
+
+[Cursor Skills](https://cursor.com/docs/skills) package reusable agent behavior.
+Use a skill when a workflow needs more than a short rule: steps, examples,
+scripts, references, or assets.
+
+## Folder Shape
+
+A project skill can live under `.cursor/skills`:
+
+```text
+.cursor/
+  skills/
+    release-check/
+      SKILL.md
+      scripts/
+      references/
+      assets/
+```
+
+Cursor also understands skills in `.agents/skills`, `.claude/skills`, and
+`.codex/skills`. That compatibility matters when a repository uses more than one
+agent.
+
+## Minimal Skill
+
+```md
+---
+name: release-check
+description: Verify package release readiness before publishing.
+---
+
+Read the package manifest, changelog, generated exports, and test commands.
+Run the documented verification commands. Stop and report the exact blocker if a
+command fails.
+```
+
+Keep the entrypoint short. Put long examples in `references/`, reusable commands
+in `scripts/`, and visual or binary inputs in `assets/`.
+
+## Rules Versus Skills
+
+Use Rules for constraints:
+
+```text
+Always add regression tests for bug fixes.
+```
+
+Use Skills for procedures:
+
+```text
+Run the release readiness process and produce the shipping checklist.
+```
+
+If the instruction has phases, files to inspect, and a completion signal, it is
+probably a skill.
+
+## Skill Hygiene
+
+Skills are executable context. Treat them like source code:
+
+- Keep them versioned.
+- Keep them small enough to review.
+- Remove stale commands when the repository changes.
+- Make verification commands explicit.
+- Avoid copying vendor documentation that will drift.
+
+The agent should be able to run the workflow from the filesystem, not from a
+memory of a past chat.

--- a/courses/ai-development/cursor-subagents.md
+++ b/courses/ai-development/cursor-subagents.md
@@ -1,0 +1,64 @@
+---
+title: Cursor Subagents
+description: >-
+  Use Cursor subagents for isolated research, shell, browser, and specialized
+  repository tasks without over-splitting the work.
+modified: 2026-06-24
+date: 2026-06-23
+---
+
+[Cursor subagents](https://cursor.com/docs/subagents) are specialized agents with
+their own context. They can run in the editor, the command line interface, and
+Cloud Agents.
+
+The value is isolation. A subagent can inspect one concern deeply without
+polluting the main agent's context with every intermediate detail.
+
+## Built-In Subagents
+
+Cursor includes built-in subagents such as Explore, Bash, and Browser. They are
+useful for bounded tasks:
+
+- Explore: inspect a repository or design space.
+- Bash: run terminal-heavy investigation.
+- Browser: inspect web or application behavior.
+
+Use them when the task shape matches the tool. Do not split work just to make
+the prompt look sophisticated.
+
+## Custom Subagents
+
+Custom subagents live in `.cursor/agents/`:
+
+```md
+---
+name: test-auditor
+description: Find missing regression coverage for a described bug.
+model: auto
+readonly: true
+---
+
+Inspect the changed files and closest tests. Report missing coverage with file
+references. Do not edit files.
+```
+
+Cursor also supports compatible agent definitions from `.claude/agents` and
+`.codex/agents`, which is useful in mixed-agent repositories.
+
+## Foreground and Background Work
+
+A foreground subagent blocks the main task until it returns. A background
+subagent can continue while the main agent proceeds. Background work is useful
+for independent research, but it needs a crisp return format:
+
+```text
+Return only: findings, file references, and whether the main task should stop.
+```
+
+Without a return contract, parallel work often creates more context than value.
+
+## When Not to Use a Subagent
+
+Do not use subagents for tiny edits, single-file fixes, or tasks where one
+developer needs to keep the whole mental model in view. Subagents are a way to
+reduce context pressure, not a way to avoid thinking.

--- a/courses/ai-development/git-worktrees.md
+++ b/courses/ai-development/git-worktrees.md
@@ -1,77 +1,56 @@
 ---
-title: Using Git Worktrees for Parallel AI Development
+title: Git Worktrees for Agentic Development
 description: >-
-  Set up Git worktrees to run multiple Claude Code instances simultaneously for
-  parallel development workflows.
-modified: 2026-03-17
+  Use Git worktrees to isolate agent work, run parallel experiments, and keep
+  reviewable diffs without losing repository history.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-[Git Worktree](https://git-scm.com/docs/git-worktree) is a Git feature that allows developers to create multiple working directories from a single Git repository. Each working directory is linked to a specific branch within the repository, enabling concurrent work on different branches or features without constantly switching between them. This feature was introduced with Git version 2.5 and helps streamline workflows, save time, and reduce the risk of accidentally committing changes to the wrong branch.
+[Git worktrees](https://git-scm.com/docs/git-worktree) let one repository have
+multiple working directories checked out at different branches. They are useful
+with agents because agents produce file changes, and file changes need isolation.
 
-## Why Use Git Worktrees with Claude Code?
+## Why Worktrees Help
 
-The primary benefit of using Git Worktrees with Claude Code is to **run multiple Claude Code instances simultaneously on different parts of your project**, each focused on its own independent task. This addresses the challenge of working on the same codebase and Git branch, which can lead to conflicts, especially when implementing features that cross multiple files.
+Use worktrees when:
 
-- **Parallelization**: You can have one Claude instance refactoring an authentication system while another builds a completely unrelated data visualization component. This allows agents to work at full speed without waiting for each other's changes or dealing with immediate merge conflicts.
-- **Isolation**: Each worktree has its own independent file state, preventing Claude instances from interfering with each other.
-- **Increased Impact**: By parallelizing the efforts of multiple LLMs, you can get different versions of a feature or codebase, allowing you to select the best one.
-- **Efficiency**: It enables you to **continue your own development in one worktree while Claude works on a long-running task in another**.
+- You want to run two agent experiments in parallel.
+- A cloud or command line agent should not touch your main working tree.
+- You need a clean branch for review while local work continues elsewhere.
+- You want to compare two implementation paths without stashing.
 
-## Setting Up Git Worktrees with Claude Code
+## Basic Commands
 
-Setting up Git Worktrees for use with Claude Code involves a few steps, ranging from manual creation to advanced automation:
+```bash
+git worktree add ../project-feature feature/agent-experiment
+git worktree list
+git worktree remove ../project-feature
+```
 
-### Manual Creation of a Git Worktree
+Run the agent from inside the worktree:
 
-- First, **create a new branch** for your feature, for example, `git branch feature-name`.
-- Then, create a separate directory for your worktree using `git worktree add <path> <branch>`. For instance, `git worktree add ../project-feature-a feature-a` will create a new directory named `project-feature-a` adjacent to your main project folder, containing a complete copy of your codebase on the `feature-a` branch.
-- **It is recommended to create a dedicated "worktrees" folder adjacent to your main project folder** to keep things organized and avoid confusing Git with nested repositories or accidental commits of copied codebases.
-- Navigate into the newly created worktree directory: `cd ../project-feature-a`.
-- To see a list of all current worktrees, use `git worktree list`.
-- Once inside the worktree, you can start Claude Code: `claude`.
+```bash
+cd ../project-feature
+claude
+```
 
-### Automating Worktree Setup with Claude Code (Limitations and Workarounds)
+or:
 
-- You can attempt to create a custom slash command in Claude Code (e.g., in `.claude/commands/create_worktree.md`) to automate the worktree creation process.
-- However, Claude Code typically operates within the confines of the main project folder and its subfolders. **It generally does not have the security permissions to move out of the main project folder to create directories elsewhere on your file system**. This means Claude itself cannot `cd` into the newly created worktree folder outside its current scope.
-- A more effective approach for full automation is to **use a terminal alias with an external script** (e.g., a ZSH script). This script can perform all the necessary steps, including creating the adjacent worktree folder, creating the Git Worktree, and opening the new worktree in a separate IDE window or terminal tab. You can even have Claude write this script for you.
+```bash
+agent
+```
 
-### Initializing Claude Code in New Worktrees
+## Review Discipline
 
-- When you create a worktree, it copies the entire codebase, including your `.claude/CLAUDE.md` file if it exists in the root.
-- It's a good practice to run `/init` in each new worktree session to ensure Claude Code is properly oriented with the codebase within that specific worktree, populating its project-specific `CLAUDE.md` file.
+A worktree isolates files. It does not prove correctness. Before merging work
+from any agent-created branch:
 
-## Using Multiple Claude Code Instances with Worktrees
+```bash
+git status --short
+git diff
+bun run lint
+bun run test:unit
+```
 
-Once your Git Worktrees are set up, you can leverage them for multi-agent workflows:
-
-1. **Open Each Worktree in Separate Terminal Tabs/IDE Windows**: Create multiple instances of Claude Code by opening each worktree folder in a separate terminal tab or IDE window (e.g., VS Code or Cursor). This allows you to visually differentiate between the working environments.
-2. **Start Claude in Each Folder with Different Tasks**: Assign distinct tasks to each Claude instance. For example, one Claude can work on adding a new feature (like "drums" to a music app), while another adds a different one (like "bases"), all in parallel without immediate file conflicts.
-3. **Cycle Through to Check Progress**: Regularly check the progress of each Claude instance and approve or deny any permission requests.
-4. **Track Work**: You can use a `tasks.md` file to track what each branch is working on, with a "main" branch's Claude Code instance handling merges and overall planning/testing.
-5. **Merge Changes**: When work is completed on a worktree branch, you can merge it back into the main branch, just like you would with a regular Git branch. However, be mindful that eventually, these outputs must be integrated, which can lead to complex logical conflicts or difficult Git merges that may require human intervention.
-
-## Best Practices and Tips
-
-To maximize the effectiveness of Git Worktrees with Claude Code:
-
-- **Organized Directory Structure**: Use consistent naming conventions for your worktree directories (e.g., `project-feature-a`) to easily identify the associated task or branch.
-- **Limit Active Worktrees**: Create worktrees only for active tasks and remove them once a branch or job is complete to prevent clutter.
-- **Routine Maintenance**: Regularly use `git worktree prune` to clean up metadata from old or deleted worktrees and ensure each worktree stays updated with the latest changes from the main repository to prevent conflicts.
-- **Commit Often**: Frequently commit changes within each worktree to safeguard against data loss and maintain a granular version history.
-- **CLAUDE.md for Project Context**: Utilize the `CLAUDE.md` file in each worktree to provide persistent, project-specific context, coding standards, and workflows. This file is automatically read by Claude at the start of every session. You can even link to other relevant markdown files within `CLAUDE.md` using the `@` syntax to manage large amounts of documentation without overloading the main file.
-- **Leverage Headless Mode**: For automation and scripting, use Claude Code in headless mode with the `-p` flag (`claude -p`).
-- **Notifications**: Set up notifications (e.g., using iTerm2 on Mac) to be alerted when Claude needs attention or completes a long-running task.
-- **Plan Before Coding**: Encourage Claude to first explore the codebase, then create a detailed step-by-step plan, and only then proceed with coding. This "Explore, Plan, Code, Commit" workflow is a foundational best practice. For complex problems, explicitly asking Claude to "think hard" can encourage deeper consideration.
-- **Role Specialization**: For multi-agent systems, design agents with narrow, well-defined roles (e.g., Architect, Builder, Validator, Scribe) and use shared planning documents for coordination.
-
-## Challenges to Be Aware Of
-
-While powerful, Git Worktrees can present some challenges:
-
-- **Learning Curve**: They can be complex for those new to Git, requiring a steeper learning curve.
-- **Management Overhead**: With multiple active worktrees, it's easy to confuse them, potentially leading to changes in the wrong directory or branch. They also require regular maintenance to prune old ones.
-- **Syncing Issues**: There's an increased risk of worktrees becoming outdated if not regularly updated from the main repository, which can lead to merge conflicts or redundant work. While worktrees minimize _overlaps_, integration and merging outputs can still lead to complex logical conflicts.
-- **Tooling Compatibility**: Not all development tools or Git GUIs are fully optimized for Git Worktrees, which might cause inconsistencies.
-- **Resource Consumption**: Running a large number of Claude Code instances, even with worktrees, can be resource-intensive in terms of CPU, memory, and API costs.
+Use worktrees to make parallel work reviewable, not to avoid review.

--- a/courses/ai-development/index.toml
+++ b/courses/ai-development/index.toml
@@ -29,12 +29,36 @@ title = "Cursor Rules"
 href = "cursor-rules.md"
 
 [[section.item]]
-title = "Notepads"
+title = "Cursor Skills"
+href = "cursor-skills.md"
+
+[[section.item]]
+title = "Cursor Subagents"
+href = "cursor-subagents.md"
+
+[[section.item]]
+title = "Cursor Hooks"
+href = "cursor-hooks.md"
+
+[[section.item]]
+title = "Cursor Command Line Interface"
+href = "cursor-cli.md"
+
+[[section.item]]
+title = "Notepads Migration"
 href = "cursor-notepads.md"
 
 [[section.item]]
-title = "Background Agents"
+title = "Cloud Agents"
 href = "cursor-background-agents.md"
+
+[[section.item]]
+title = "Cursor Automations"
+href = "cursor-automations.md"
+
+[[section.item]]
+title = "Bugbot and Security Review"
+href = "cursor-bugbot-and-security-review.md"
 
 [[section.item]]
 title = "Cursor Checkpoints"
@@ -48,7 +72,7 @@ title = "Model Context Protocol"
 href = "mcp.md"
 
 [[section.item]]
-title = "Some MCP Servers"
+title = "MCP in Claude Code and Cursor"
 href = "mcp-for-claude-code-and-cursor.md"
 
 [[section]]
@@ -91,11 +115,11 @@ title = "Plan Mode"
 href = "claude-code-plan-mode.md"
 
 [[section.item]]
-title = "Sub-Agents"
+title = "Subagents"
 href = "claude-code-sub-agents.md"
 
 [[section.item]]
-title = "Sub-Agent Anti-Patterns"
+title = "Subagent Anti-Patterns"
 href = "subagent-anti-patterns.md"
 
 [[section.item]]
@@ -111,7 +135,7 @@ title = "Claude Code's Permission System"
 href = "claude-code-permissions.md"
 
 [[section.item]]
-title = "Claude Code Commands"
+title = "Claude Code Commands and Skills"
 href = "claude-code-commands.md"
 
 [[section.item]]
@@ -165,5 +189,5 @@ title = "Cursor Environment Configuration"
 href = "cursor-environment-configuration.md"
 
 [[section.item]]
-title = "Cursor Ghost Mode"
+title = "Cursor Privacy Mode"
 href = "cursor-ghost-mode.md"

--- a/courses/ai-development/installing-claude-code.md
+++ b/courses/ai-development/installing-claude-code.md
@@ -33,7 +33,9 @@ reason to prefer it over package-manager installs for most developers.
 
 ## Package Managers
 
-Homebrew and WinGet are supported alternatives:
+[Homebrew](https://brew.sh/) and
+[WinGet](https://learn.microsoft.com/windows/package-manager/winget/) are
+supported alternatives:
 
 ```bash
 brew install --cask claude-code

--- a/courses/ai-development/installing-claude-code.md
+++ b/courses/ai-development/installing-claude-code.md
@@ -1,60 +1,72 @@
 ---
 title: Installing and Setting Up Claude Code
 description: >-
-  Complete installation guide for Claude Code CLI tool with system requirements
-  and initial configuration.
-modified: 2026-03-17
+  Install Claude Code with the native installer, Homebrew, WinGet, release
+  channels, auto-updates, Windows guidance, and claude doctor.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Claude Code is a **powerful agentic AI coding assistant** that transforms how developers approach their workflows. Unlike traditional code completion tools, it operates directly in your terminal, understanding your entire codebase and executing complex development tasks through natural language commands. It functions less like a suggestion tool and more like an **intelligent partner** or a junior developer on your team.
+[Claude Code](https://code.claude.com/docs/en/overview) is
+[Anthropic](https://www.anthropic.com/)'s agentic development tool. It runs in
+the terminal, IDEs, desktop and web surfaces, and automation contexts.
 
-Here's a comprehensive guide on how to install and get started with Claude Code:
+The current primary install path is the native installer. Do not teach npm as the
+default install path for new users.
 
-## Understanding What Claude Code Is
+## Native Installer
 
-Claude Code is an **agentic code tool** developed by Anthropic that provides a native way to integrate Claude into coding workflows. It's designed to be a **low-level, unopinionated, and flexible power tool**, offering nearly raw access to the underlying model's capabilities. Its core strengths include:
-
-- **Full Codebase Awareness**: It's initialized within a specific project directory, giving it a persistent, broad understanding of the entire project structure, inter-file relationships, and coding patterns.
-- **Autonomous Execution**: Claude Code can perform complex, multi-step workflows with a degree of autonomy, directly manipulating files, executing shell commands, managing Git operations, and running tests, often without continuous human intervention. It can even operate in an "auto mode".
-- **Terminal-Native Integration**: As a command-line interface (CLI) tool, it integrates directly into the terminal, facilitating scripting, automation, and integration with other command-line tools. It allows you to chat with it like a regular AI model.
-
-## System Requirements
-
-Before installation, ensure your system meets these prerequisites:
-
-- **Operating Systems**: macOS 10.15+, Ubuntu 20.04+/Debian 10+, or Windows via WSL (Windows Subsystem for Linux).
-- **Hardware**: A minimum of 4GB RAM is recommended.
-- **Software**: **Node.js 18+** is essential, which includes npm (Node Package Manager). Git 2.23+ is optional but highly recommended for version control. GitHub or GitLab CLI is optional for Pull Request (PR) workflows.
-- **Network**: An active internet connection is required for authentication and AI processing.
-- **Location**: Claude Code is only available in supported countries.
-
-## Installation Steps
-
-Installation is straightforward, typically involving npm.
+On macOS and Linux:
 
 ```bash
-npm install -g @anthropic-ai/claude-code
+curl -fsSL https://claude.ai/install.sh | bash
 ```
 
-1. **Install Node.js**: If you don't have Node.js 18+ or need to update, use your distribution's package manager or Node Version Manager (nvm).
-2. **Install Claude Code**: Open your terminal and run the command: `npm install -g @anthropic-ai/claude-code`.
-   - **Important**: **Do NOT use `sudo`** with this command unless absolutely necessary, as it can cause permission issues. If you encounter permission errors on Linux, it's recommended to configure npm to use a user-writable directory within your home folder, for example, `~/.npm-global`, and then add it to your PATH.
-3. **Authentication**: The first time you run `claude` in your project directory, it will guide you through an OAuth process to connect to your Anthropic account.
-   - You will need an active billing setup (e.g., sufficient credits) in your Anthropic Console account.
-   - Alternatively, you can log in with your **Claude.ai Pro or Max plan** subscription for a unified experience.
-   - Claude Code can also be configured for enterprise deployments through Amazon Bedrock or Google Vertex AI.
+On Windows PowerShell:
 
-### Check Your Set Up
+```powershell
+irm https://claude.ai/install.ps1 | iex
+```
 
-Run Claude's built-in diagnostic tool:
+The native installer supports auto-updates and release channels. That is the main
+reason to prefer it over package-manager installs for most developers.
+
+## Package Managers
+
+Homebrew and WinGet are supported alternatives:
 
 ```bash
+brew install --cask claude-code
+```
+
+```powershell
+winget install Anthropic.ClaudeCode
+```
+
+The tradeoff is update behavior. Homebrew and WinGet installations do not use
+Claude Code's built-in auto-update path, so the package manager owns updates.
+
+## Windows and WSL
+
+Claude Code supports native Windows installation. Windows Subsystem for Linux is
+still useful when the repository and toolchain are Linux-oriented. Choose the
+environment that matches the project, not the one that makes installation look
+shorter.
+
+## Verify the Setup
+
+Run:
+
+```bash
+claude --version
 claude doctor
 ```
 
-Expected output:
+`claude doctor` checks common environment and authentication problems. Use it
+before debugging a repository-specific failure.
 
-```ts
-✔ All systems go
-```
+## Release Channels
+
+Claude Code supports stable and latest channels through settings such as
+`autoUpdatesChannel`. For teaching and team onboarding, prefer stable unless a
+lesson explicitly depends on a new feature from the latest channel.

--- a/courses/ai-development/installing-cursor.md
+++ b/courses/ai-development/installing-cursor.md
@@ -57,8 +57,11 @@ interactive session, or use print mode for automation:
 agent -p "Review the staged changes for correctness."
 ```
 
-File modification from print mode requires an explicit flag such as `--force` or
-`--yolo`. Treat that as a real permission decision, not a convenience switch.
+File modification from
+[print mode](https://cursor.com/docs/cli/headless) requires an explicit flag such
+as `--force` or `--yolo`, which is a name that is at least honest about the life
+choice you are making. Treat that as a real permission decision, not a
+convenience switch.
 
 ## First Project Setup
 

--- a/courses/ai-development/installing-cursor.md
+++ b/courses/ai-development/installing-cursor.md
@@ -1,76 +1,99 @@
 ---
 title: Installing and Getting Started with Cursor
 description: >-
-  Download, install, and configure Cursor AI code editor with VS Code migration
-  and core interaction modes.
-modified: 2026-03-17
+  Download, install, and configure Cursor with Visual Studio Code migration,
+  privacy settings, rules, skills, and the command line interface.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-You can [download Cursor here](https://cursor.com). The installation process is straightforward and feels similar to installing Visual Studio Code (and for a good reason, right?): download, run, and it's done.
+[Cursor](https://cursor.com) is still easiest to explain as a code editor with an
+agent built into the workflow. The important update is that the editor is no
+longer the whole product. Current Cursor also includes cloud agents, automations,
+subagents, hooks, skills, Bugbot, Security Agents, and a terminal interface.
 
-## Initial Setup and Onboarding
+Start with the desktop application because that is where the everyday feedback
+loop is strongest.
 
-A neat part of onboarding with Cursor is its **one-click migration feature**, which automatically imports all your existing extensions, settings, themes, and keybindings from a Visual Studio Code installation. This ensures the new environment is immediately familiar and configured for productivity. While the initial setup is easy, mastering advanced features like `.cursor/rules` or background agents might take some time, requiring experimentation—trust me.
+## Install the Desktop Application
 
-## Core Workflow and Interaction Modes
+Download Cursor from [cursor.com](https://cursor.com). During onboarding, Cursor can
+import extensions, settings, keybindings, and themes from
+[Visual Studio Code](https://code.visualstudio.com/). That migration is useful
+because Cursor is familiar enough that the editor should not be the new thing you
+are learning. The agent workflow should be.
 
-Cursor's daily usage revolves around three fundamental interaction modes:
+After installation, check these settings before you hand it a real repository:
 
-- **Inline Edit (Cmd/Ctrl+K)**: This is considered a "killer feature" for surgical, in-place code modifications. You select a block of code, press `Cmd/Ctrl+K`, and issue a natural language instruction (e.g., "Refactor this function to use async/await"). The AI proposes changes directly within the editor with a color-coded diff view for clear additions and deletions before acceptance. It's ideal for quick, targeted changes and generation.
-- **AI Chat (Cmd/Ctrl+L)**: This opens a conversational interface, similar to ChatGPT but with the context of your entire codebase. It's useful for brainstorming, asking questions about the codebase (e.g., "Show me where the database connection string is defined"), and generating larger code blocks. By default, it's aware of the current file, but you can include the whole repository using the "Codebase" button or typing `@codebase`.
-- **The Agent (Cmd/Ctrl+I)**: This mode enables true agentic coding for complex, multi-file tasks. You describe a high-level goal, and the agent plans and executes the necessary changes across the entire project. It can create and modify files, run terminal commands, perform semantic code searches, and handle file operations autonomously. By default, the agent will ask for user approval before executing any command, ensuring you remain in control. This mode is now often the default chat mode.
+- Enable **Privacy Mode** if the repository contains proprietary code.
+- Decide whether model requests can use premium or Max Mode models.
+- Add User Rules only for preferences that should follow you across every
+  repository.
+- Keep repository-specific rules in `.cursor/rules/*.mdc`.
+- Configure trusted MCP servers in `.cursor/mcp.json` or `~/.cursor/mcp.json`.
 
-## Customizing Behavior and Context Management
+The rule of thumb is simple: personal defaults go in user settings, repository
+behavior goes in the repository, and external tools should be explicit enough
+that a teammate can audit them.
 
-**Prompting Effectively**: The quality of AI-generated code heavily depends on the prompts.
+## Install the Command Line Interface
 
-- **Be Specific**: Clearly define the task, language, function/class name, inputs/outputs, and style guidelines. Vague prompts like "Make this better" or "Fix everything" are less effective.
-- **Provide Context**: Include relevant code snippets or descriptions. Cursor automatically provides context like the current file, recently viewed files, semantic search results, linter errors, and edit history.
-- **Set Constraints**: Specify limitations or requirements (e.g., error handling, edge cases, performance optimization, coding standards).
-- **Examples**: "Add TypeScript types to this function. Don't change logic" is a good prompt. Providing a template for new components (e.g., "Create a new `DropdownMenu` component that follows the same style and structure as the Select component in `@components/select.tsx`") helps the AI emulate a concrete pattern.
-- **Break Down Problems**: For complex tasks, ask the AI to outline its strategy first (e.g., "First, provide a PLAN with your REASONING. Then, implement the changes step-by-step"). This "Plan-and-Act" approach allows for review and approval of the plan before execution.
-- **Iterative Refinement**: Treat the process as a dialogue, refining prompts based on AI output and providing specific feedback on errors.
-- **Ask Questions**: Encourage Cursor to ask clarifying questions by ending your prompt with phrases like "Ask any and all questions you might have that makes the instructions clearer".
+Cursor also ships a terminal agent. Install it with the official installer:
 
-**`.cursor/rules` Files**: These files allow you to define project-wide rules and styles that Cursor follows every time it edits. They are typically stored in a `.cursor/rules` file at the root of your project.
+```bash
+curl https://cursor.com/install -fsS | bash
+```
 
-- They can enforce code style, language preferences (e.g., "Always write code in **TypeScript**"), formatting, and quality guidelines.
-- Rules can be configured to apply always, auto-attach based on file patterns, or be requested by the agent.
-- **Global AI Rules**: You can establish universal guidelines that the AI should always follow across all projects under `Settings -> Cursor Settings -> Rules -> User Rules`.
-- It's recommended to start small and iterate on your rules as you go, adding to them when you notice the AI making the same mistake twice.
+On Windows, use PowerShell:
 
-**[Notepads](cursor-notepads.md)**: These are like "supercharged sticky notes" for your code.
+```powershell
+irm 'https://cursor.com/install?win32=true' | iex
+```
 
-- They can store frequently used prompts, file references, and explanations for quick reuse.
-- You can create dynamic templates and reference them using the `@` syntax (e.g., `@MyNotepad`).
-- They are useful for documenting project architecture, development guidelines, or team-specific rules.
-- **@ Symbol for Context**: This is Cursor's primary mechanism for providing specific context to the AI.
-- **@Files and @Folders**: Reference specific files or entire directories (e.g., `@files:app/services/data_service.py`).
-- **@Code and @Symbols**: Reference a specific function, class, or variable within the project (e.g., `@code:processOrder`).
-- **@Docs**: Reference official documentation for libraries and frameworks. You can also add your own documentation by URL, and Cursor will index it.
-- **@Web**: Allows Cursor to perform a live web search to find relevant, up-to-date information, adding search results to your query's context.
+The command is `agent`, not `cursor`. Run `agent` inside a repository for an
+interactive session, or use print mode for automation:
 
-**[Model Context Protocol](mcp.md) (MCP)**: An open standard that allows AI agents to safely and efficiently connect to external tools, data sources, and APIs.
+```bash
+agent -p "Review the staged changes for correctness."
+```
 
-- Cursor integrates MCP as a core extensibility mechanism, transforming context provision into a programmable process.
-- It manages MCP server connections via a declarative `mcp.json` file, supporting both project-specific (`.cursor/mcp.json`) and global (`~/.cursor/mcp.json`) toolsets.
-- MCP enables integrations with project management tools (Linear, Shortcut), design tools (Figma), browser/debugging tools, and databases like PostgreSQL, allowing the AI agent to access real-time, authoritative context and new capabilities.
-- When the agent uses an MCP tool, it usually requires **explicit user approval** by default, showing which tool it wants to call and its arguments.
+File modification from print mode requires an explicit flag such as `--force` or
+`--yolo`. Treat that as a real permission decision, not a convenience switch.
 
-## Advanced Features and Best Practices
+## First Project Setup
 
-- **AI Models**: Cursor allows you to choose from various models like GPT-3.5, GPT-4, Claude, and Gemini. Each has pros and cons regarding speed, cost, and accuracy. For complex architecture or critical tasks, Claude Opus is recommended, while GPT-4 is good for deep restructuring, and Claude Sonnet for general coding. There is also an "Auto" mode that intelligently selects the most appropriate model. You can use your own API keys for services like OpenAI or Anthropic for more control over costs.
-- **Debugging with AI**: Cursor can help debug by analyzing error messages and stack traces, suggesting fixes, and even instrumenting code with logs to trace variable values. It also has a "Bug finder" feature that scans code and recent changes for potential bugs and offers fixes.
-- **Test-Driven Development (TDD)**: Cursor can be instructed to "Write tests first, then write the code to implement the feature, and finally, run the tests and update the code until all tests pass". This provides confidence that the generated code meets specifications.
-- **Automated Linting Fixes**: With "Iterate on Lints" enabled, the agent can automatically run linters (e.g., ESLint) and attempt to fix violations.
+For a serious repository, create the project-level files before asking the agent
+to edit code:
 
-**Git Integration**
+```text
+.cursor/
+  rules/
+    architecture.mdc
+    testing.mdc
+  mcp.json
+```
 
-- **AI-generated Commit Messages**: Cursor can automatically generate descriptive Git commit messages based on staged changes, often adapting to the repository's existing commit style.
-- **AI-assisted Code Reviews**: You can leverage the agent as a code reviewer by providing it with pending changes (e.g., `@Commit (Diff of Working State)` context) and asking it to review like a senior engineer.
+Add skills only when a workflow needs more structure than a rule can provide:
 
-**Yolo Mode**: This setting allows the agent to apply changes and run tests without explicit approval. It's recommended only when you trust the AI and context. (So, like _never_.)
+```text
+.cursor/
+  skills/
+    release-checklist/
+      SKILL.md
+```
 
-- **Managing Context Window**: AI context windows are limited. It's advised to **keep conversations short and focused** and to **commit early and often** to avoid losing context or getting stuck in loops. Breaking down large requests into smaller steps helps manage context.
-- **Privacy Mode**: For proprietary or sensitive code, enable "Privacy Mode" in `Settings > General > Privacy Mode`. When active, Cursor guarantees that user code is never stored on its servers or used for model training by third-party providers. For maximum security, "Local/Ghost Mode" ensures all processing happens locally. Cursor is SOC 2 Type II certified, adhering to high industry standards for security and privacy.
+If the repository already has `AGENTS.md`, Cursor will read it as an instruction
+source. I still prefer putting Cursor-specific behavior in Cursor files so the
+reader can tell which tool owns which instruction.
+
+## Verification Checklist
+
+Before you trust a new setup, ask Cursor to perform a read-only orientation:
+
+```text
+Read this repository and summarize the build, test, lint, and release commands.
+Do not edit files. Cite the files you used.
+```
+
+Then compare its answer to the repository scripts. If it invents commands, fix
+the rules or context before you use Agent mode for changes.

--- a/courses/ai-development/installing-cursor.md
+++ b/courses/ai-development/installing-cursor.md
@@ -25,12 +25,16 @@ are learning. The agent workflow should be.
 
 After installation, check these settings before you hand it a real repository:
 
-- Enable **Privacy Mode** if the repository contains proprietary code.
-- Decide whether model requests can use premium or Max Mode models.
+- Enable
+  [**Privacy Mode**](https://cursor.com/help/security-and-privacy/privacy) if the
+  repository contains proprietary code.
+- Decide whether model requests can use premium or
+  [Max Mode](https://cursor.com/docs/models-and-pricing) models.
 - Add User Rules only for preferences that should follow you across every
   repository.
 - Keep repository-specific rules in `.cursor/rules/*.mdc`.
-- Configure trusted MCP servers in `.cursor/mcp.json` or `~/.cursor/mcp.json`.
+- Configure trusted [MCP](https://modelcontextprotocol.io/) servers in
+  `.cursor/mcp.json` or `~/.cursor/mcp.json`.
 
 The rule of thumb is simple: personal defaults go in user settings, repository
 behavior goes in the repository, and external tools should be explicit enough
@@ -85,9 +89,9 @@ Add skills only when a workflow needs more structure than a rule can provide:
       SKILL.md
 ```
 
-If the repository already has `AGENTS.md`, Cursor will read it as an instruction
-source. I still prefer putting Cursor-specific behavior in Cursor files so the
-reader can tell which tool owns which instruction.
+If the repository already has [`AGENTS.md`](https://agents.md/), Cursor will read
+it as an instruction source. I still prefer putting Cursor-specific behavior in
+Cursor files so the reader can tell which tool owns which instruction.
 
 ## Verification Checklist
 

--- a/courses/ai-development/integrating-with-github-actions.md
+++ b/courses/ai-development/integrating-with-github-actions.md
@@ -15,9 +15,12 @@ pull request or comment.
 
 ## Claude Code GitHub Actions
 
-Claude Code GitHub Actions are built on the Claude Agent SDK. The current
-workflow uses `@anthropics/claude-code-action@v1`, a `prompt`, and optional
-`claude_args`. Older beta `mode` patterns should not be copied into new lessons.
+Claude Code GitHub Actions are built on the
+[Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview). The
+current workflow uses
+[`@anthropics/claude-code-action@v1`](https://github.com/anthropics/claude-code-action),
+a `prompt`, and optional `claude_args`. Older beta `mode` patterns should not be
+copied into new lessons.
 
 Use `/install-github-app` for guided setup when possible. For manual setup, keep
 the Anthropic API key in GitHub Secrets and scope repository permissions tightly.

--- a/courses/ai-development/integrating-with-github-actions.md
+++ b/courses/ai-development/integrating-with-github-actions.md
@@ -1,133 +1,54 @@
 ---
-title: Integrating Claude Code with GitHub Actions
+title: Integrating with GitHub Actions
 description: >-
-  Set up AI-powered automation in GitHub workflows using Claude Code for code
-  reviews and pull requests.
-modified: 2026-03-17
+  Use Claude Code GitHub Actions and Cursor review automation with explicit
+  prompts, secrets, permissions, and pull request verification.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Claude Code GitHub Actions enable AI-powered automation within your GitHub workflows. By simply mentioning `@claude` in a pull request (PR) or issue, Claude can analyze your code, create PRs, implement features, and fix bugs, all while adhering to your project's defined standards. It's built on the Claude Code SDK, which allows programmatic integration.
+[Claude Code GitHub Actions](https://code.claude.com/docs/en/github-actions) and
+[Cursor](https://cursor.com/docs/integrations/github) can bring agents into
+[GitHub](https://github.com/) workflows. The common pattern is simple: an event
+or comment gives an agent a bounded task, and the agent reports back through a
+pull request or comment.
 
-## Setting Up Claude Code GitHub Actions
+## Claude Code GitHub Actions
 
-Setting up this integration involves a few key steps to ensure Claude has the necessary access and context:
+Claude Code GitHub Actions are built on the Claude Agent SDK. The current
+workflow uses `@anthropics/claude-code-action@v1`, a `prompt`, and optional
+`claude_args`. Older beta `mode` patterns should not be copied into new lessons.
 
-### Prerequisites
+Use `/install-github-app` for guided setup when possible. For manual setup, keep
+the Anthropic API key in GitHub Secrets and scope repository permissions tightly.
 
-- **Node.js**: Node.js 18+ is essential. For Windows users, it's recommended to use Windows Subsystem for Linux (WSL).
-- **Git**: Git version 2.23+ is recommended for version control.
-- **GitHub CLI (`gh`)**: Install the `gh` CLI locally, as Claude knows how to use it for interacting with GitHub (e.g., creating issues, opening pull requests, reading comments). Without `gh` installed, Claude can still use the GitHub API or Model Context Protocol (MCP) server if configured.
+## Cursor Review and Automation
 
-### Installation
+Cursor can participate in GitHub through Cloud Agents, automations, Bugbot, and
+Security Agents. GitHub triggers can include issue comments, pull request review
+comments, submitted reviews, review thread updates, and workflow run completion.
 
-- **Quick Setup (Recommended for direct Anthropic API users)**: Open Claude Code in your terminal and run the `/install-github-app` command. This command will guide you through setting up the GitHub app and the required secrets. You must be a repository administrator to install the GitHub app and add secrets.
-- **Manual Setup**: If the quick setup fails or you prefer manual configuration, follow these steps:
-  1. Install the Claude GitHub app to your repository by visiting `https://github.com/apps/claude`.
-  2. **Add `ANTHROPIC_API_KEY` to your repository secrets**. You should never commit API keys directly to your repository; always use GitHub Secrets.
-  3. Copy the example workflow file (e.g., from `examples/claude.yml` in the Claude Code Action repository) into your repository's `.github/workflows/` directory.
-- **Enterprise Platforms (AWS Bedrock & Google Vertex AI)**: For enterprise environments, you can configure Claude Code GitHub Actions with your own cloud infrastructure to control data residency and billing. This requires specific prerequisites for Google Cloud Vertex AI or AWS Bedrock, including enabling relevant services, configuring Workload Identity Federation or GitHub OIDC Identity Provider, and setting up appropriate service accounts or IAM roles with necessary permissions (e.g., `AmazonBedrockFullAccess`). You'll need to use specific environment variables for these services in your workflow files, such as `ANTHROPIC_VERTEX_PROJECT_ID` or `CLOUD_ML_REGION`.
+Use these integrations for bounded work:
 
-## Configuring GitHub Actions Workflows
+```text
+When CI fails, inspect the failing job. Open a pull request only if the fix is
+confined to test configuration. Otherwise, comment with the diagnosis and the
+failing command.
+```
 
-Once set up, you define how Claude Code interacts with your repository through workflow files:
+## Security Boundaries
 
-### Triggering the Action
+Agent workflows in GitHub need special care:
 
-- By default, the Claude Code GitHub Action listens for comments or issues mentioning `@claude`.
-- You can customize triggers in your YAML workflow file. For instance, to automate PR reviews on every pull request opening or update, you can use `pull_request: types: [opened, synchronize]`.
-- To trigger only on demand via comments, use an `issue_comment` trigger with a filter like `if: contains(github.event.comment.body, '@claude')`.
+- Do not expose broad secrets to pull request workflows from forks.
+- Keep write permissions narrow.
+- Require human review for generated pull requests.
+- Treat MCP servers and external tools as part of the workflow's trusted
+  computing base.
+- Pin action versions according to the repository's security policy.
 
-1. **Workflow Structure (Example YAML)**: A typical workflow file will include:
+## Completion Criteria
 
-   ```ts
-   name: Claude Code Review
-   on:
-     pull_request:
-       types: [opened, synchronize] # Run when PR is opened or updated
-   jobs:
-     review:
-       runs-on: ubuntu-latest
-       permissions: { contents: read } # allow reading code
-       steps:
-         - uses: actions/checkout@v4
-           with: { fetch-depth: 0 }
-         - name: Run Claude Code Review
-           uses: anthropics/claude-code-action@beta
-           with:
-             anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-             direct_prompt: |
-               Review the PR changes for potential bugs, style issues, and adherence to our standards. Provide a detailed comment with findings and suggestions.
-   ```
-
-   This example demonstrates how Claude checks out the code and executes a review prompt when a PR is triggered.
-
-2. **Action Parameters**: The `claude-code-action` supports key parameters:
-   - `trigger_phrase`: The phrase that activates Claude (e.g., "@claude").
-   - `timeout_minutes`: Sets a timeout for Claude's operation.
-   - `github_token`: Used for authentication with GitHub actions.
-   - `direct_prompt`: Allows you to specify the exact prompt for Claude to execute. If omitted, Claude can infer the task from the issue or comment text.
-   - `allowed_tools`: Specifies which tools Claude is permitted to use (e.g., `mcp__github__create_pull_request`, `Bash(git push:*)`).
-   - `use_vertex`: Boolean to indicate use of Google Vertex AI.
-   - `model`: Specifies the Claude model to use (e.g., "claude-3-7-sonnet@20250219").
-
-3. **Permissions within Workflows**: For Claude to perform actions like creating PRs or pushing changes, you must grant explicit permissions in your workflow YAML. For example, add `pull-requests: write` and potentially `contents: write` to the `permissions` scope of your job. Claude Code runs with a restricted default toolset (read-only and non-destructive) for security.
-
-## Best Practices and Tips
-
-To maximize the effectiveness of Claude Code with GitHub Actions:
-
-- **`CLAUDE.md` for Project Context**: Create a `CLAUDE.md` file in your repository root. This special file is automatically pulled into Claude's context, making it ideal for documenting code style guidelines, testing instructions, core files, utility functions, and repository etiquette. Claude respects this file even when running in CI/CD pipelines. You can link to other relevant markdown files within `CLAUDE.md` using the `@` syntax to manage large amounts of documentation without overloading the main file.
-- **Security Considerations**: Always use GitHub Secrets for API keys (e.g., `${{ secrets.ANTHROPIC_API_KEY }}`) instead of hardcoding them. Limit action permissions to only what is necessary, granting only the minimum required. **Always review Claude's suggestions before merging**.
-
-### Optimizing Performance and Cost
-
-    - Use issue templates to provide clear, concise context.
-    - Keep your `CLAUDE.md` concise and focused.
-    - Configure appropriate timeouts for your workflows.
-    - Be aware that Claude Code runs on GitHub-hosted runners, consuming GitHub Actions minutes, and each interaction consumes API tokens. Fixed-cost subscription plans can help with predictable costs.
-
-- **Leverage Headless Mode**: Use Claude Code in headless mode with the `-p` flag (`claude -p`) for automation and scripting. This is ideal for integrating Claude into CI/CD pipelines or for large-scale migrations. Headless mode does not persist between sessions, so you have to trigger it each session.
-- **Pipelining**: Claude can be integrated into existing data/processing pipelines by piping data in and out. For example, `cat build-error.txt | claude -p 'concisely explain the root cause of this build error' > output.txt`. JSON output can provide structured data for easier automated processing.
-- **Commit Often**: Frequently commit changes within your repository to maintain a granular version history. Claude can draft commit messages automatically by looking at your changes and recent history. You can also add pre-commit checks to your repo to ensure code quality before Claude commits changes.
-
-### CI Safety Checklist
-
-- [ ] Run on least‑privilege: set `permissions:` per job (e.g., `pull-requests: write`; avoid `contents: write` unless needed).
-- [ ] Gate destructive tools: configure `allowed_tools` and block risky commands in hooks or workflow steps.
-- [ ] Require tests before PR creation: run unit, lint, and type checks; fail fast on errors.
-- [ ] Timebox and budget: set `timeout_minutes` and limit turns/iterations.
-- [ ] Secrets: use `${{ secrets.* }}` only; never echo secrets or write them to artifacts.
-- [ ] Logs: redact tokens; attach succinct logs to PR comments, not raw traces.
-- [ ] Human in the loop: require review/approval before merging AI‑authored changes.
-
-### AI Code Review Checklist
-
-- [ ] Scope: Does the diff match the stated goal? Anything unexpected?
-- [ ] Tests: Are there new/updated unit tests? Do all tests pass?
-- [ ] Types & lint: Typecheck/lint clean? Any any/ts‑ignore or disabled rules?
-- [ ] Security: Inputs validated? Safe file/FS/net operations? Secrets untouched?
-- [ ] Performance: Any obvious N+1, synchronous I/O in hot path, missing memoization/caching?
-- [ ] API contracts: Request/response shapes and error handling consistent? OpenAPI/typing updated?
-- [ ] Docs: Changelog/README/CLAUDE.md updated if behavior changed?
-
-## Example Use Cases
-
-Claude Code GitHub Actions can assist with a variety of development tasks:
-
-- **Turning Issues into Pull Requests (PRs)**: Claude can analyze an issue description, write the code to implement the feature or fix the bug, and create a PR for review, all with a simple `@claude implement this feature` comment.
-- **Automated Code Review**: Claude can be configured to review PRs automatically when they are opened or updated. It can identify potential bugs, style issues, and adherence to project standards, then add comments to the PR. This provides an AI code review on demand.
-- **Fixing Bugs Quickly**: Claude can locate bugs, implement fixes, and create PRs for the changes. This works best for small, self-contained bugs.
-- **Issue Triage and Categorization**: Claude can inspect new issues, determine their nature (e.g., bug, feature request), and automatically apply appropriate labels.
-- **Large-Scale Code Migrations/Refactoring**: For sweeping changes across a codebase, Claude Code can assist by searching for usages of old APIs, editing files, running tests to verify, and iterating until the task is complete.
-- **Automated Release Note Generation**: Claude can generate human-readable summaries for release notes by processing a list of commits.
-- **Linting and Type Checking**: Claude can be used as a linter, identifying issues like typos, stale comments, or misleading names, and can also be integrated into pre-commit checks to enforce code quality.
-
-## Troubleshooting
-
-If Claude is not responding to `@claude` commands in GitHub Actions, you should:
-
-- Verify the GitHub App is installed correctly.
-- Check that workflows are enabled.
-- Ensure the API key is correctly set in repository secrets.
-- Confirm the comment actually contains `@claude` (not `/claude`).
+An agent-assisted pull request is not done when the bot posts a comment. It is
+done when the diff is reviewed, comments are resolved, continuous integration is
+green, and the branch still merges cleanly with the base branch.

--- a/courses/ai-development/interacting-with-cursor.md
+++ b/courses/ai-development/interacting-with-cursor.md
@@ -1,91 +1,86 @@
 ---
-title: Interacting with Cursor's AI Features
+title: Interacting with Cursor
 description: >-
-  Master Cursor's Tab completion, Inline Edit, AI Chat, and Agent modes for
-  effective AI-powered coding.
-modified: 2026-03-17
+  Use Cursor's inline editing, chat, agent, plan, cloud, and terminal workflows
+  with clear approval boundaries.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Cursor AI is an AI-powered code editor built on the VS Code foundation, designed to act as an AI pair programmer by integrating directly into your coding environment and understanding your entire codebase contextually. It aims to make coding smarter, faster, and safer.
+[Cursor](https://cursor.com) gives you several interaction surfaces. They are not
+different skins on the same prompt. Each one has a different blast radius.
 
-To effectively leverage Cursor, it's essential to understand its core AI interaction modes: Tab completions, Inline Edit (`Cmd/Ctrl+K`), and AI Chat (`Cmd/Ctrl+L`), as well as the more advanced Agent mode (`Cmd/Ctrl+I`). Each is best suited for different use cases and types of interactions.
+## Inline Edit
 
-Here’s a guide to understanding and utilizing each:
+Use inline edit for surgical changes to selected code. Select the relevant code,
+press `Cmd+K` or `Ctrl+K`, and ask for the change you want. This is the right
+tool when the surrounding file already tells the story.
 
-## Tab (Predictive Autocomplete and Smart Rewrites)
+Good inline prompts are narrow:
 
-Cursor's **Tab** feature is an advanced, predictive autocomplete system. It goes beyond single-word suggestions, offering multi-line edits and automatically correcting minor errors or typos (known as "smart rewrites"). This feature is powered by custom models that anticipate the developer's intent based on recent changes and surrounding code context. Users often describe it as "magic" due to its uncanny ability to predict their next steps, significantly contributing to a "flow state" in coding.
+```text
+Convert this function to return a discriminated union.
+Do not change the call sites.
+```
 
-### How to Best Take Advantage
+If the request needs repository search, tests, or multiple files, move up to the
+agent.
 
-- **Accept Multi-line Suggestions:** While typing, observe the grayed-out text suggestions. Hitting `Tab` will accept these multi-line proposals, allowing you to quickly complete functions, loops, or entire code blocks.
-- **Trust Smart Rewrites:** Allow Cursor to automatically correct typos and minor errors, enabling you to type more freely without sacrificing accuracy.
+## Chat
 
-### Best Use Cases
+Chat is useful for questions, debugging, and design discussion. Cursor can use
+open files, selected code, mentioned files, documentation references, images, and
+web context. Ask for citations when you need to understand where an answer came
+from.
 
-- **Boilerplate Code:** Quickly generating standard project structures, configuration files, or common patterns.
-- **Repetitive Tasks:** Completing common coding patterns like React hooks, SQL queries, or test stubs.
-- **Maintaining Flow:** It's ideal for day-to-day coding to accelerate typing and minimize interruptions, helping you code at the "speed of thought".
+```text
+Explain how authentication is wired in this project.
+Use file references and do not propose changes yet.
+```
 
-## Inline Edit (`Cmd/Ctrl+K`)
+Use Chat when the next best step is understanding. Use Agent when the next best
+step is changing code.
 
-The **Cmd/Ctrl+K** shortcut is a primary tool for "surgical, in-place code modifications". It offers two distinct functions depending on whether code is selected. The proposed changes are displayed as a clear, color-coded diff view (red for deletions, green for additions) before you accept them, giving you full control. It is generally faster for working with selected code compared to the Agent mode.
+## Agent Mode
 
-### How to Best Take Advantage
+Agent mode opens from the side pane with `Cmd+I` or `Ctrl+I`. It can search the
+repository, read files, edit files, run shell commands, use configured MCP tools,
+open a browser, and ask clarifying questions while continuing with work it can
+already do.
 
-    - **Generate New Code (no selection):** When no code is selected, pressing `Cmd/Ctrl+K` opens a prompt to generate entirely new code. Describe the desired function, class, or HTML structure in natural language. Provide boilerplate or constraints like naming conventions or return types in the prompt.
-    - **Edit/Refactor Existing Code (with selection):** Select a specific block of code and press `Cmd/Ctrl+K` to issue instructions for editing or refactoring that snippet.
-    - **Review Diffs Carefully:** Always review the diff preview before applying changes, as the AI might add or modify more than expected.
-    - **Iterative Refinement:** If the initial output isn't perfect, refine your prompt with more details or chain prompts (e.g., generate code, then ask to "rewrite this using concurrency primitives").
+Give the agent a verifiable finish line:
 
-### Best Use Cases
+```text
+Add validation for invalid invite tokens.
+Write the failing test first, implement the fix, then run the targeted test and
+the repository lint command. Stop if either command fails for an unrelated reason.
+```
 
-- **Targeted Modifications:** Converting a function to be asynchronous, adding error handling, or translating code to another language.
-- **Refactoring Specific Snippets:** Improving the structure or efficiency of a small code block.
-- **Quick Code Generation:** Creating new, self-contained code blocks or functions from a natural language description.
+Cursor creates checkpoints during agent work, so you can inspect or roll back a
+bad turn. Checkpoints are a recovery feature. They are not a substitute for
+reviewing diffs.
 
-## AI Chat (`Cmd/Ctrl+L`) and Agent Mode (`Cmd/Ctrl+I`)
+## Plan and Ask Modes
 
-The **Cmd/Ctrl+L** command opens the main AI chat panel, which functions as a "project-aware collaborator". This interface can access the context of currently open files and be instructed to consider the entire codebase. As of late February 2025, Agent mode often becomes the default chat mode.
+Plan mode is for research before edits. Ask mode is for answers without action.
+Use Plan mode when a request has multiple reasonable designs, unknown files, or
+security implications.
 
-**Agent Mode (Cmd/Ctrl+I)** is designed for complex, multi-file tasks where you describe a high-level goal, and the AI plans and executes the necessary changes across the entire project. It allows for "agentic" or "autonomous" execution, where the AI can create/modify files, run terminal commands, and perform semantic code searches. By default, the agent will ask for user approval before executing commands, keeping you in control.
+A useful plan request names the decision you need:
 
-### How to Best Take Advantage
+```text
+Plan the smallest change that adds Slack notifications to failed imports.
+Compare the two likely implementation paths and list the files each path touches.
+Do not edit files.
+```
 
-- **Leverage Codebase Context:** By default, the chat is aware of the current file. For broader questions, use the "Codebase" button or type `@codebase` to include the entire repository's semantic index in the context. This dramatically improves accuracy for architecture-level questions.
-- **Surgical Context Provisioning:** Use the `@` symbol to precisely provide context:
-  - `@Files` and `@Folders`: Reference specific files (e.g., `@src/components/Button.tsx`) or entire directories (e.g., `@src/api/v1`).
-  - `@Code` and `@Symbols`: Focus on specific functions, classes, or variables (e.g., `@useUserData hook`).
-  - `@Docs` and `@Web`: Extend the AI's knowledge beyond local code by referencing external documentation or performing live web searches. You can even add your own documentation by URL for Cursor to index.
-  - `@Git`, `@Linter Errors`, `@Past Chats`: Provide specific context like commit history, diffs, linter errors, or previous conversations.
-- **Define Project-Wide Rules with `.cursor/rules`:** Create a `.cursor/rules.mdc` file at your project's root to define consistent code style, language preferences, and quality guidelines that Cursor will always follow. Global rules can also be set in Cursor settings.
-- **Utilize Notepads:** Create "supercharged sticky notes" to store frequently used prompts, file references, and explanations. These can be referenced using `@MyNotepad` to include their content, streamlining repetitive workflows.
-- **Break Down Problems (Plan-and-Act):** For complex tasks, ask the AI to first provide a step-by-step plan and reasoning, then instruct it to execute the plan after your review. This helps avoid flawed strategies.
-- **Iterative Refinement:** Treat interactions as a dialogue. Start broad, then refine prompts based on the AI's output, providing specific feedback.
+## Cloud and Terminal Workflows
 
-### Best Use Cases
+Cloud Agents run in isolated cloud environments and are useful for tasks that can
+continue away from your laptop. Automations run Cloud Agents from schedules and
+events. The `agent` command line interface is useful for terminal-native review,
+scripts, and remote sessions.
 
-- **Brainstorming and High-Level Questions:** Discussing architecture, understanding complex codebases, or exploring solutions.
-- **Larger Code Generation:** Generating more complex code segments that can then be applied directly to the editor.
-- **Multi-File Refactoring:** Tasks like renaming variables across the entire project, moving logic, or performing semantic search-and-edit operations.
-- **Feature Implementation:** Delegating tasks like building a new user registration page or adding an API endpoint, where the agent needs to create and modify multiple files.
-- **Debugging:** Analyzing error messages, stack traces, suggesting fixes, and even instrumenting code with logs.
-- **Test-Driven Development (TDD):** Instructing the AI to write tests first, then the code, and iteratively fix until tests pass.
-- **Automated Linting Fixes:** With "Iterate on Lints" enabled, the agent can automatically run linters and attempt to fix violations.
-- **Git Integration:** Generating descriptive Git commit messages based on staged changes, or assisting with code reviews by reviewing pending changes.
-
-## Comparison and Best Practices
-
-Cursor's AI features are designed to allow you to shift from typing every line of code to directing the AI, much like a project manager directs a team.
-
-- **Tab (Autocomplete)** is your **fast, always-on assistant** for micro-level completion and error correction, speeding up your typing without explicit prompting.
-- **Inline Edit (Cmd/Ctrl+K)** is your **precision tool** for targeted code generation, modification, or refactoring within a selected area or current file. It's direct and provides immediate visual feedback.
-- **AI Chat (Cmd/Ctrl+L)** and **Agent Mode (Cmd/Ctrl+I)** serve as your **collaborative partner and project orchestrator**. They are for broader conversations, understanding complex codebases, and delegating multi-step, multi-file tasks across the entire project. While Cmd+L opens the conversational _interface_, Cmd+I is explicitly for initiating agentic _tasks_ where the AI can plan and execute.
-
-## General Best Practices across All Modes
-
-- **Review All AI-Generated Code:** Never blindly trust AI. Always **review the diffs** before committing changes.
-- **Use Version Control:** Experiment in branches and **commit early and often**. Cursor's tight Git integration can even generate commit messages for you.
-- **Prompt in Small Chunks:** Avoid overwhelming the AI with vague or massive prompts. Break down large requests into smaller, verifiable steps.
-- **Manage Context:** Keep conversation history short and focused, restarting if the AI gets stuck in a loop. Leverage `@` symbols and `.cursor/rules` to provide the most precise context.
+These surfaces are powerful because they can act while you are not staring at
+the editor. That is also the risk. For cloud or terminal work, make permissions,
+verification commands, and failure signals explicit in the prompt.

--- a/courses/ai-development/mcp-for-claude-code-and-cursor.md
+++ b/courses/ai-development/mcp-for-claude-code-and-cursor.md
@@ -1,79 +1,77 @@
 ---
-title: Popular MCP Servers for Claude Code and Cursor
+title: MCP in Claude Code and Cursor
 description: >-
-  Explore essential MCP servers for knowledge, databases, web automation, and
-  specialized development tasks.
-modified: 2026-03-17
+  Compare MCP configuration, transports, OAuth, permissions, and security review
+  in Cursor and Claude Code.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-Model Context Protocol (MCP) is an **open standard protocol** that enables different AI models and tools to **talk to one another seamlessly**. It functions like a universal connector, standardizing how Large Language Models (LLMs) and AI agentic frameworks interact with external systems. MCP servers are components within this ecosystem that **expose capabilities, tools, and data sources** through the protocol. They run as independent processes and communicate with AI clients via transport protocols like stdio, Server-Sent Events (SSE), or Streamable HTTP. These servers allow AI agents to **access necessary endpoints, data sources, and business tools more efficiently**, replacing the need for custom integration points for each data source.
+[Cursor](https://cursor.com/docs/mcp) and
+[Claude Code](https://code.claude.com/docs/en/mcp) both support MCP, but their
+configuration and permission models are not identical.
 
-MCP servers are **highly beneficial** when working with Cursor or Claude Code because they **stream external knowledge** like files, databases, design specs, and issue trackers directly into the LLM's "context window," enhancing performance and enabling more dynamic interactions. They also allow for **direct integration** with external services and APIs, offering a streamlined workflow and eliminating the friction of setting up local servers.
+## Configuration Locations
 
-## Knowledge & Documentation Servers
+Cursor uses JSON configuration files:
 
-### [Context 7 by Upstach](https://github.com/upstash/context7)
+```text
+.cursor/mcp.json
+~/.cursor/mcp.json
+```
 
-Addresses the common problem where AI coding assistants like Cursor and Windsurf struggle with writing code for newer APIs or packages, leading to hallucinations or outdated solutions. Context 7 pulls **up-to-date documentation and code examples** from its own libraries or websites, ingesting them directly into the app's context to generate correct solutions much faster. This reduces frustration and speeds up development, especially given the rapid pace of change in the AI space. It's described as a "super smart librarian" for Cursor.
+Claude Code can use the command line interface and project configuration:
 
-### [Notion MCP](https://developers.notion.com/docs/mcp)
+```bash
+claude mcp add
+claude mcp list
+claude mcp get
+claude mcp remove
+```
 
-Allows AI assistants to **interact directly with your Notion pages and databases**, enabling tasks like creating documentation (PRDs, tech specs), searching content, managing tasks, building reports, and planning campaigns. It provides **live access to documents** without manual copying or syncing, making workflows cleaner and more reliable. It's called a "killer" MCP server and is "optimized for AI" with efficient data formatting.
+Project-scoped Claude Code servers can also live in `.mcp.json`. Prefer
+project-scoped configuration when the server is part of how the repository is
+developed. Prefer user-scoped configuration for personal tools.
 
-## Code & DevOps Servers
+## Transports
 
-### [GitHub MCP](https://github.com/github/github-mcp-server)
+Both tools support local `stdio` servers and remote servers. For new remote
+servers, prefer HTTP where available. Claude Code still supports SSE, but its
+documentation treats SSE as deprecated. Do not design new teaching material
+around SSE unless you are explicitly covering migration.
 
-The **official GitHub MCP server**, it provides seamless integration with GitHub's issue tracking system and APIs, allowing LLMs to interact with GitHub issues, list pull requests, create branches, analyze code, and automate various repository-centric workflows. It offers frictionless setup (remote hosting) and auto-updates.
-repo-centric workflows".
+## OAuth and Login
 
-### [Desktop Commander](https://desktopcommander.app/)
+Cursor supports OAuth for remote MCP servers, including a Cursor callback flow.
+Claude Code supports OAuth flows from the `claude mcp` command line interface,
+including `claude mcp login` and `claude mcp logout`.
 
-Gives AI the ability to **read, write, and use command lines directly on your machine**, allowing Claude to modify your computer or code for you. It's described as "extremely powerful" for native desktop interaction.
+OAuth makes the integration easier for humans and more serious for security. The
+server can now act with a user's delegated access.
 
-## Databases & Vector Memory Servers
+## Permissions
 
-### Supabase MCP
+Cursor generally asks before MCP tool calls unless a run mode or setting changes
+that behavior. Claude Code routes MCP calls through its permission system, where
+allow, ask, and deny rules can be scoped by tool.
 
-The official Supabase server that connects AI tools to your Supabase projects, allowing them to **manage tables, fetch configuration, and query data**. It supports secure, read-only modes and project scoping. It can handle tasks like designing tables with migrations, fetching data, running reports, and spinning up new Supabase projects. It uses JWT-based authentication for cloud safety.
+For both tools, the safest pattern is:
 
-### [Postgres MCP Pro](https://github.com/crystaldba/postgres-mcp)
+- Use read-only tools by default.
+- Keep write tools narrow.
+- Name the server and tool in the prompt when the action is important.
+- Review generated pull requests or external changes before treating them as
+  complete.
 
-Provides **configurable read/write access and performance analysis** for PostgreSQL databases. It allows AI agents to explore database schemas with granular row-level filters and offers an optional read-only mode, enabling safe database interactions. It includes tools for index tuning, explain plans, health checks, and secure SQL execution. It combines LLMs with "classical optimization algorithms" for reliable and flexible database tuning.
+## Security Review Checklist
 
-## Web Automation & Search Servers
+Before enabling an MCP server for a repository or team, answer these questions:
 
-### [Playwright MCP](https://github.com/microsoft/playwright-mcp)
+- Who maintains the server?
+- Which secrets does it receive?
+- Which external systems can it read or write?
+- Does it log prompts, tool arguments, or returned data?
+- Can the agent use it from cloud environments?
+- Can a pull request modify the configuration to add a more powerful server?
 
-Provides **browser automation capabilities**, allowing LLMs to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models. It's fast, lightweight, and LLM-friendly. It's particularly useful for **testing web applications** running locally.
-
-### [Brave Search](https://brave.com/search/api/guides/use-with-claude-desktop-with-mcp/)
-
-Provides web search capabilities for AI agents. It's highlighted for its **AI-centric web search**, summarizing information perfectly for LLMs, and finding supplemental resources like community forum posts that might not be in a knowledge base.
-
-### [Firecrawl MCP](https://www.firecrawl.dev/mcp)
-
-An open-source server that can **grab text, images, or data from websites** and organize it into formats like JSON or Markdown for Cursor to use. It can scan at high speeds and is great for research or content projects.
-
-### [Exa Search](https://docs.exa.ai/examples/exa-mcp)
-
-A programmatic search tool that helps in finding **real statistics** and solutions to recurring issues or bugs. It offers better development experience, results, and features compared to Perplexity, and enables strong control over the context provided to the system for more precise and accurate AI outputs.
-
-## Specialized & Emerging Servers
-
-### [Magic UI MCP](https://magicui.design/docs/mcp)
-
-These design-oriented MCPs help **integrate UI components and libraries** into applications, especially useful for landing page design. They can translate designs into fully coded applications more effectively, improving code generation fidelity and reducing LLM usage by minimizing guesswork.
-
-### [Pieces](https://pieces.app/features/mcp)
-
-Acts as a **shared memory among different LLMs**, watching user activity in tools like Claude, Gemini AI Studio, Perplexity, and Cursor, and saving contextual snippets to a database for later recall. This allows for a shared memory pool across various AI coding assistants.
-
-### [Sentry MCP](https://docs.sentry.io/product/sentry-mcp/)
-
-Provides a **secure way to bring Sentry's full issue context** into MCP-leveraging systems. It allows access to Sentry issues and errors, searching for errors in specific files, querying projects, and even invoking Seer for automated issue fixes. It is remotely hosted (preferred) and supports OAuth.
-
-### [Zapier](https://zapier.com/mcp)
-
-Connects AI agents to **8,000+ apps instantly**, allowing for broad automation capabilities across various services.
+MCP is not just context. It is capability.

--- a/courses/ai-development/mcp.md
+++ b/courses/ai-development/mcp.md
@@ -39,9 +39,10 @@ marks SSE as deprecated.
 
 ## Authentication
 
-Remote MCP servers can use OAuth. That makes the security model more like a
-first-party application integration than a local editor extension. Review the
-scopes, callback URL, and token storage before enabling a server for a team.
+Remote MCP servers can use [OAuth](https://oauth.net/2/). That makes the
+security model more like a first-party application integration than a local
+editor extension. Review the scopes, callback URL, and token storage before
+enabling a server for a team.
 
 Local servers can also leak secrets through environment variables, logs, and tool
 arguments. "It runs on my machine" is not a security review.

--- a/courses/ai-development/mcp.md
+++ b/courses/ai-development/mcp.md
@@ -1,51 +1,63 @@
 ---
-title: Understanding Model Context Protocol (MCP)
+title: Model Context Protocol
 description: >-
-  Learn how MCP enables AI tools to connect with external systems for enhanced
-  context and capabilities.
-modified: 2026-03-17
+  Understand MCP as the tool and data layer for coding agents, including
+  transports, permissions, OAuth, tool interfaces, and security review.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-[**Model Context Protocol (MCP)** ](https://modelcontextprotocol.io/overview) is an **open standard protocol** that enables different AI models and tools to **talk to one another seamlessly**. It functions like a universal connector, similar to how USB-C replaced various chargers and connectors, standardizing how Large Language Models (LLMs) and AI agentic frameworks interact with external systems. Essentially, MCP creates a common way for AI tools to communicate.
+[Model Context Protocol](https://modelcontextprotocol.io/) is a standard way for
+agents to connect to tools and data sources. Think of it as the adapter layer
+between an agent and the systems it needs to inspect or change.
 
-**MCP servers** are components within this ecosystem that **expose capabilities, tools, and data sources** through the MCP. They run as independent processes and communicate with AI clients via transport protocols like stdio, Server-Sent Events (SSE), or Streamable HTTP. These servers allow AI agents to **access necessary endpoints, data sources, and business tools more efficiently**, replacing the need for custom integration points for each data source.
+An MCP server might expose:
 
-**Why MCP servers are helpful when working with Cursor or Claude Code:**
+- Database queries.
+- Browser automation.
+- Issue tracker actions.
+- Design files.
+- Internal documentation search.
+- Deployment status.
+- Custom product tools.
 
-MCP servers significantly enhance the capabilities of AI coding assistants like Cursor and Claude Code by providing them with **external context and tools**.
+The agent does not need bespoke code for each integration. It reads the server's
+tool list, asks for permission when required, and calls the tool with structured
+arguments.
 
-## Expanded Context and Reduced Hallucination
+## Transports
 
-- Traditional AI development environments often struggle with writing code for newer APIs or packages, leading to hallucinations of non-existent functions or outdated solutions. Built-in documentation in tools like Cursor can also be poor at indexing or scraping relevant context.
-- MCP servers, such as **Context 7**, solve this by **pulling up-to-date documentation and code examples from their own libraries or websites**, ingesting them into the app's context to generate correct solutions much faster. This means less frustration and a quicker time to reaching correct solutions, especially given the rapid development in the AI space.
-- Similarly, **Exa Search by Exa AI** provides programmatic search capabilities to gather real statistics or find solutions to recurring issues, ensuring AI outputs are more precise and accurate by having strong control over the context provided to the system.
+Current agent tools commonly support:
 
-## Seamless Integration and Streamlined Workflows
+- `stdio` for local servers launched as subprocesses.
+- `http` for remote servers.
+- `sse` for older remote servers.
 
-- MCP enables Cursor to **connect directly to external tools and data sources**, meaning you don't have to repeatedly explain your project structure.
-- For Claude Code, MCP allows direct integration with external services and APIs, offering a **streamlined workflow for developers** and **eliminating the friction of setting up local MCP servers** to work with an existing toolchain. Claude Code supports stdio, SSE, and streamable HTTP servers for real-time communication.
-- Tools like **Notion MCP** allow AI assistants to interact directly with your Notion pages and databases, enabling tasks like creating documentation (PRDs, tech specs), searching content, managing tasks, building reports, and planning campaigns.
-- **Figma Dev Mode MCP server** provides AI models with direct access to design data, such as precise figures, color shades, variables, components, and layout data, to more effectively translate designs into fully coded applications. This significantly improves code generation fidelity, reduces LLM usage by minimizing guesswork, and ensures generated code aligns with design intent and existing codebases.
-- **GitHub MCP** provides integration with GitHub's issue tracking system and APIs, allowing LLMs to interact with GitHub issues, list pull requests, create branches, and push files, automating various repo-centric workflows.
-- **Linear MCP** lets agents triage issues, update cycle status, and create tasks directly from chat, providing a simple and secure way to access Linear data.
+For new remote integrations, prefer HTTP when the client supports it. Treat SSE
+as a compatibility path, especially in Claude Code where the documentation now
+marks SSE as deprecated.
 
-## Improved System Architecture and Maintainability
+## Authentication
 
-- MCP enforces a **strict separation of concerns** in agentic AI systems, where **agents orchestrate and tools execute**. This means agents don't perform I/O, parsing, or direct database interactions; instead, they declaratively invoke external MCP tools for these tasks.
-- This architecture leads to decoupled logic (agents can be tested independently of tool implementations), reusable tooling across workflows, and backend-agnostic execution (you can swap MCP servers without rewriting agent logic).
-- **Postgres MCP Pro** allows agents to explore database schemas with granular row-level filters and optional read-only mode, enabling safe database interactions. Similarly, **Supabase MCP** connects AI tools to Supabase projects for tasks like managing tables, fetching config, and querying data, with security features like read-only mode and project scoping.
-- **Qdrant MCP** and **Weaviate MCP** act as semantic memory layers or vector stores, allowing AI agents to store and retrieve memories (code snippets, documentation) and perform semantic searches across codebases, which is crucial for Retrieval-Augmented Generation (RAG) and maintaining context awareness during development.
+Remote MCP servers can use OAuth. That makes the security model more like a
+first-party application integration than a local editor extension. Review the
+scopes, callback URL, and token storage before enabling a server for a team.
 
-## Advanced Capabilities and Automation
+Local servers can also leak secrets through environment variables, logs, and tool
+arguments. "It runs on my machine" is not a security review.
 
-- **Clawed Taskmaster** (Sean Kochel's favorite tool) takes an existing feature specification document, translates it into a Product Requirements Document (PRD), and generates intricately planned, granular tasks to execute an entire project step by step. It also self-corrects and updates the task list as the solution is built, enabling developers to give meticulous instructions to systems like Cursor to build functional applications.
-- **Knowledge Graph Memory by Anthropic** helps AI systems retain valuable memories across different projects or coding sessions, store relationships between data, and dynamically update prompts based on past events, making complexity management easier.
-- **Magic UI MCP and 21st Devs Magic MCP** are design-oriented servers that help integrate UI components and libraries into applications, especially useful for landing page design.
-- **Desktop Commander** gives AI the ability to read, write, and use command lines directly on your machine, enabling it to modify your computer or code for you.
-- **TestSprite MCP Server** allows AI agents to write and debug test automation code, generate test plans and results, and even fix application code by understanding the application and its context locally.
-- **Pieces** acts as a shared memory among different LLMs, watching user activity in tools like Claude, Gemini AI Studio, Perplexity, and Cursor, and saving contextual snippets to a database for later recall.
-- **Browser tools** or **Browserbase MCP** allow agents to perform browser-level actions and automations, useful for debugging web-based applications or scraping data.
-- **Brave Search**, **Tavily**, and **Firecrawl** provide robust web search and scraping capabilities, allowing AI agents to ground their answers in real-time internet data and pull in the latest documentation or community forum posts.
+## Tool User Interfaces
 
-**Security Considerations:** While highly beneficial, it's crucial to **verify the source** of MCP servers, **review permissions** they request, **limit API keys** to minimal required permissions, and **audit their code** for critical integrations. MCP servers can access external services and execute code on your behalf, so understanding their functions before installation is vital. For sensitive data, it's recommended to run servers locally with stdio transport, use environment variables for secrets, and consider isolated environments. Additionally, precautions against prompt injection attacks are necessary, and many MCP clients, including Cursor, ask for manual approval before executing tool calls.
+Some MCP integrations can return richer user interfaces, not just text. Cursor
+documents MCP Apps and tool user interfaces as part of its MCP support. That is
+powerful for workflows where the agent needs a human to inspect structured
+results, choose an option, or confirm an action.
+
+The same rule applies: the prettier the tool surface, the more important the
+underlying permission boundary becomes.
+
+## Course Rule
+
+Use MCP when the agent needs authoritative external context or a real action. Do
+not use MCP to hide a shell script that should live in the repository, and do not
+enable broad write access without a review path.

--- a/courses/ai-development/notebooklm.md
+++ b/courses/ai-development/notebooklm.md
@@ -3,7 +3,7 @@ title: Using NotebookLM for AI Development
 description: >-
   Leverage Google's NotebookLM for research, documentation analysis, and
   knowledge synthesis in AI projects.
-modified: 2026-03-17
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
@@ -61,7 +61,8 @@ For engineering work, NotebookLM shines as a “source-of-truth synthesizer” f
 ## Integrating with Cursor and Claude Code
 
 - **Create a “brief” for agents:** Use NotebookLM to produce a concise system overview (constraints, conventions, key files) and paste it into `.cursor/rules` or `CLAUDE.md`.
-- **Notepads/commands:** Turn NotebookLM's checklists and procedures into Cursor Notepads or Claude slash commands for repeatable workflows.
+- **Rules and skills:** Turn NotebookLM's checklists and procedures into Cursor Rules,
+  Cursor Skills, or Claude Code Skills for repeatable workflows.
 - **Context handoff:** When asking an AI coding tool to implement changes, include the brief plus links back to exported NotebookLM docs to keep work grounded.
 
 > [!NOTE] Grounding improves reliability.

--- a/courses/ai-development/openai-codex.md
+++ b/courses/ai-development/openai-codex.md
@@ -3,7 +3,7 @@ title: Understanding OpenAI Codex for Code Generation
 description: >-
   Explore OpenAI Codex's AI-powered code generation capabilities and autonomous
   software engineering features.
-modified: 2026-03-17
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
@@ -59,7 +59,7 @@ Codex is engineered to handle a diverse range of tasks, including:
 ## Workflow and Interaction
 
 - Developers access Codex through a dedicated section in the ChatGPT sidebar. They connect a GitHub repository or organization, and Codex filters repositories they have access to.
-- Tasks can be assigned by typing a prompt and initiating "Code" for file mutations and patches, or "Ask" for codebase questions. Codex supports **parallel processing**, allowing multiple tasks to run simultaneously. Power users can comfortably run up to **60 concurrent instances per hour** during the research preview.
+- Tasks can be assigned by typing a prompt and initiating "Code" for file mutations and patches, or "Ask" for codebase questions. Codex supports **parallel processing**, allowing multiple tasks to run simultaneously. Older course recordings mentioned research-preview concurrency limits; treat those as historical product context, not current guidance.
 - Codex provides **verifiable evidence of its actions** through citations of terminal logs and test outputs. Once a task is completed, it commits its changes within its environment and allows users to open a GitHub pull request or integrate changes locally.
 - **Guidance via AGENTS.md**: Developers can guide Codex's behavior using `AGENTS.md` files within the repository. These files serve as a communication channel, informing Codex how to navigate the codebase, which commands to run for testing, and how to adhere to project coding standards. Instructions in `AGENTS.md` take precedence based on nesting depth, though direct user prompts can override them.
 - **Prompting Habits**: Effective prompts are clear and detailed, similar to assigning work to a junior engineer, focusing on clear goals, success criteria, and testing instructions. Providing existing tests is encouraged, as Codex optimizes for passing them. It's recommended to chunk work into many narrow tasks for parallelism.

--- a/courses/ai-development/plan-implement-verify.md
+++ b/courses/ai-development/plan-implement-verify.md
@@ -1,94 +1,66 @@
 ---
-title: Plan-Implement-Verify Pattern
+title: The Plan → Implement → Verify Prompt Pattern
 description: >-
-  Structure AI coding tasks using the Plan-Implement-Verify pattern for better
-  results and fewer errors.
-modified: 2026-03-17
+  Structure agentic development work as a bounded loop with explicit plans,
+  implementation scope, verification commands, and failure signals.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-When you ask AI to write code immediately, it makes assumptions—often wrong ones. The **Plan → Implement → Verify** pattern forces AI to:
+The simplest reliable agent workflow is still:
 
-1. **Think through requirements** before writing code
-2. **Identify dependencies** and potential issues early
-3. **Create testable success criteria** upfront
-4. **Build incrementally** with verification at each step
+1. Plan.
+2. Implement.
+3. Verify.
 
-## Phase 1: Plan
+The point is not ceremony. The point is making the agent show its understanding
+before it changes files and making success mechanically checkable afterward.
 
-AI analyzes the request and creates a structured approach:
+## The Pattern
 
-- Breaks down the task into steps
-- Identifies required files and dependencies
-- Considers edge cases and error handling
-- Defines success criteria
+```text
+Goal:
+Add validation for expired invite tokens.
 
-## Phase 2: Implement
+Plan:
+First inspect the token validation path and the closest tests. Summarize the
+smallest implementation path before editing.
 
-AI executes the plan systematically:
+Implement:
+Write the failing regression test first. Then make the smallest production
+change that passes it.
 
-- Follows the planned steps in order
-- Creates/modifies files as specified
-- Implements error handling
-- Writes tests alongside code
+Verify:
+Run bun test:unit -- src/lib/server/invitations.test.ts and bun run lint.
 
-## Phase 3: Verify
-
-AI confirms the implementation works:
-
-- Runs tests to ensure correctness
-- Checks for type errors or linting issues
-- Validates against success criteria
-- Identifies any remaining issues
-
-## Formatting and an Example
-
-It honestly doesn't matter too much, I typically use Markdown checklists because I am lazy, but you can use YAML too if that makes you happier.
-
-```yaml
-Task: Add a health check endpoint to the Express server
-
-Steps:
-  1. Create basic Express server setup
-     - File: src/server.ts
-     - Set up Express app with TypeScript
-     - Configure basic middleware
-
-  2. Create health check route
-     - File: src/routes/health.ts
-     - Implement GET /health endpoint
-     - Return status, timestamp, uptime
-
-  3. Add types for response
-     - File: src/types/health.ts
-     - Define TypeScript interface
-
-  4. Create tests
-     - File: tests/health.test.ts
-     - Test endpoint returns 200
-     - Validate response structure
-
-  5. Update package.json scripts
-     - Add dev script
-     - Add test script
-
-Success Criteria:
-  - GET /health returns 200 status
-  - Response includes: status, timestamp, uptime
-  - TypeScript compiles without errors
-  - Tests pass
+Stop:
+If a command fails for an unrelated reason, stop and report the command, output,
+and likely cause instead of changing unrelated files.
 ```
 
-## What Makes a Good Plan?
+This works in [Cursor](https://cursor.com/) Agent mode, Cursor Cloud Agents,
+[Claude Code](https://code.claude.com/docs/en/overview), and most command line
+agent workflows.
 
-- **Specific files:** Names the exact files to create/modify
-- **Clear sequence:** Steps build on each other logically
-- **Test inclusion:** Tests are part of the plan, not an afterthought
-- **Success criteria:** Measurable outcomes defined
+## Why It Works
 
-Weak plans—on the other hand—have these qualities:
+Planning catches misunderstandings while the cost is still low. Implementation
+keeps the agent inside the task. Verification turns "looks good" into a binary
+check.
 
-- Vague steps like "implement the feature"
-- Missing file locations
-- No consideration of testing
-- Unclear dependencies between steps
+The stop condition matters as much as the success condition. Without it, agents
+will often route around failures by editing adjacent code, weakening tests, or
+claiming partial success.
+
+## When to Skip the Full Pattern
+
+For a tiny inline edit, a full plan is overkill. Use the pattern when the task:
+
+- Touches more than one file.
+- Has security, data, or user-facing risk.
+- Requires tests or generated artifacts.
+- Could be solved in more than one reasonable way.
+- Will run in a cloud, command line, or automated context.
+
+If you cannot name the verification command, you probably do not have a complete
+task yet.

--- a/courses/ai-development/referencing-files-in-claude-code.md
+++ b/courses/ai-development/referencing-files-in-claude-code.md
@@ -1,70 +1,65 @@
 ---
-title: Referencing Files and Resources in Claude Code
+title: Referencing Files in Claude Code
 description: >-
-  Master the @ symbol system in Claude Code to reference files, directories, and
-  MCP resources effectively.
-modified: 2026-03-17
-date: 2025-07-24
+  Reference files, directories, images, imports, and generated context in Claude
+  Code without overloading the session.
+modified: 2026-06-24
+date: 2025-07-29
 ---
 
-In Claude Code—just like in Cursor, the `@` symbol is a powerful mechanism used to **reference files, directories, and even external Model Context Protocol (MCP) resources**, enabling Claude to access and integrate relevant information directly into its context. This feature significantly enhances Claude Code's ability to understand your project, execute tasks, and provide accurate responses by providing it with explicit, structured context.
+[Claude Code](https://code.claude.com/docs/en/overview) can search the
+repository, but explicit file references still help. They tell Claude which
+files define correctness, not just which files happen to be nearby.
 
-## What is `@` Referencing?
+## Use @path References
 
-`@` referencing serves as a shortcut within Claude Code's interactive sessions and custom commands to specify files or resources that Claude should read or consider. Instead of copying and pasting file contents or providing lengthy descriptions, you can simply use the `@` prefix followed by the path or resource identifier. Claude Code will then automatically fetch and include the content of the specified file or resource into its context.
+Use `@` to reference files and directories:
 
-## Syntax for Referencing Files and Directories
+```text
+Read @src/lib/server/invitations.ts and
+@src/lib/server/invitations.test.ts. Add the missing expired-token regression
+test before editing production code.
+```
 
-The basic syntax involves typing `@` followed by the file or directory path:
+Use directories when the pattern matters:
 
-- **Referencing a specific file**: `@path/to/your/file.js`
-  - This will include the **full content** of the file in the conversation context.
-- **Referencing a directory**: `@path/to/your/directory/`
-  - This will provide a **directory listing with file information**, but not the contents of all files within it.
+```text
+Inspect @src/routes/api/ for existing error response conventions.
+```
 
-### Tips for File Path Input
+Do not attach the entire repository when two files and one test define the task.
 
-- File paths can be **relative or absolute**.
-- You can use **tab-completion** in the Claude Code CLI to quickly insert file paths into your prompt, making it easy to reference files or folders anywhere in your repository.
-- You can reference **multiple files** in a single message (e.g., `@file1.js and @file2.js`).
-- You can also **drag and drop a file** directly into the Claude Code window, which will automatically insert its path.
+## Imports in Memory Files
 
-## Referencing MCP Resources
+`CLAUDE.md` can import other files with `@path` references:
 
-Beyond local files, `@` also allows you to reference resources exposed by connected MCP servers. This extends Claude's reach to external services like GitHub issues, databases, or API documentation.
+```md
+@AGENTS.md
+@docs/testing.md
+```
 
-- **Syntax for MCP Resources**: `@server:protocol://resource/path`
-  - **Examples**:
-    - `@github:issue://123`: To analyze GitHub issue #123.
-    - `@docs:file://api/authentication`: To review API documentation.
-    - `@postgres:schema://users`: To compare a PostgreSQL schema.
-- **Functionality**: Resources are automatically fetched and included as attachments when referenced. Claude Code provides tools to list and read MCP resources if servers support them, and these resources can contain various content types (text, JSON, structured data).
+Use imports to keep shared instructions in one place. Do not duplicate long
+guidance across `CLAUDE.md`, rules, and skills.
 
-## How `@` Enhances Context and Memory
+## Images and Non-Code Context
 
-The `@` referencing mechanism is deeply integrated with Claude Code's memory system, particularly with `CLAUDE.md` files:
+Claude Code can work with images and other context when the tool surface
+supports it. Use that for user interface bugs, diagrams, and visual regression
+work, but still tie the request back to files and verification:
 
-- **`CLAUDE.md` Imports**: `CLAUDE.md` files, which serve as persistent, project-specific memory, can directly import additional Markdown files using the `@path/to/import` syntax.
-  - This allows you to **modularize your project's knowledge base**, preventing the main `CLAUDE.md` file from becoming too large and consuming excessive context.
-  - For example, you can link to `docs/testing.md` from your main `CLAUDE.md` for specific testing guidelines.
-  - This also enables **hierarchical memory**, where Claude recursively loads `CLAUDE.md` files from parent directories and on-demand from child directories when you interact with files within them.
-  - This approach is recommended over the deprecated `CLAUDE.local.md` for multi-git worktrees.
-- **Dynamic Context Priming**: When you use `@` to reference a file in a prompt, Claude Code not only includes the file's content but also automatically pulls in any `CLAUDE.md` files present in that file's directory and its parent directories. This ensures that Claude has the most relevant, localized context for the specific task.
+```text
+Compare this screenshot to @src/lib/components/checkout-form.svelte.
+Fix the spacing regression and run the component test.
+```
 
-## Benefits and Use Cases
+## Ask for Citations
 
-Using `@` to reference files offers several key benefits in Claude Code workflows:
+For investigation work, require file references:
 
-1. **Reduced Prompt Overhead**: Instead of repeatedly pasting large code sections or verbose instructions, a simple `@filename` provides Claude with immediate access to the necessary context.
-2. **Improved Accuracy and Relevance**: By explicitly directing Claude to specific files or documentation, you minimize guesswork and ensure its responses are more accurate and tailored to your project's specifics.
-3. **Enhanced Codebase Understanding**: For tasks like onboarding to a new codebase or deep analysis, you can ask Claude to read relevant files (e.g., "explain the logic in `@src/utils/auth.js`").
-4. **Structured Workflows**: `@` can be used within custom slash commands to create highly structured and reusable workflows. For instance, a `/project:fix-github-issue 1234` command might reference the issue details from GitHub via an MCP and then automatically search relevant codebase files.
-5. **Efficient Data Handling**: It provides a streamlined way to feed data (like code snippets, logs, or configuration files) into Claude's context, especially when dealing with multiple files.
-6. **Multi-Agent Collaboration**: In multi-agent setups, `@` references can be used to pass shared plans, instructions, or artifacts between different Claude instances (e.g., an Architect agent creating a `MULTI_AGENT_PLAN.md` that a Builder agent references).
+```text
+Explain where billing webhooks are handled. Cite the files and functions you
+used. Do not edit files.
+```
 
-## Practical Tips for Effective Use
-
-- **Be Specific**: While Claude Code is good at discovering information, explicitly pointing it to relevant files with `@` ensures it focuses on the right content.
-- **Combine with `CLAUDE.md`**: Leverage `CLAUDE.md` for high-level project guidelines and common commands, and use `@` imports for more granular, modular documentation.
-- **Use for Debugging and Code Review**: When debugging an error or requesting a code review, direct Claude to the specific files involved using `@` for a more targeted and efficient analysis.
-- **Visual Context**: You can also provide image paths using `@` (or drag-and-drop screenshots) for UI or design-related tasks, allowing Claude to interpret visual intent.
+If the answer cannot cite the relevant files, the next step is more context, not
+implementation.

--- a/courses/ai-development/subagent-anti-patterns.md
+++ b/courses/ai-development/subagent-anti-patterns.md
@@ -1,22 +1,50 @@
 ---
-title: Common Sub-Agent Anti-Patterns and Pitfalls
+title: Subagent Anti-Patterns
 description: >-
-  Avoid common mistakes when using Claude Code's sub-agent system for delegation
-  and task management.
-modified: 2026-03-17
+  Avoid over-splitting work across subagents, losing ownership, duplicating
+  context, and accepting unaudited parallel output.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-At the time of this writing, sub-agents are still pretty new. (Like, less than a week old.) So, they still have some rough edges.
+Subagents are useful when they reduce context pressure. They are harmful when
+they create an illusion of rigor without a clear owner.
 
-- **Inconsistent activation** — Claude often ignores an appropriate sub-agent unless you name it explicitly. Even with a solid description in `claude.md`, auto-selection fires only _sometimes_, so “fire-and-forget” delegation isn’t reliable yet.
-- **State loss on rejection** — If you decline an agent’s draft, main Claude spins up a _fresh_ copy rather than letting you iterate with the same one. All of that agent-specific context disappears, forcing a ground-up re-run.
-- **No mid-stream dialogue** — You can’t ask a running agent clarifying questions or nudge it part-way through a task. The black-box execution means you wait in silence, then accept or reject a lump-sum result.
-- **Opaque inner workings** — Internal tool calls and partial thoughts remain hidden. When an agent chews through 50 k tokens you have no incremental visibility, which makes debugging slow or impossible.
-- **Token & time bloat** — Each sub-agent adds another context window. Large fleets (10-15+) eat through the 200 k token budget quickly and can run for an hour+ before surfacing anything useful.
-- **Performance degradation with “too many chefs”** — A long agent list dilutes relevance signals; the delegating model spends cycles choosing instead of doing. Overlapping responsibilities cause ping-ponging or duplicate work.
-- **Tool-scope confusion** — Giving every agent every tool sounds convenient but introduces noise. The model sometimes picks an ill-suited tool or fails because it can’t decide which one to use.
-- **Short, shallow outputs** — Even well-defined agents can return a single-sentence verdict (“yeah, looks good”) instead of the requested deep dive. You still need follow-up prompts to get actionable detail.
-- **Verbose auto-generated prompts** — The `/agents` wizard produces sprawling system prompts. These eat context, slow reasoning, and still don’t guarantee correct activation. Most users end up trimming them manually.
-- **Non-deterministic variance** — The same task with the same agents can yield different plans—or different _no_-shows—run to run. Measuring improvements is tricky because signal swings with each session.
-- **Activation edge cases** — Agents created for highly specific events (e.g., post-file-save code-guardian) may never trigger unless the main prompt or repo state matches their narrow pattern exactly.
+## Anti-Pattern: Splitting Tiny Work
+
+Do not create a subagent to rename a function, update one test, or read one file.
+The overhead is larger than the task.
+
+Use a subagent when the work has a natural boundary: security review, test audit,
+repository orientation, browser reproduction, or release checklist.
+
+## Anti-Pattern: No Return Contract
+
+Bad:
+
+```text
+Have a subagent look into this.
+```
+
+Better:
+
+```text
+Ask a read-only subagent to inspect authentication tests. Return confirmed gaps
+only, with file references and the exact regression each test should cover.
+```
+
+Subagent output should be easy to accept, reject, or turn into a task.
+
+## Anti-Pattern: Parallelizing Shared State
+
+Two agents editing the same files at once will often fight. Parallelize research,
+not overlapping writes. If multiple agents need to edit, give each one exclusive
+files or sequence the work.
+
+## Anti-Pattern: Treating Subagents as Review
+
+A subagent can help review, but the main agent or human still owns the decision.
+Run the tests, inspect the diff, and resolve conflicts in one place.
+
+The best subagent output is narrow enough that it improves the main workflow
+instead of becoming a second workflow.

--- a/courses/ai-development/test-driven-development-with-claude.md
+++ b/courses/ai-development/test-driven-development-with-claude.md
@@ -1,39 +1,53 @@
 ---
 title: Test-Driven Development with Claude Code
 description: >-
-  Implement TDD workflows using Claude Code for iterative, test-first
-  development with automated feedback loops.
-modified: 2026-03-17
+  Use Claude Code for regression-first development with failing tests, smallest
+  implementation changes, and explicit verification gates.
+modified: 2026-06-24
 date: 2025-07-29
 ---
 
-The process of implementing TDD with Claude Code follows a structured, iterative cycle:
+[Claude Code](https://code.claude.com/docs/en/overview) is strongest when the
+definition of done is executable. Test-driven development gives the agent a
+tight loop: reproduce the bug, make the test pass, then refactor only if needed.
 
-1. **Write Tests First**: Begin by describing the desired functionality and explicitly asking Claude to **write tests for a new feature that doesn't yet exist**. It's crucial to be explicit that you are doing TDD, which helps Claude avoid creating mock implementations or stubbing out imaginary code prematurely. You can specify input/output pairs for these tests. Claude can use a Filesystem Model Context Protocol (MCP) server to create new test files in the appropriate directory.
-2. **Confirm Tests Fail**: Instruct Claude to **run the newly written tests and confirm that they fail as expected**. This step is vital for validating that the tests correctly target the non-existent functionality. Claude can execute these tests using its built-in Bash tool (e.g., running `pytest` or `jest`).
-3. **Commit Failing Tests**: Once you are satisfied that the tests accurately capture the requirements, **have Claude commit them to your repository**. This creates a clear, verifiable definition of "done" for the feature.
-4. **Write Code to Pass Tests**: Now, instruct Claude to **write the implementation code with the sole goal of making all the committed tests pass**, ensuring it does _not_ modify the tests themselves. Claude will likely enter an **autonomous loop** here, writing code, running the test suite, analyzing failure messages, adjusting its code based on errors, and repeating until all tests pass.
-5. **Commit Passing Code**: Once all tests pass and you are satisfied with the solution, instruct Claude to **commit the implementation code**, completing the TDD cycle. Claude can draft a descriptive commit message based on the changes and even create a pull request.
+## A Good TDD Prompt
 
-## Benefits of TDD with Claude Code
+```text
+Bug:
+Expired invite tokens are accepted.
 
-Employing TDD with Claude Code offers several significant advantages:
+Task:
+Write the failing regression test first in the closest test file. Then implement
+the smallest production change that makes it pass.
 
-- **Higher Quality and Maintainability**: This workflow ensures that your code is always covered by tests, leading to more robust, higher-quality, and maintainable software. Claude's ability to iterate until tests pass helps it refine its output, catching issues that might otherwise be missed.
-- **Clear Targets for AI**: Claude performs best when it has a clear, verifiable target. Tests provide this explicit target, allowing Claude to make changes, evaluate results, and incrementally improve its code.
-- **Faster Iteration and Feedback Loops**: The automated feedback loop provided by running tests means Claude can self-correct and iterate much faster, significantly reducing the human intervention needed for debugging. This "tight feedback loop" allows Claude to reliably build modular functionality.
-- **Structured Problem Solving**: TDD naturally breaks down complex problems into smaller, manageable, verifiable units, which aligns well with Claude's agentic capabilities and helps it stay focused.
-- **Reduced Context Drift**: By having a clear test suite as a "source of truth," Claude is less likely to drift off-topic or introduce unintended side effects, even in long conversations.
+Verification:
+Run bun test:unit -- src/lib/server/invitations.test.ts and bun run lint.
 
-## Advanced Tips and Complementary Strategies for TDD with Claude
+Stop:
+If either command fails for an unrelated reason, stop and report the failure
+instead of editing unrelated files.
+```
 
-To maximize the effectiveness of TDD with Claude Code, consider these additional tips:
+This prompt gives Claude a behavior to reproduce, a scope boundary, and a finish
+line.
 
-- **Specify Testing Frameworks**: Claude is aware of various testing libraries, so you can prompt it to use specific ones (e.g., "Write a Jest test suite").
-- **Prevent Overfitting with Sub-Agents**: To ensure the implementation is robust and not just "overfitting" to the specific tests, you can instruct Claude to use a **separate sub-agent to independently verify the implementation**. This multi-agent approach provides multiple perspectives and helps catch more issues.
-- **Proactive Planning**: Even with TDD, it's beneficial to have Claude explore and plan before diving into coding. You can use the `/plan` mode, or instruct Claude to "think hard" (or "ultrathink") to encourage deeper consideration and create a detailed, step-by-step plan, including testing procedures.
-- **Leverage CLAUDE.md**: Use your `CLAUDE.md` file to establish project-wide conventions, including testing guidelines and quality standards. This ensures Claude consistently applies these rules without needing repeated instructions.
-- **Use Hooks for Automation**: Configure PostToolUse hooks to **automatically run linters and test suites** after any file edit. This enforces consistent code style and provides immediate feedback, without blocking the agent's workflow. Hooks can also enforce critical constraints that Claude cannot ignore.
-- **Course Correction**: Be an active collaborator and guide Claude's approach. If Claude goes off track, use tools like `Esc` to interrupt or double-`Esc` to revise your previous prompt.
-- **Specificity in Prompts**: Provide **clear and specific instructions** to Claude. For example, instead of "add tests," specify "Write a new unit test in `tests/auth_test.py` covering the logout edge case (user without session). Do not use any mocks". This minimizes ambiguity and improves alignment with your expectations.
-- **Cost Management**: While multi-agent TDD can consume more tokens due to extensive iterations and context, the resulting time savings and quality improvements often justify the cost. Strategic model selection (e.g., Sonnet for iterative tasks) and proper context management can help optimize costs.
+## Watch the First Test
+
+Do not let the agent write a test that already passes. Ask it to report the
+failing assertion before implementation:
+
+```text
+After writing the regression test, run it and show the failing assertion before
+changing production code.
+```
+
+That one sentence prevents a lot of fake coverage.
+
+## Keep Refactors Separate
+
+After the test passes, ask whether a refactor is necessary. Many fixes are better
+left small. If the implementation is clear and the tests pass, stop.
+
+When a refactor is justified, run the same verification command afterward. A
+green test before a refactor does not prove the refactor is safe.


### PR DESCRIPTION
## Summary

- Refresh `courses/ai-development/` against the official Cursor and Claude Code source set named in the plan as of June 23, 2026.
- Add missing Cursor lessons for Skills, Subagents, Hooks, CLI, Automations, and Bugbot/Security Review, and wire them into `index.toml`.
- Rewrite stale/deprecated guidance for Cursor Notepads, Privacy Mode/Ghost Mode, Cursor rules/context/checkpoints/cloud agents, and Claude Code installation, memory, models, hooks, MCP, subagents, GitHub Actions, compaction, permissions, and automation workflows.
- Make shared MCP and workflow lessons explicit about Cursor versus Claude Code configuration, permission, transport, and review differences.

## Review committee

Pre-reviewed by `prose-editor`, `junior-engineer`, `simplicity-engineer`, and the mandatory Codex adversarial reviewer.

- `junior-engineer` approved after hook/MCP/Cloud Agent correctness fixes.
- `simplicity-engineer` approved; structural consolidation suggestions were recorded as non-blocking because the plan explicitly preserves routes and adds the missing Cursor lessons.
- Codex approved after the hook examples, control-flow contracts, MCP wording, and Cursor hook/cloud notes were corrected.
- `prose-editor` approved after all blocking first-use/source-link findings were resolved.

## Test plan

- `bun run content:validate`
- `bun run lint`
- `bun run check`
- `bun run continuous-integration:validate`

Local final gate passed on June 24, 2026. Content validation still reports the repository's pre-existing orphan-lesson warnings outside `courses/ai-development/`, but exits successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime code; residual risk is outdated or imprecise security/permission advice, which the PR description notes was pre-reviewed.
> 
> **Overview**
> **Refreshes `courses/ai-development/`** against official Cursor and Claude Code documentation (baseline June 23, 2026). The course README and lesson tone shift from long feature tours to **agent safety habits**: explicit context, rules vs skills, permissions, diff review, and keeping truth in the repo—not chat.
> 
> **Claude Code lessons** are largely rewritten and shortened. Notable guidance updates include **Skills as the primary workflow packaging** (with `.claude/commands` as legacy shortcuts), **plan mode and `opusplan`**, compaction with filesystem state, hook control flow and smaller cookbooks, MCP setup/permissions, subagents, `CLAUDE.md` / rules / auto memory, and bounded shell/script usage (including `!` bash behavior).
> 
> **Cursor coverage** is brought current: **Cloud Agents** (replacing “background agents” framing), **Privacy Mode** vs older Ghost Mode language, context/rules/skills/MCP, checkpoints, and **new lessons** for CLI (`agent`), hooks, automations, Bugbot/security review, plus environment configuration for cloud runs. **`index.toml`** links the added Cursor topics into the course outline.
> 
> Shared workflow lessons (cost, MCP, etc.) emphasize **Cursor vs Claude Code differences** in configuration, permissions, and review rather than one-size-fits-all instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8bc489e32ba77cb794e3f9aa827257d7fe5159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->