### PR TITLE
Add project content routes and metadata

### DIFF
--- a/applications/website/src/app.css
+++ b/applications/website/src/app.css
@@ -19,6 +19,7 @@
 @source '../**/*.{svelte,js,ts,md}';
 @source '../../../writing/**/*.md';
 @source '../../../courses/**/*.md';
+@source '../../../projects/**/*.md';
 @source '../../../packages/components/**/*.{svelte,js,ts}';
 @source '../../../packages/content-enhancements/src/**/*.ts';
 @source '../../../packages/markdown/src/**/*.ts';

--- a/applications/website/src/lib/llms-path.test.ts
+++ b/applications/website/src/lib/llms-path.test.ts
@@ -17,6 +17,10 @@ describe('createLlmsAlternatePath', () => {
     );
   });
 
+  it('returns a per-project llms route for project detail pages', () => {
+    expect(createLlmsAlternatePath('/projects/weft')).toBe('/projects/weft/llms.txt');
+  });
+
   it('returns a per-lesson llms route for course lesson pages', () => {
     expect(
       createLlmsAlternatePath('/courses/self-testing-ai-agents/lab-wrap-a-custom-verification-mcp'),
@@ -27,10 +31,12 @@ describe('createLlmsAlternatePath', () => {
     expect(createLlmsAlternatePath('/writing')).toBeNull();
     expect(createLlmsAlternatePath('/writing/page/2')).toBeNull();
     expect(createLlmsAlternatePath('/courses')).toBeNull();
+    expect(createLlmsAlternatePath('/projects')).toBeNull();
   });
 
   it('does not emit llms alternates for reserved writing routes', () => {
     expect(createLlmsAlternatePath('/writing/rss')).toBeNull();
     expect(createLlmsAlternatePath('/writing/open-graph.jpg')).toBeNull();
+    expect(createLlmsAlternatePath('/projects/open-graph.jpg')).toBeNull();
   });
 });

--- a/applications/website/src/lib/llms-path.ts
+++ b/applications/website/src/lib/llms-path.ts
@@ -22,6 +22,10 @@ export const createLlmsAlternatePath = (pathname: string): string | null => {
     return `${normalizedPath}/llms.txt`;
   }
 
+  if (segments[0] === 'projects' && segments.length === 2 && !isReservedSegment(segments[1])) {
+    return `${normalizedPath}/llms.txt`;
+  }
+
   if (
     segments[0] === 'courses' &&
     segments.length === 3 &&

--- a/applications/website/src/lib/repository-path.ts
+++ b/applications/website/src/lib/repository-path.ts
@@ -1,1 +1,1 @@
-export type RepositoryPath = `courses/${string}` | `writing/${string}`;
+export type RepositoryPath = `courses/${string}` | `projects/${string}` | `writing/${string}`;

--- a/applications/website/src/lib/server/content-documents.ts
+++ b/applications/website/src/lib/server/content-documents.ts
@@ -11,6 +11,7 @@ type MarkdownLoader = () => Promise<MarkdownModule>;
 
 const writingMarkdownModules = import.meta.glob<MarkdownModule>('../../../../../writing/*.md');
 const courseMarkdownModules = import.meta.glob<MarkdownModule>('../../../../../courses/*/*.md');
+const projectMarkdownModules = import.meta.glob<MarkdownModule>('../../../../../projects/*.md');
 
 export class MarkdownModuleNotFoundError extends Error {
   constructor(sourcePath: string) {
@@ -27,6 +28,10 @@ const getLoader = (sourcePath: string): MarkdownLoader | undefined => {
 
   if (sourcePath.startsWith('courses/')) {
     return courseMarkdownModules[key];
+  }
+
+  if (sourcePath.startsWith('projects/')) {
+    return projectMarkdownModules[key];
   }
 
   return undefined;
@@ -63,4 +68,10 @@ export const renderLessonDocument = async (sourcePath: string): Promise<string> 
   renderMarkdownModule(sourcePath, {
     class: 'prose dark:prose-invert max-w-none',
     as: 'article',
+  });
+
+export const renderProjectDocument = async (sourcePath: string): Promise<string> =>
+  renderMarkdownModule(sourcePath, {
+    class: 'prose dark:prose-invert max-w-none',
+    as: 'section',
   });

--- a/applications/website/src/lib/server/content.test.ts
+++ b/applications/website/src/lib/server/content.test.ts
@@ -6,6 +6,8 @@ import {
   getLessonRoute,
   getPostIndex,
   getPrerenderEntries,
+  getProjectIndex,
+  getProjectRoute,
   getWritingRoute,
 } from './content';
 
@@ -41,6 +43,17 @@ describe('generated content lookups', () => {
     });
   });
 
+  it('returns generated project metadata', () => {
+    const project = getProjectRoute('weft');
+
+    expect(project).toMatchObject({
+      contentType: 'project',
+      projectSlug: 'weft',
+      sourcePath: 'projects/weft.md',
+      githubUrl: 'https://github.com/stevekinney/weft',
+    });
+  });
+
   it('normalizes legacy markdown course slugs before looking up generated routes', () => {
     const course = getCourseRoute('testing.md');
 
@@ -61,6 +74,12 @@ describe('generated content lookups', () => {
     expect(new Date(first.date).getTime()).toBeGreaterThanOrEqual(new Date(second.date).getTime());
   });
 
+  it('keeps the project index sorted by project name', () => {
+    const [first, second] = getProjectIndex();
+
+    expect(first.name.localeCompare(second.name)).toBeLessThanOrEqual(0);
+  });
+
   it('includes canonical and legacy prerender entries for content detail routes', () => {
     const entries = getPrerenderEntries();
 
@@ -73,6 +92,8 @@ describe('generated content lookups', () => {
 
     expect(entries.lessons).toContainEqual({ course: 'testing', lesson: 'the-basics' });
     expect(entries.lessons).toContainEqual({ course: 'testing', lesson: 'the-basics.md' });
+
+    expect(entries.projects).toContainEqual({ project: 'weft' });
   });
 
   it('omits legacy markdown prerender entries during Vercel builds', () => {

--- a/applications/website/src/lib/server/content.ts
+++ b/applications/website/src/lib/server/content.ts
@@ -6,6 +6,8 @@ import type {
   CourseIndexEntry,
   GeneratedContent,
   LessonContentRoute,
+  ProjectContentRoute,
+  ProjectIndexEntry,
   WritingContentRoute,
   WritingIndexEntry,
 } from '@stevekinney/utilities/content-types';
@@ -15,6 +17,7 @@ const content = generatedContent as GeneratedContent;
 
 const writingIndexBySlug = new Map(content.writing.map((entry) => [entry.slug, entry]));
 const courseIndexBySlug = new Map(content.courses.map((entry) => [entry.slug, entry]));
+const projectIndexBySlug = new Map(content.projects.map((entry) => [entry.slug, entry]));
 
 const lessonSlugCourseMap = content.lessons.reduce<Map<string, string | null>>((map, lesson) => {
   const existing = map.get(lesson.slug);
@@ -35,6 +38,8 @@ export const getPostIndex = (): WritingIndexEntry[] => content.siteIndex.posts;
 
 export const getCourseIndex = (): CourseIndexEntry[] => content.siteIndex.courses;
 
+export const getProjectIndex = (): ProjectIndexEntry[] => content.siteIndex.projects;
+
 export const getRouteByPath = (pathname: string): ContentRoute | null =>
   content.routes[normalizeRoutePath(pathname)] ?? null;
 
@@ -43,6 +48,9 @@ export const getWritingEntry = (slug: string): WritingIndexEntry | null =>
 
 export const getCourseEntry = (slug: string): CourseIndexEntry | null =>
   courseIndexBySlug.get(normalizeLegacyMarkdownSlug(slug)) ?? null;
+
+export const getProjectEntry = (slug: string): ProjectIndexEntry | null =>
+  projectIndexBySlug.get(slug) ?? null;
 
 export const getWritingRoute = (slug: string): WritingContentRoute | null => {
   const route = getRouteByPath(`/writing/${slug}`);
@@ -62,6 +70,11 @@ export const getLessonRoute = (
   return route?.contentType === 'lesson' ? route : null;
 };
 
+export const getProjectRoute = (projectSlug: string): ProjectContentRoute | null => {
+  const route = getRouteByPath(`/projects/${projectSlug}`);
+  return route?.contentType === 'project' ? route : null;
+};
+
 const shouldIncludeLegacyMarkdownPrerenderEntries = (): boolean => !process.env.VERCEL;
 
 const filterLegacyMarkdownEntries = <T extends Record<string, string>>(entries: T[]): T[] => {
@@ -78,6 +91,7 @@ export const getPrerenderEntries = () => ({
   writing: filterLegacyMarkdownEntries(content.prerenderEntries.writing),
   courses: filterLegacyMarkdownEntries(content.prerenderEntries.courses),
   lessons: filterLegacyMarkdownEntries(content.prerenderEntries.lessons),
+  projects: content.prerenderEntries.projects,
 });
 
 export const findCourseForLessonSlug = (lessonSlug: string): string | null =>

--- a/applications/website/src/lib/server/load-raw-content.ts
+++ b/applications/website/src/lib/server/load-raw-content.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { getCourseRoute, getLessonRoute, getWritingRoute } from '$lib/server/content';
+import {
+  getCourseRoute,
+  getLessonRoute,
+  getProjectRoute,
+  getWritingRoute,
+} from '$lib/server/content';
 
 const root = path.resolve(process.cwd(), '..', '..');
 
@@ -36,6 +41,17 @@ export async function loadRawCourseLesson(courseSlug: string, lessonSlug: string
   const route = getLessonRoute(courseSlug, lessonSlug);
   if (!route) {
     throw new Error(`Lesson route not found for '${courseSlug}/${lessonSlug}'.`);
+  }
+
+  const filePath = path.join(root, route.sourcePath);
+  const raw = await fs.readFile(filePath, 'utf-8');
+  return stripFrontmatter(raw);
+}
+
+export async function loadRawProjectContent(projectSlug: string): Promise<string> {
+  const route = getProjectRoute(projectSlug);
+  if (!route) {
+    throw new Error(`Project route not found for '${projectSlug}'.`);
   }
 
   const filePath = path.join(root, route.sourcePath);

--- a/applications/website/src/lib/server/open-graph-metadata.test.ts
+++ b/applications/website/src/lib/server/open-graph-metadata.test.ts
@@ -16,6 +16,9 @@ describe('resolveOpenGraphMetadata', () => {
     await expect(resolveOpenGraphMetadata('/courses')).resolves.toMatchObject({
       title: 'Courses',
     });
+    await expect(resolveOpenGraphMetadata('/projects')).resolves.toMatchObject({
+      title: 'Projects',
+    });
   });
 
   it('uses generated metadata for writing routes', async () => {
@@ -39,11 +42,19 @@ describe('resolveOpenGraphMetadata', () => {
     });
   });
 
+  it('uses generated metadata for project routes', async () => {
+    await expect(resolveOpenGraphMetadata('/projects/weft')).resolves.toMatchObject({
+      title: 'Weft',
+      description: expect.stringContaining('Durable execution primitives'),
+    });
+  });
+
   it('normalizes trailing slashes and rejects malformed nested paths', async () => {
     await expect(resolveOpenGraphMetadata('/courses/testing/')).resolves.toMatchObject({
       title: 'Introduction to Testing',
     });
     await expect(resolveOpenGraphMetadata('/courses/testing/the-basics/extra')).resolves.toBeNull();
     await expect(resolveOpenGraphMetadata('/writing/does-not-exist')).resolves.toBeNull();
+    await expect(resolveOpenGraphMetadata('/projects/weft/extra')).resolves.toBeNull();
   });
 });

--- a/applications/website/src/lib/server/open-graph-metadata.ts
+++ b/applications/website/src/lib/server/open-graph-metadata.ts
@@ -1,6 +1,11 @@
 import metadata from '$lib/metadata';
 import { normalizeOpenGraphPath } from '$lib/og/paths';
-import { getCourseEntry, getRouteByPath, getWritingEntry } from '$lib/server/content';
+import {
+  getCourseEntry,
+  getProjectEntry,
+  getRouteByPath,
+  getWritingEntry,
+} from '$lib/server/content';
 
 import type { OpenGraphOptions } from './open-graph';
 
@@ -20,10 +25,17 @@ const COURSES_INDEX: StaticRoute = {
     "A collection of courses that I've taught over the years, including full course walkthroughs and recordings from Frontend Masters.",
 };
 
+const PROJECTS_INDEX: StaticRoute = {
+  title: 'Projects',
+  description:
+    'A collection of tools, experiments, and open source projects that I maintain or keep nearby.',
+};
+
 const STATIC_ROUTES = new Map<string, StaticRoute>([
   ['/', { title: metadata.title, description: metadata.description }],
   ['/writing', WRITING_INDEX],
   ['/courses', COURSES_INDEX],
+  ['/projects', PROJECTS_INDEX],
 ]);
 
 const safeDecode = (value: string): string => {
@@ -92,6 +104,21 @@ const resolveCourseMetadata = async (pathname: string): Promise<OpenGraphOptions
   };
 };
 
+const resolveProjectMetadata = (pathname: string): OpenGraphOptions | null => {
+  if (!pathname.startsWith('/projects/')) return null;
+
+  const slug = safeDecode(pathname.replace('/projects/', ''));
+  if (!slug || slug.includes('/')) return null;
+
+  const project = getProjectEntry(slug);
+  if (!project) return null;
+
+  return {
+    title: project.name,
+    description: project.description || metadata.description,
+  };
+};
+
 export const resolveOpenGraphMetadata = async (
   pathname: string,
 ): Promise<OpenGraphOptions | null> => {
@@ -105,6 +132,9 @@ export const resolveOpenGraphMetadata = async (
 
   const courseMetadata = await resolveCourseMetadata(normalized);
   if (courseMetadata) return courseMetadata;
+
+  const projectMetadata = resolveProjectMetadata(normalized);
+  if (projectMetadata) return projectMetadata;
 
   return null;
 };

--- a/applications/website/src/routes/[...path]/llms.txt/+server.ts
+++ b/applications/website/src/routes/[...path]/llms.txt/+server.ts
@@ -1,10 +1,16 @@
 import { error } from '@sveltejs/kit';
 
 import { url } from '$lib/metadata';
-import { getCourseEntry, getLessonRoute, getWritingEntry } from '$lib/server/content';
+import {
+  getCourseEntry,
+  getLessonRoute,
+  getProjectEntry,
+  getWritingEntry,
+} from '$lib/server/content';
 import {
   loadRawCourseLesson,
   loadRawCourseReadme,
+  loadRawProjectContent,
   loadRawWritingContent,
 } from '$lib/server/load-raw-content';
 
@@ -94,6 +100,38 @@ const resolveCourseLesson = async (
   }
 };
 
+const resolveProject = async (projectSlug: string): Promise<string | null> => {
+  const project = getProjectEntry(projectSlug);
+  if (!project) return null;
+
+  try {
+    const body = await loadRawProjectContent(projectSlug);
+    const header = [
+      `# ${project.name}`,
+      '',
+      `URL: ${url}/projects/${projectSlug}`,
+      `GitHub: ${project.githubUrl}`,
+      `Description: ${project.description}`,
+    ];
+
+    if (project.productionUrl) {
+      header.push(`Production: ${project.productionUrl}`);
+    }
+
+    if (project.writingPath) {
+      header.push(`Related writing: ${url}${project.writingPath}`);
+    }
+
+    if (project.youtubeUrl) {
+      header.push(`YouTube: ${project.youtubeUrl}`);
+    }
+
+    return [...header, '', '---', '', body].join('\n');
+  } catch {
+    return null;
+  }
+};
+
 export const GET: RequestHandler = async ({ params }) => {
   const rawPath = safeDecode(params.path || '');
   const segments = rawPath.split('/').filter(Boolean);
@@ -106,6 +144,8 @@ export const GET: RequestHandler = async ({ params }) => {
     content = await resolveCourse(segments[1]);
   } else if (segments[0] === 'courses' && segments.length === 3) {
     content = await resolveCourseLesson(segments[1], segments[2]);
+  } else if (segments[0] === 'projects' && segments.length === 2) {
+    content = await resolveProject(segments[1]);
   }
 
   if (!content) {

--- a/applications/website/src/routes/llms-full.txt/+server.ts
+++ b/applications/website/src/routes/llms-full.txt/+server.ts
@@ -1,12 +1,17 @@
 import { url } from '$lib/metadata';
-import { getCourseIndex, getPostIndex } from '$lib/server/content';
-import { loadRawCourseReadme, loadRawWritingContent } from '$lib/server/load-raw-content';
+import { getCourseIndex, getPostIndex, getProjectIndex } from '$lib/server/content';
+import {
+  loadRawCourseReadme,
+  loadRawProjectContent,
+  loadRawWritingContent,
+} from '$lib/server/load-raw-content';
 
 export const prerender = true;
 
 export async function GET() {
   const posts = getPostIndex();
   const courses = getCourseIndex();
+  const projects = getProjectIndex();
 
   const postBodies = await Promise.all(
     posts.map(async (post) => {
@@ -26,6 +31,17 @@ export async function GET() {
         return { course, body };
       } catch {
         return { course, body: '' };
+      }
+    }),
+  );
+
+  const projectBodies = await Promise.all(
+    projects.map(async (project) => {
+      try {
+        const body = await loadRawProjectContent(project.slug);
+        return { project, body };
+      } catch {
+        return { project, body: '' };
       }
     }),
   );
@@ -64,6 +80,31 @@ export async function GET() {
       '---',
       '',
     ]),
+    '## Projects',
+    '',
+    ...projectBodies.flatMap(({ project, body }) => {
+      const header = [
+        `### ${project.name}`,
+        '',
+        `URL: ${url}/projects/${project.slug}`,
+        `GitHub: ${project.githubUrl}`,
+        `Description: ${project.description}`,
+      ];
+
+      if (project.productionUrl) {
+        header.push(`Production: ${project.productionUrl}`);
+      }
+
+      if (project.writingPath) {
+        header.push(`Related writing: ${url}${project.writingPath}`);
+      }
+
+      if (project.youtubeUrl) {
+        header.push(`YouTube: ${project.youtubeUrl}`);
+      }
+
+      return [...header, '', body, '', '---', ''];
+    }),
   ];
 
   const responseBody = lines.join('\n');

--- a/applications/website/src/routes/llms.txt/+server.ts
+++ b/applications/website/src/routes/llms.txt/+server.ts
@@ -1,11 +1,12 @@
 import { url } from '$lib/metadata';
-import { getCourseIndex, getPostIndex } from '$lib/server/content';
+import { getCourseIndex, getPostIndex, getProjectIndex } from '$lib/server/content';
 
 export const prerender = true;
 
 export function GET() {
   const posts = getPostIndex();
   const courses = getCourseIndex();
+  const projects = getProjectIndex();
 
   const lines = [
     '# Steve Kinney',
@@ -26,6 +27,13 @@ export function GET() {
     ...courses.map(
       (course) =>
         `- [${course.title}](${url}/courses/${course.slug}): ${course.description} ([llms.txt](${url}/courses/${course.slug}/llms.txt))`,
+    ),
+    '',
+    '## Projects',
+    '',
+    ...projects.map(
+      (project) =>
+        `- [${project.name}](${url}/projects/${project.slug}): ${project.description} ([llms.txt](${url}/projects/${project.slug}/llms.txt))`,
     ),
     '',
     '## Links',

--- a/applications/website/src/routes/projects/+page.server.ts
+++ b/applications/website/src/routes/projects/+page.server.ts
@@ -1,0 +1,14 @@
+import { getProjectIndex } from '$lib/server/content';
+
+import type { PageServerLoad } from './$types';
+
+export const prerender = true;
+
+export const load: PageServerLoad = async () => {
+  return {
+    title: 'Projects',
+    description:
+      'A collection of tools, experiments, and open source projects that I maintain or keep nearby.',
+    projects: getProjectIndex(),
+  };
+};

--- a/applications/website/src/routes/projects/+page.svelte
+++ b/applications/website/src/routes/projects/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import SEO from '$lib/components/seo.svelte';
+  import { url } from '$lib/metadata';
+  import { buildBreadcrumbSchema } from '$lib/structured-data';
+
+  const { data } = $props();
+
+  const jsonLd = buildBreadcrumbSchema([{ name: 'Projects', url: `${url}/projects` }]);
+</script>
+
+<SEO title={data.title} description={data.description} {jsonLd} />
+
+<section class="space-y-8">
+  <hgroup class="space-y-3">
+    <h1 class="text-3xl font-bold">Projects</h1>
+    <p class="max-w-3xl font-serif text-2xl text-slate-700 dark:text-slate-300">
+      {data.description}
+    </p>
+  </hgroup>
+
+  <div class="grid gap-5 md:grid-cols-2">
+    {#each data.projects as project (project.slug)}
+      <article class="space-y-4 border-b border-slate-200 pb-5 dark:border-slate-800">
+        <div class="space-y-2">
+          <h2 class="text-xl font-bold">
+            <a
+              class="decoration-primary-600 hover:text-primary-800 dark:hover:text-primary-200 font-semibold decoration-4 underline-offset-8 focus:ring-2 focus:ring-primary-600 focus:ring-offset-2 focus:outline-none dark:decoration-slate-400"
+              href={project.path}
+            >
+              {project.name}
+            </a>
+          </h2>
+          <p class="text-slate-700 dark:text-slate-300">{project.description}</p>
+        </div>
+
+        <div class="flex flex-wrap gap-x-4 gap-y-2 text-sm">
+          <a
+            class="font-semibold underline decoration-2 underline-offset-4"
+            href={project.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
+          {#if project.productionUrl}
+            <a
+              class="font-semibold underline decoration-2 underline-offset-4"
+              href={project.productionUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Production
+            </a>
+          {/if}
+          {#if project.writingPath}
+            <a
+              class="font-semibold underline decoration-2 underline-offset-4"
+              href={project.writingPath}
+            >
+              Writing
+            </a>
+          {/if}
+        </div>
+      </article>
+    {/each}
+  </div>
+</section>

--- a/applications/website/src/routes/projects/[project]/+page.server.ts
+++ b/applications/website/src/routes/projects/[project]/+page.server.ts
@@ -1,0 +1,52 @@
+import { error } from '@sveltejs/kit';
+
+import type { RepositoryPath } from '$lib/repository-path';
+import { getPrerenderEntries, getProjectRoute } from '$lib/server/content';
+import { renderProjectDocument } from '$lib/server/content-documents';
+
+import type { PageServerLoad } from './$types';
+
+export const prerender = true;
+export const csr = false;
+
+const getYouTubeEmbedUrl = (youtubeUrl: string | undefined): string | undefined => {
+  if (!youtubeUrl) return undefined;
+
+  try {
+    const url = new URL(youtubeUrl);
+    const host = url.hostname.replace(/^www\./, '');
+    const videoId = host === 'youtu.be' ? url.pathname.slice(1) : url.searchParams.get('v');
+
+    if (!videoId) return undefined;
+
+    return `https://www.youtube.com/embed/${videoId}`;
+  } catch {
+    return undefined;
+  }
+};
+
+export const load: PageServerLoad = async ({ params }) => {
+  const route = getProjectRoute(params.project);
+  if (!route) {
+    throw error(404, 'Project not found');
+  }
+
+  return {
+    project: {
+      slug: route.projectSlug,
+      name: route.name,
+      description: route.description,
+      githubUrl: route.githubUrl,
+      productionUrl: route.productionUrl,
+      writingPath: route.writingPath,
+      youtubeUrl: route.youtubeUrl,
+      youtubeEmbedUrl: getYouTubeEmbedUrl(route.youtubeUrl),
+    },
+    sourcePath: route.sourcePath as RepositoryPath,
+    contentHtml: await renderProjectDocument(route.sourcePath),
+  };
+};
+
+export function entries() {
+  return getPrerenderEntries().projects;
+}

--- a/applications/website/src/routes/projects/[project]/+page.svelte
+++ b/applications/website/src/routes/projects/[project]/+page.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import ContentEnhancements from '$lib/components/content-enhancements.svelte';
+  import OpenInObsidian from '$lib/components/open-in-obsidian.svelte';
+  import PullRequest from '$lib/components/pull-request.svelte';
+  import SEO from '$lib/components/seo.svelte';
+  import { url } from '$lib/metadata';
+  import { buildBreadcrumbSchema } from '$lib/structured-data';
+
+  const { data } = $props();
+
+  const jsonLd = $derived(
+    buildBreadcrumbSchema([
+      { name: 'Projects', url: `${url}/projects` },
+      { name: data.project.name, url: `${url}/projects/${data.project.slug}` },
+    ]),
+  );
+</script>
+
+<SEO title={data.project.name} description={data.project.description} {jsonLd} />
+
+<ContentEnhancements />
+
+<OpenInObsidian repositoryPath={data.sourcePath} />
+
+<article class="space-y-10">
+  <hgroup class="space-y-3">
+    <p class="text-sm font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
+      Project
+    </p>
+    <h1 class="text-3xl font-bold">{data.project.name}</h1>
+    <p class="max-w-3xl font-serif text-2xl text-slate-700 dark:text-slate-300">
+      {data.project.description}
+    </p>
+  </hgroup>
+
+  <div class="flex flex-wrap gap-x-4 gap-y-2">
+    <a
+      class="font-semibold underline decoration-4 underline-offset-8"
+      href={data.project.githubUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      GitHub
+    </a>
+    {#if data.project.productionUrl}
+      <a
+        class="font-semibold underline decoration-4 underline-offset-8"
+        href={data.project.productionUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Production
+      </a>
+    {/if}
+    {#if data.project.writingPath}
+      <a
+        class="font-semibold underline decoration-4 underline-offset-8"
+        href={data.project.writingPath}
+      >
+        Related Writing
+      </a>
+    {/if}
+    {#if data.project.youtubeUrl}
+      <a
+        class="font-semibold underline decoration-4 underline-offset-8"
+        href={data.project.youtubeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        YouTube
+      </a>
+    {/if}
+  </div>
+
+  {#if data.project.youtubeEmbedUrl}
+    <div class="aspect-video overflow-hidden rounded border border-slate-200 dark:border-slate-800">
+      <iframe
+        class="size-full"
+        src={data.project.youtubeEmbedUrl}
+        title={`${data.project.name} on YouTube`}
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowfullscreen
+      ></iframe>
+    </div>
+  {/if}
+
+  <div data-content-document>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html data.contentHtml}
+  </div>
+</article>
+
+<PullRequest repositoryPath={data.sourcePath} />

--- a/applications/website/src/routes/sitemap.xml/+server.ts
+++ b/applications/website/src/routes/sitemap.xml/+server.ts
@@ -40,7 +40,7 @@ const getStaticLastModified = async (filePath: string): Promise<Date | null> => 
   }
 };
 
-const getContentLastModified = (modified: string, date: string): Date | null => {
+const getContentLastModified = (modified?: string, date?: string): Date | null => {
   const value = modified || date;
   if (!value) {
     return null;
@@ -92,7 +92,11 @@ export const GET = async () => {
     }
 
     const priority =
-      route.contentType === 'course' ? 0.8 : route.contentType === 'writing' ? 0.7 : 0.6;
+      route.contentType === 'course'
+        ? 0.8
+        : route.contentType === 'writing' || route.contentType === 'project'
+          ? 0.7
+          : 0.6;
 
     paths.push(
       h('url', [

--- a/applications/website/src/routes/sitemap.xml/sitemap.test.ts
+++ b/applications/website/src/routes/sitemap.xml/sitemap.test.ts
@@ -13,12 +13,15 @@ describe('sitemap metadata generation', () => {
     expect(xml).toContain('https://stevekinney.com/writing/setup-python');
     expect(xml).toContain('https://stevekinney.com/courses/testing');
     expect(xml).toContain('https://stevekinney.com/courses/testing/the-basics');
+    expect(xml).toContain('https://stevekinney.com/projects/weft');
     expect(xml).toContain('<loc>https://stevekinney.com/</loc>');
     expect(xml).not.toContain('[course]');
+    expect(xml).not.toContain('[project]');
     expect(xml.match(/https:\/\/stevekinney\.com\/courses\/testing<\/loc>/g)).toHaveLength(1);
     expect(
       xml.match(/https:\/\/stevekinney\.com\/courses\/testing\/the-basics<\/loc>/g),
     ).toHaveLength(1);
+    expect(xml.match(/https:\/\/stevekinney\.com\/projects\/weft<\/loc>/g)).toHaveLength(1);
 
     expect(testingLesson).not.toBeNull();
     expect(xml).toContain(

--- a/applications/website/vite.config.ts
+++ b/applications/website/vite.config.ts
@@ -41,7 +41,7 @@ const applyClientBuildOnly = (plugin: unknown): PluginOption => {
   return plugin as PluginOption;
 };
 
-const contentDirectories = ['writing', 'courses'].map((directory) =>
+const contentDirectories = ['writing', 'courses', 'projects'].map((directory) =>
   path.resolve(workspaceRoot, directory),
 );
 const contentEnhancementsSourceDirectory = path.resolve(
@@ -73,7 +73,7 @@ export default defineConfig({
     ...contentDevelopmentPlugins({
       workspaceRoot,
       contentDirectories,
-      contentAssetPathPrefixes: ['/courses/', '/writing/'],
+      contentAssetPathPrefixes: ['/courses/', '/projects/', '/writing/'],
       enhancementSourceDirectories: [contentEnhancementsSourceDirectory],
       contentBuildScriptPath,
       contentBuildWorkingDirectory: process.cwd(),

--- a/packages/components/navigation.svelte
+++ b/packages/components/navigation.svelte
@@ -10,6 +10,7 @@
 <nav class={merge('flex items-center gap-4', className)} aria-label="Main Navigation">
   <Link href="/writing">Writing</Link>
   <Link href="/courses">Courses</Link>
+  <Link href="/projects">Projects</Link>
   <Link
     href="https://cinder.website/"
     target="_blank"

--- a/packages/scripts/check-image-manifest.ts
+++ b/packages/scripts/check-image-manifest.ts
@@ -10,7 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = path.resolve(__dirname, '..', '..');
 const MANIFEST_PATH = path.resolve(REPOSITORY_ROOT, 'image-manifest.json');
 
-const MARKDOWN_PATTERNS = ['writing/**/*.md', 'courses/**/*.md'];
+const MARKDOWN_PATTERNS = ['writing/**/*.md', 'courses/**/*.md', 'projects/**/*.md'];
 
 const normalizePath = (value: string): string => value.split(path.sep).join('/');
 const toRepositoryPath = (absolutePath: string): string =>

--- a/packages/scripts/content-build.ts
+++ b/packages/scripts/content-build.ts
@@ -113,6 +113,7 @@ const main = async (): Promise<void> => {
     writing: repository.writing,
     courses: repository.courses,
     lessons: repository.lessons,
+    projects: repository.projects,
     prerenderEntries: repository.prerenderEntries,
   };
 

--- a/packages/scripts/content-paths.ts
+++ b/packages/scripts/content-paths.ts
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const repositoryRoot = path.resolve(__dirname, '..', '..');
 export const writingRoot = path.resolve(repositoryRoot, 'writing');
 export const coursesRoot = path.resolve(repositoryRoot, 'courses');
+export const projectsRoot = path.resolve(repositoryRoot, 'projects');
 export const websiteRoot = path.resolve(repositoryRoot, 'applications', 'website');
 export const websiteStaticRoot = path.resolve(websiteRoot, 'static');
 export const websiteBuildRoot = path.resolve(websiteRoot, 'build');

--- a/packages/scripts/content-repository.test.ts
+++ b/packages/scripts/content-repository.test.ts
@@ -30,7 +30,7 @@ describe('collectContentRepository', () => {
     expect(repository.meta.sourceFileCount).toBeGreaterThan(800);
   });
 
-  test('builds a route map for writing, course, and lesson content', async () => {
+  test('builds a route map for writing, course, lesson, and project content', async () => {
     const repository = await repositoryPromise;
     expect(repository.routes['/writing/setup-python']).toMatchObject({
       contentType: 'writing',
@@ -49,6 +49,12 @@ describe('collectContentRepository', () => {
       courseSlug: 'testing',
       lessonSlug: 'the-basics',
       sourcePath: 'courses/testing/the-basics.md',
+    });
+
+    expect(repository.routes['/projects/weft']).toMatchObject({
+      contentType: 'project',
+      projectSlug: 'weft',
+      sourcePath: 'projects/weft.md',
     });
   });
 
@@ -77,6 +83,7 @@ describe('collectContentRepository', () => {
       course: 'testing',
       lesson: 'the-basics.md',
     });
+    expect(repository.prerenderEntries.projects).toContainEqual({ project: 'weft' });
   });
 
   test('extracts sanitized Tailwind playground source', async () => {

--- a/packages/scripts/content-repository/builders.ts
+++ b/packages/scripts/content-repository/builders.ts
@@ -7,6 +7,7 @@ import type {
   CourseContentsData,
   ContentRoute,
   GeneratedContent,
+  ProjectIndexEntry,
   SiteContentIndex,
   WritingIndexEntry,
 } from '@stevekinney/utilities/content-types';
@@ -29,8 +30,15 @@ import type {
   CourseRecord,
   LessonRecord,
   MarkdownSource,
+  ProjectRecord,
 } from './types.ts';
-import { requiredString, safeDateString, validateCourseContents } from './validation.ts';
+import {
+  optionalString,
+  requiredString,
+  safeDateString,
+  validateCourseContents,
+  validateUrlFrontmatter,
+} from './validation.ts';
 
 const compareByDate = (left: { date: string }, right: { date: string }): number =>
   new Date(right.date).getTime() - new Date(left.date).getTime();
@@ -181,9 +189,40 @@ export const buildCourseEntry = async (
   };
 };
 
+export const buildProjectEntry = async (
+  source: MarkdownSource,
+  issues: ContentValidationIssue[],
+): Promise<ProjectRecord> => {
+  const { data, sourceHash, sourcePath } = source;
+  const slug = path.basename(source.absolutePath, '.md');
+  const githubUrl = requiredString(sourcePath, data.githubUrl, 'githubUrl', issues);
+  const productionUrl = optionalString(sourcePath, data.productionUrl, 'productionUrl', issues);
+  const writingPath = optionalString(sourcePath, data.writingPath, 'writingPath', issues);
+  const youtubeUrl = optionalString(sourcePath, data.youtubeUrl, 'youtubeUrl', issues);
+
+  validateUrlFrontmatter(sourcePath, githubUrl, 'githubUrl', issues);
+  validateUrlFrontmatter(sourcePath, productionUrl, 'productionUrl', issues);
+  validateUrlFrontmatter(sourcePath, youtubeUrl, 'youtubeUrl', issues);
+
+  return {
+    name: requiredString(sourcePath, data.name, 'name', issues),
+    description: requiredString(sourcePath, data.description, 'description', issues),
+    githubUrl,
+    ...(productionUrl ? { productionUrl } : {}),
+    ...(writingPath ? { writingPath } : {}),
+    ...(youtubeUrl ? { youtubeUrl } : {}),
+    slug,
+    sourcePath,
+    sourceHash,
+    path: `/projects/${slug}`,
+    source,
+  };
+};
+
 export const buildRoutes = (
   writingEntries: WritingIndexEntry[],
   courseEntries: CourseRecord[],
+  projectEntries: ProjectRecord[],
 ): Record<string, ContentRoute> => {
   const routes = new Map<string, ContentRoute>();
 
@@ -232,6 +271,25 @@ export const buildRoutes = (
     }
   }
 
+  for (const project of projectEntries) {
+    routes.set(project.path, {
+      path: project.path,
+      title: project.name,
+      description: project.description,
+      sourcePath: project.sourcePath,
+      sourceHash: project.sourceHash,
+      llmsPath: `${project.path}/llms.txt`,
+      openGraphPath: `${project.path}/open-graph.jpg`,
+      contentType: 'project',
+      projectSlug: project.slug,
+      name: project.name,
+      githubUrl: project.githubUrl,
+      ...(project.productionUrl ? { productionUrl: project.productionUrl } : {}),
+      ...(project.writingPath ? { writingPath: project.writingPath } : {}),
+      ...(project.youtubeUrl ? { youtubeUrl: project.youtubeUrl } : {}),
+    });
+  }
+
   return Object.fromEntries(
     [...routes.entries()].sort(([left], [right]) => left.localeCompare(right)),
   );
@@ -250,6 +308,7 @@ export const buildRepositoryHash = (sourceHashes: Map<string, string>): string =
 export const buildSiteIndex = (
   writingEntries: WritingIndexEntry[],
   courseEntries: CourseRecord[],
+  projectEntries: ProjectRecord[],
 ): Pick<ContentRepository, 'lessons' | 'siteIndex'> => {
   const lessonEntries = courseEntries
     .flatMap((course) => course.lessons)
@@ -263,6 +322,9 @@ export const buildSiteIndex = (
           course,
       )
       .sort(compareByDate),
+    projects: [...projectEntries]
+      .map(({ source: _source, ...project }) => project)
+      .sort((left, right) => left.name.localeCompare(right.name)),
   };
 
   return {
@@ -275,6 +337,7 @@ export const buildPrerenderEntries = (
   writingEntries: WritingIndexEntry[],
   courseEntries: CourseRecord[],
   lessonEntries: ContentRepository['lessons'],
+  projectEntries: ProjectIndexEntry[],
 ): GeneratedContent['prerenderEntries'] => {
   const uniqueLessonRedirectSlugs = lessonEntries
     .reduce<Map<string, string | null>>((map, lesson) => {
@@ -309,5 +372,6 @@ export const buildPrerenderEntries = (
       ...lessonEntries.map((entry) => ({ course: entry.courseSlug, lesson: entry.slug })),
       ...lessonEntries.map((entry) => ({ course: entry.courseSlug, lesson: `${entry.slug}.md` })),
     ],
+    projects: projectEntries.map((entry) => ({ project: entry.slug })),
   };
 };

--- a/packages/scripts/content-repository/collect.ts
+++ b/packages/scripts/content-repository/collect.ts
@@ -2,11 +2,12 @@ import fg from 'fast-glob';
 
 import { buildTailwindPlaygroundSource } from '@stevekinney/utilities/tailwind-playground';
 
-import { coursesRoot, writingRoot } from '../content-paths.ts';
+import { coursesRoot, projectsRoot, writingRoot } from '../content-paths.ts';
 
 import {
   buildCourseEntry,
   buildPrerenderEntries,
+  buildProjectEntry,
   buildRepositoryHash,
   buildRoutes,
   buildSiteIndex,
@@ -19,7 +20,11 @@ import type {
   CourseRecord,
   MarkdownSource,
 } from './types.ts';
-import { validateMarkdownLinks, validateRouteCollisions } from './validation.ts';
+import {
+  validateMarkdownLinks,
+  validateProjectFrontmatterLinks,
+  validateRouteCollisions,
+} from './validation.ts';
 
 const collectSourceArtifacts = async (
   source: MarkdownSource,
@@ -56,12 +61,23 @@ export const collectContentRepository = async (): Promise<ContentRepository> => 
     absolute: true,
     onlyDirectories: true,
   });
+  const projectFiles = await fg('*.md', {
+    cwd: projectsRoot,
+    absolute: true,
+    onlyFiles: true,
+  });
   const writingSources = await Promise.all(
     writingFiles.sort().map((file) => loadMarkdownSource(file)),
+  );
+  const projectSources = await Promise.all(
+    projectFiles.sort().map((file) => loadMarkdownSource(file)),
   );
 
   const writingEntries = await Promise.all(
     writingSources.map((source) => buildWritingEntry(source, validationIssues)),
+  );
+  const projectEntries = await Promise.all(
+    projectSources.map((source) => buildProjectEntry(source, validationIssues)),
   );
   const courseEntries = (
     await Promise.all(
@@ -69,8 +85,8 @@ export const collectContentRepository = async (): Promise<ContentRepository> => 
     )
   ).filter((entry): entry is CourseRecord => entry !== null);
 
-  const routes = buildRoutes(writingEntries, courseEntries);
-  validateRouteCollisions(writingEntries, courseEntries, routes, validationIssues);
+  const routes = buildRoutes(writingEntries, courseEntries, projectEntries);
+  validateRouteCollisions(writingEntries, courseEntries, projectEntries, routes, validationIssues);
 
   const routePaths = new Set(Object.keys(routes));
   const courseDirectorySlugs = new Set(courseEntries.map((entry) => entry.slug));
@@ -80,6 +96,17 @@ export const collectContentRepository = async (): Promise<ContentRepository> => 
   for (const writingSource of writingSources) {
     await collectSourceArtifacts(
       writingSource,
+      routePaths,
+      courseDirectorySlugs,
+      sourceHashes,
+      tailwindPlaygrounds,
+      validationIssues,
+    );
+  }
+
+  for (const projectSource of projectSources) {
+    await collectSourceArtifacts(
+      projectSource,
       routePaths,
       courseDirectorySlugs,
       sourceHashes,
@@ -114,9 +141,11 @@ export const collectContentRepository = async (): Promise<ContentRepository> => 
     }
   }
 
+  validateProjectFrontmatterLinks(projectEntries, routePaths, validationIssues);
+
   const sourceFiles = [...sourceHashes.keys()].sort();
   const repositoryHash = buildRepositoryHash(sourceHashes);
-  const { lessons, siteIndex } = buildSiteIndex(writingEntries, courseEntries);
+  const { lessons, siteIndex } = buildSiteIndex(writingEntries, courseEntries, projectEntries);
 
   return {
     meta: {
@@ -130,7 +159,13 @@ export const collectContentRepository = async (): Promise<ContentRepository> => 
     writing: siteIndex.posts,
     courses: siteIndex.courses,
     lessons,
-    prerenderEntries: buildPrerenderEntries(writingEntries, courseEntries, lessons),
+    projects: siteIndex.projects,
+    prerenderEntries: buildPrerenderEntries(
+      writingEntries,
+      courseEntries,
+      lessons,
+      siteIndex.projects,
+    ),
     validationIssues,
     tailwindPlaygroundSource: buildTailwindPlaygroundSource(tailwindPlaygrounds),
     sourceFiles,

--- a/packages/scripts/content-repository/constants.ts
+++ b/packages/scripts/content-repository/constants.ts
@@ -1,6 +1,7 @@
 export const writingReservedSlugs = new Set(['page', 'rss', 'open-graph.jpg', 'llms.txt']);
 export const courseReservedSlugs = new Set(['open-graph.jpg', 'llms.txt']);
 export const lessonReservedSlugs = new Set(['open-graph.jpg', 'llms.txt']);
+export const projectReservedSlugs = new Set(['open-graph.jpg', 'llms.txt']);
 export const staticRoutes = new Set([
   '/',
   '/courses',
@@ -8,6 +9,8 @@ export const staticRoutes = new Set([
   '/llms-full.txt',
   '/llms.txt',
   '/open-graph.jpg',
+  '/projects',
+  '/projects/open-graph.jpg',
   '/sitemap.xml',
   '/writing',
   '/writing/open-graph.jpg',

--- a/packages/scripts/content-repository/types.ts
+++ b/packages/scripts/content-repository/types.ts
@@ -5,6 +5,7 @@ import type {
   CourseIndexEntry,
   GeneratedContent,
   LessonIndexEntry,
+  ProjectIndexEntry,
 } from '@stevekinney/utilities/content-types';
 import { parseFrontmatter } from '@stevekinney/utilities/frontmatter';
 
@@ -47,6 +48,10 @@ export type CourseRecord = CourseIndexEntry & {
   source: MarkdownSource;
   contentsSource?: CourseContentsSource;
   lessons: LessonRecord[];
+};
+
+export type ProjectRecord = ProjectIndexEntry & {
+  source: MarkdownSource;
 };
 
 export type ContentRepository = GeneratedContent & {

--- a/packages/scripts/content-repository/validation.ts
+++ b/packages/scripts/content-repository/validation.ts
@@ -6,6 +6,7 @@ import { normalizeRoutePath } from '@stevekinney/utilities/routes';
 import type {
   ContentRoute,
   CourseContentsData,
+  ProjectIndexEntry,
   WritingIndexEntry,
 } from '@stevekinney/utilities/content-types';
 import type { Root } from 'mdast';
@@ -13,12 +14,18 @@ import { visit } from 'unist-util-visit';
 
 import {
   coursesRoot,
+  projectsRoot,
   resolveRepositoryPath,
   websiteStaticRoot,
   writingRoot,
 } from '../content-paths.ts';
 
-import { courseReservedSlugs, staticRoutes, writingReservedSlugs } from './constants.ts';
+import {
+  courseReservedSlugs,
+  projectReservedSlugs,
+  staticRoutes,
+  writingReservedSlugs,
+} from './constants.ts';
 import { fileExists, isExternalUrl, stripQueryAndHash } from './markdown.ts';
 import type { ContentValidationIssue, CourseRecord, MarkdownReferenceNode } from './types.ts';
 
@@ -44,7 +51,7 @@ export const safeDateString = (
 export const requiredString = (
   file: string,
   value: unknown,
-  field: 'title' | 'description',
+  field: 'title' | 'name' | 'description' | 'githubUrl',
   issues: ContentValidationIssue[],
 ): string => {
   if (typeof value === 'string' && value.trim().length > 0) {
@@ -57,6 +64,53 @@ export const requiredString = (
   });
 
   return '';
+};
+
+export const optionalString = (
+  file: string,
+  value: unknown,
+  field: 'productionUrl' | 'writingPath' | 'youtubeUrl',
+  issues: ContentValidationIssue[],
+): string | undefined => {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  issues.push({
+    file,
+    message: `Invalid '${field}' frontmatter.`,
+  });
+
+  return undefined;
+};
+
+const isUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  } catch {
+    return false;
+  }
+};
+
+export const validateUrlFrontmatter = (
+  file: string,
+  value: string | undefined,
+  field: 'githubUrl' | 'productionUrl' | 'youtubeUrl',
+  issues: ContentValidationIssue[],
+): void => {
+  if (!value) return;
+
+  if (!isUrl(value)) {
+    issues.push({
+      file,
+      message: `Invalid URL in '${field}' frontmatter.`,
+    });
+  }
 };
 
 const validateHeadingAnchor = (
@@ -132,6 +186,17 @@ const validateRootLink = (
     return;
   }
 
+  if (normalized.startsWith('/projects/')) {
+    if (!routePaths.has(normalized)) {
+      issues.push({
+        file,
+        message: `Unknown project route '${urlPath}'.`,
+        line,
+      });
+    }
+    return;
+  }
+
   const staticAssetPath = path.join(websiteStaticRoot, normalized.slice(1));
   if (!existsSync(staticAssetPath)) {
     issues.push({
@@ -150,7 +215,11 @@ const validateRelativeLink = async (
 ): Promise<void> => {
   const resolvedPath = path.resolve(path.dirname(resolveRepositoryPath(file)), urlPath);
 
-  if (!resolvedPath.startsWith(writingRoot) && !resolvedPath.startsWith(coursesRoot)) {
+  if (
+    !resolvedPath.startsWith(writingRoot) &&
+    !resolvedPath.startsWith(coursesRoot) &&
+    !resolvedPath.startsWith(projectsRoot)
+  ) {
     issues.push({
       file,
       message: `Relative link escapes content roots: '${urlPath}'.`,
@@ -275,9 +344,36 @@ export const validateCourseContents = (
   }
 };
 
+export const validateProjectFrontmatterLinks = (
+  projectEntries: ProjectIndexEntry[],
+  routePaths: Set<string>,
+  issues: ContentValidationIssue[],
+): void => {
+  for (const project of projectEntries) {
+    if (!project.writingPath) continue;
+
+    const normalized = normalizeRoutePath(project.writingPath);
+    if (!normalized.startsWith('/writing/')) {
+      issues.push({
+        file: project.sourcePath,
+        message: `Project writingPath '${project.writingPath}' must point at a writing route.`,
+      });
+      continue;
+    }
+
+    if (!routePaths.has(normalized)) {
+      issues.push({
+        file: project.sourcePath,
+        message: `Unknown writing route '${project.writingPath}' in project frontmatter.`,
+      });
+    }
+  }
+};
+
 export const validateRouteCollisions = (
   writingEntries: WritingIndexEntry[],
   courseEntries: CourseRecord[],
+  projectEntries: ProjectIndexEntry[],
   routes: Record<string, ContentRoute>,
   issues: ContentValidationIssue[],
 ): void => {
@@ -295,6 +391,15 @@ export const validateRouteCollisions = (
       issues.push({
         file: course.sourcePath,
         message: `Course slug '${course.slug}' collides with a reserved route.`,
+      });
+    }
+  }
+
+  for (const project of projectEntries) {
+    if (projectReservedSlugs.has(project.slug)) {
+      issues.push({
+        file: project.sourcePath,
+        message: `Project slug '${project.slug}' collides with a reserved route.`,
       });
     }
   }

--- a/packages/scripts/content-repository/validation.ts
+++ b/packages/scripts/content-repository/validation.ts
@@ -214,12 +214,16 @@ const validateRelativeLink = async (
   line?: number,
 ): Promise<void> => {
   const resolvedPath = path.resolve(path.dirname(resolveRepositoryPath(file)), urlPath);
+  const contentRoots = [writingRoot, coursesRoot, projectsRoot];
+  const isInsideContentRoot = contentRoots.some((root) => {
+    const relativeToRoot = path.relative(root, resolvedPath);
+    return (
+      relativeToRoot === '' ||
+      (!relativeToRoot.startsWith('..') && !path.isAbsolute(relativeToRoot))
+    );
+  });
 
-  if (
-    !resolvedPath.startsWith(writingRoot) &&
-    !resolvedPath.startsWith(coursesRoot) &&
-    !resolvedPath.startsWith(projectsRoot)
-  ) {
+  if (!isInsideContentRoot) {
     issues.push({
       file,
       message: `Relative link escapes content roots: '${urlPath}'.`,

--- a/packages/scripts/sync-images.ts
+++ b/packages/scripts/sync-images.ts
@@ -13,7 +13,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = path.resolve(__dirname, '..', '..');
 const MANIFEST_PATH = path.resolve(REPOSITORY_ROOT, 'image-manifest.json');
 
-const MARKDOWN_PATTERNS = ['writing/**/*.md', 'courses/**/*.md'];
+const MARKDOWN_PATTERNS = ['writing/**/*.md', 'courses/**/*.md', 'projects/**/*.md'];
 const TARGET_WIDTHS = [480, 1024, 1600];
 const MAIN_WIDTH = 1600;
 const CONCURRENCY = 10;

--- a/packages/scripts/update-content-dates.ts
+++ b/packages/scripts/update-content-dates.ts
@@ -114,7 +114,7 @@ const main = async () => {
     files = process.argv.slice(2);
   } else {
     // Default: glob all content files
-    const patterns = ['writing/*.md', 'courses/**/*.md'];
+    const patterns = ['writing/*.md', 'courses/**/*.md', 'projects/*.md'];
     files = await fg(patterns, { cwd: REPOSITORY_ROOT, onlyFiles: true });
   }
 

--- a/packages/scripts/validate-image-compatibility.ts
+++ b/packages/scripts/validate-image-compatibility.ts
@@ -7,7 +7,7 @@ import { discoverAllImages } from '@stevekinney/utilities/image-discovery';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = path.resolve(__dirname, '..', '..');
 
-const MARKDOWN_PATTERNS = ['writing/**/*.md', 'courses/**/*.md'];
+const MARKDOWN_PATTERNS = ['writing/**/*.md', 'courses/**/*.md', 'projects/**/*.md'];
 const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.ogg']);
 const NON_TRANSFORMED_EXTENSIONS = new Set(['.webp', '.avif', '.gif', '.svg']);
 

--- a/packages/utilities/content-types.ts
+++ b/packages/utilities/content-types.ts
@@ -21,7 +21,7 @@ export type CourseContentsData = {
   };
 };
 
-export type ContentType = 'writing' | 'course' | 'lesson';
+export type ContentType = 'writing' | 'course' | 'lesson' | 'project';
 
 export type WritingIndexEntry = {
   title: string;
@@ -61,9 +61,23 @@ export type LessonIndexEntry = {
   path: string;
 };
 
+export type ProjectIndexEntry = {
+  name: string;
+  description: string;
+  githubUrl: string;
+  productionUrl?: string;
+  writingPath?: string;
+  youtubeUrl?: string;
+  slug: string;
+  sourcePath: string;
+  sourceHash: string;
+  path: string;
+};
+
 export type SiteContentIndex = {
   posts: WritingIndexEntry[];
   courses: CourseIndexEntry[];
+  projects: ProjectIndexEntry[];
 };
 
 export type ContentRouteBase = {
@@ -99,12 +113,29 @@ export type LessonContentRoute = ContentRouteBase & {
   tags: string[];
 };
 
-export type ContentRoute = WritingContentRoute | CourseContentRoute | LessonContentRoute;
+export type ProjectContentRoute = Omit<ContentRouteBase, 'date' | 'modified'> & {
+  contentType: 'project';
+  projectSlug: string;
+  name: string;
+  githubUrl: string;
+  productionUrl?: string;
+  writingPath?: string;
+  youtubeUrl?: string;
+  date?: string;
+  modified?: string;
+};
+
+export type ContentRoute =
+  | WritingContentRoute
+  | CourseContentRoute
+  | LessonContentRoute
+  | ProjectContentRoute;
 
 export type GeneratedContentPrerenderEntries = {
   writing: Array<{ slug: string }>;
   courses: Array<{ course: string }>;
   lessons: Array<{ course: string; lesson: string }>;
+  projects: Array<{ project: string }>;
 };
 
 export type GeneratedContentMeta = {
@@ -121,5 +152,6 @@ export type GeneratedContent = {
   writing: WritingIndexEntry[];
   courses: CourseIndexEntry[];
   lessons: LessonIndexEntry[];
+  projects: ProjectIndexEntry[];
   prerenderEntries: GeneratedContentPrerenderEntries;
 };

--- a/projects/agent-bureau.md
+++ b/projects/agent-bureau.md
@@ -1,0 +1,10 @@
+---
+name: Agent Bureau
+githubUrl: https://github.com/stevekinney/agent-bureau
+writingPath: /writing/ai-gateway-durable-workflows
+description: 'A playground for durable agent infrastructure: queues, schedules, memory, gateways, and all the glue code that stops being glue once it matters.'
+---
+
+[Agent Bureau](https://github.com/stevekinney/agent-bureau) is where I try out the infrastructure pieces around agentic systems: durable scheduling, memory, gateways, background work, and the small contracts that make a system less surprising after the first successful demonstration.
+
+The related post on [AI gateways and durable workflows](/writing/ai-gateway-durable-workflows) covers some of the shape of that work. The short version is that agents are much easier to take seriously when the surrounding system can remember, retry, audit, and recover without depending on a human to keep the whole state machine in their head.

--- a/projects/cinder.md
+++ b/projects/cinder.md
@@ -1,0 +1,10 @@
+---
+name: Cinder
+githubUrl: https://github.com/stevekinney/cinder
+productionUrl: https://cinder.website
+description: 'A Svelte design system for the components I keep rebuilding anyway, packaged as something I can use across real projects instead of copying snippets around.'
+---
+
+[Cinder](https://github.com/stevekinney/cinder) is my design system because apparently I was not content to merely have opinions about buttons in private. It gives me a shared set of [Svelte](https://svelte.dev/) components, styling conventions, and documentation that I can reuse across projects without starting every interface from a blank `button.svelte` file.
+
+The public site at [cinder.website](https://cinder.website) is part reference, part pressure release valve. If a component is going to be reused, it should have examples, edge cases, and enough documentation that future me cannot pretend he remembers why a prop exists.

--- a/projects/eslint-plugin-temporal.md
+++ b/projects/eslint-plugin-temporal.md
@@ -1,0 +1,10 @@
+---
+name: ESLint Plugin Temporal
+githubUrl: https://github.com/stevekinney/eslint-plugin-temporal
+writingPath: /writing/cursor-rules-temporal-typescript
+description: 'ESLint rules for catching Temporal workflow mistakes before they become replay bugs, which is the polite time to learn about them.'
+---
+
+[ESLint Plugin Temporal](https://github.com/stevekinney/eslint-plugin-temporal) is a small attempt to move [Temporal](https://temporal.io/) mistakes from runtime archaeology into editor feedback. Workflow code has constraints that normal application code does not, especially around determinism and what is safe to do during replay.
+
+I would rather have [ESLint](https://eslint.org/) complain while I am typing than discover later that a workflow history can no longer replay because I did something clever. Clever is fine. Clever plus durable history is where the bill comes due.

--- a/projects/github-webhook-schemas.md
+++ b/projects/github-webhook-schemas.md
@@ -1,0 +1,9 @@
+---
+name: GitHub Webhook Schemas
+githubUrl: https://github.com/stevekinney/github-webhook-schemas
+description: 'TypeScript schemas for GitHub webhook payloads, so webhook handlers can validate reality instead of trusting whatever just hit the endpoint.'
+---
+
+[GitHub Webhook Schemas](https://github.com/stevekinney/github-webhook-schemas) is exactly what it sounds like: schemas for [GitHub](https://github.com/) webhook payloads. Webhooks are one of those places where the data is probably shaped the way you expect, until it is not, and then your handler learns philosophy in production.
+
+The point is to put validation at the boundary. Parse the payload, prove it has the fields you intend to use, and only then let the rest of the application pretend it lives in a typed world.

--- a/projects/octavian.md
+++ b/projects/octavian.md
@@ -1,0 +1,9 @@
+---
+name: Octavian
+githubUrl: https://github.com/stevekinney/octavian
+description: 'Utilities for reasoning about musical notes, frequencies, and intervals in JavaScript without making every project relearn the circle of fifths.'
+---
+
+[Octavian](https://github.com/stevekinney/octavian) is a set of [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) utilities for working with musical notes, frequencies, and intervals. It is for the moments when you want code to understand that `A4` means something more specific than "a string with two characters in it."
+
+This one scratches a very particular itch: music theory is structured enough to model, but human enough that you immediately run into naming, enharmonics, and the tiny lies we tell ourselves so notation remains usable. Honestly, that is most software if you squint.

--- a/projects/protokit.md
+++ b/projects/protokit.md
@@ -1,0 +1,9 @@
+---
+name: Protokit
+githubUrl: https://github.com/stevekinney/protokit
+description: 'A small toolkit for protocol-shaped experiments: the sort of project where the interesting part is making messages explicit enough to reason about.'
+---
+
+[Protokit](https://github.com/stevekinney/protokit) is a small toolkit for protocol-shaped experiments. I tend to reach for this kind of project when I want messages, boundaries, and state transitions to be explicit instead of smeared across whichever file happened to be open when the idea showed up.
+
+The useful thing about protocol work is that it forces honesty. What can be sent? What comes back? What happens when the other side says no, disappears, or sends something technically valid but spiritually unhelpful? Writing those answers down in code is usually where the design starts getting real.

--- a/projects/sandman.md
+++ b/projects/sandman.md
@@ -1,0 +1,10 @@
+---
+name: Sandman
+githubUrl: https://github.com/stevekinney/sandman
+writingPath: /writing/designing-a-system-to-run-untrusted-code
+description: "A sandboxing project for running untrusted code with enough guardrails that the phrase 'what could possibly go wrong' becomes slightly less ominous."
+---
+
+[Sandman](https://github.com/stevekinney/sandman) grew out of the problem of running code you did not write and would like to continue not fully trusting. That usually means containers, limits, tokens, logs, and a long list of things that are obvious only after they have already gone sideways once.
+
+The related write-up on [designing a system to run untrusted code](/writing/designing-a-system-to-run-untrusted-code) gets into the shape of the problem. Sandman is the project version: take the threat model seriously, keep the developer experience tolerable, and do not confuse "it ran on my machine" with a security story.

--- a/projects/stardust.md
+++ b/projects/stardust.md
@@ -1,0 +1,9 @@
+---
+name: Stardust
+githubUrl: https://github.com/stevekinney/stardust
+description: 'A product and interface prototype for turning loosely structured ideas into something you can inspect, refine, and eventually hand to an agent.'
+---
+
+[Stardust](https://github.com/stevekinney/stardust) is a prototype around shaping fuzzy ideas into concrete product work. The interesting bit is not "can an agent write code?" We already know the answer is yes, followed immediately by "and then what?"
+
+This project lives closer to the planning layer: capture intent, expose assumptions, turn ambiguity into inspectable artifacts, and make the next implementation step less like handing a stranger a napkin sketch and hoping they share your taste in architecture.

--- a/projects/temporal-explorer.md
+++ b/projects/temporal-explorer.md
@@ -1,0 +1,10 @@
+---
+name: Temporal Explorer
+githubUrl: https://github.com/stevekinney/temporal-explorer
+writingPath: /writing/build-temporal-workflow
+description: 'An experimental interface for poking at Temporal workflows, histories, and runtime state without turning every debugging session into a scavenger hunt.'
+---
+
+[Temporal Explorer](https://github.com/stevekinney/temporal-explorer) is an experiment in making [Temporal](https://temporal.io/) workflows easier to look at while you are building them. Workflow histories are incredibly useful, but they are also very good at making your eyes glaze over if you are already trying to debug something at 11:37 p.m.
+
+The project is about putting the useful bits closer to the surface: what ran, what waited, what failed, and what the system thinks is supposed to happen next. Durable execution is easier to trust when the runtime is legible.

--- a/projects/temporal-mcp.md
+++ b/projects/temporal-mcp.md
@@ -1,0 +1,10 @@
+---
+name: Temporal MCP
+githubUrl: https://github.com/stevekinney/temporal-mcp
+writingPath: /writing/temporal-developer-skill
+description: 'A Model Context Protocol server for working with Temporal from agent tools, because workflow state is easier to inspect when the agent can ask directly.'
+---
+
+[Temporal MCP](https://github.com/stevekinney/temporal-mcp) connects [Temporal](https://temporal.io/) to the [Model Context Protocol](https://modelcontextprotocol.io/). The idea is pretty simple: if an agent is helping with durable workflows, it should be able to inspect workflows, namespaces, histories, and task queues without me narrating the entire state of the cluster by hand.
+
+This sits in the same general neighborhood as my [Temporal developer skill](/writing/temporal-developer-skill): make the durable system visible to the tool doing the work. Agents get a lot more useful when they can interrogate the runtime instead of guessing from source files and vibes.

--- a/projects/tribunal.md
+++ b/projects/tribunal.md
@@ -1,0 +1,9 @@
+---
+name: Tribunal
+githubUrl: https://github.com/stevekinney/tribunal
+description: 'A review and adjudication interface for agent work, built around the idea that automated feedback still needs a place to become a decision.'
+---
+
+[Tribunal](https://github.com/stevekinney/tribunal) is an interface for reviewing agent work and turning feedback into something actionable. Agents can produce a lot of output very quickly. The hard part is deciding what actually matters, what is already fixed, and what needs to block the next step.
+
+I think of it as a place for review state to stop being ambient conversation. Comments, checks, findings, and decisions belong in a system that can track them explicitly, because "I saw that somewhere in the thread" is not a process. It is barely a coping mechanism.

--- a/projects/vector-frankl.md
+++ b/projects/vector-frankl.md
@@ -1,0 +1,10 @@
+---
+name: Vector Frankl
+githubUrl: https://github.com/stevekinney/vector-frankl
+writingPath: /writing/using-a-vector-database
+description: "A semantic search and vector database experiment, because sometimes the question is not 'what matched?' but 'what was this kind of like?'"
+---
+
+[Vector Frankl](https://github.com/stevekinney/vector-frankl) is a semantic search experiment built around vector embeddings and retrieval. Keyword search is great until you cannot remember the keyword. Then you want the computer to understand "that thing about the architecture decision with the weird tradeoff" and somehow not make you regret asking.
+
+The related post on [using a vector database](/writing/using-a-vector-database) covers the underlying idea: represent meaning as numbers, compare those numbers, and accept that "meaning as numbers" sounds fake right up until it is useful.

--- a/projects/weft.md
+++ b/projects/weft.md
@@ -1,0 +1,9 @@
+---
+name: Weft
+githubUrl: https://github.com/stevekinney/weft
+description: 'Durable execution primitives for TypeScript applications that need workflows, retries, timers, and real state without pretending distributed systems are easy.'
+---
+
+I built [Weft](https://github.com/stevekinney/weft) because I kept wanting the boring parts of durable execution without hauling in a whole operations department. Sometimes you need a workflow to survive a restart, wait for a timer, retry the thing that failed, and remember where it was when the process fell over. That should not require a blood oath.
+
+The goal is to make durable workflows feel like normal [TypeScript](https://www.typescriptlang.org/) code: explicit enough that you can reason about it, small enough that you can actually read it, and honest about the fact that time, retries, and side effects are where otherwise reasonable programs go to learn humility.

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,8 @@
         "../content-enhancements/src/**/*.ts",
         "../../applications/website/static/**",
         "../../writing/**",
-        "../../courses/**"
+        "../../courses/**",
+        "../../projects/**"
       ],
       "outputs": [
         "../../applications/website/.generated/content-data.json",
@@ -43,7 +44,8 @@
         "../utilities/tailwind-playground.ts",
         "../../applications/website/static/**",
         "../../writing/**",
-        "../../courses/**"
+        "../../courses/**",
+        "../../projects/**"
       ]
     },
     "@stevekinney/scripts#content:images:check": {
@@ -52,7 +54,8 @@
         "validate-image-compatibility.ts",
         "../../image-manifest.json",
         "../../writing/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}",
-        "../../courses/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}"
+        "../../courses/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}",
+        "../../projects/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}"
       ]
     },
     "@stevekinney/scripts#images:check": {
@@ -60,7 +63,8 @@
         "check-image-manifest.ts",
         "../../image-manifest.json",
         "../../writing/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}",
-        "../../courses/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}"
+        "../../courses/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}",
+        "../../projects/**/*.{png,jpg,jpeg,svg,gif,avif,webp,mp4}"
       ]
     },
     "@stevekinney/scripts#images:sync": {
@@ -81,6 +85,7 @@
         "../utilities/tailwind-playground.ts",
         "../../writing/**/*.md",
         "../../courses/**/*.md",
+        "../../projects/**/*.md",
         "../../courses/*/index.toml"
       ]
     },


### PR DESCRIPTION
## Summary
- Add project content to the generated repository, routes, and sitemap
- Render project documents and expose project metadata for open graph and navigation
- Add project listing/detail coverage in unit tests

## Testing
- Unit tests updated for project content lookups, open graph metadata, and sitemap entries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared content build artifact and many site routes, but largely mirrors existing writing/course patterns with added unit tests rather than new security-sensitive logic.
> 
> **Overview**
> Adds **projects** as a first-class content type (markdown under `projects/`) wired through the same generated repository, prerender, and site surfaces as writing and courses.
> 
> The content build now discovers project files, validates frontmatter (`name`, `description`, `githubUrl`, optional URLs and `writingPath`), emits routes/index/prerender entries, and includes projects in link validation and image tooling. The website gets **`/projects`** and **`/projects/[slug]`** pages (SSR/prerendered markdown HTML, GitHub/production/writing links, optional YouTube embed), a **Projects** nav item, sitemap and **open graph** metadata, and **llms.txt** / **llms-full.txt** coverage. Fourteen initial project pages are added in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac88c0510ac9140fdfc7c10fd7655431562100f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->