### PR TITLE
Add /dashboard: live GitHub, npm, and course stats

### DIFF
--- a/applications/website/.env.example
+++ b/applications/website/.env.example
@@ -1,0 +1,8 @@
+# Token for the /dashboard data loader (server-side only). Public read access is
+# enough — a fine-grained personal access token with no extra scopes works. The
+# GitHub GraphQL API rejects unauthenticated requests entirely, so without a
+# token the dashboard's GitHub section reports an error state.
+#
+# GITHUB_DASHBOARD_TOKEN is read first, falling back to GITHUB_TOKEN, so a stale
+# GITHUB_TOKEN exported by your shell can't shadow the one configured here.
+GITHUB_DASHBOARD_TOKEN=""

--- a/applications/website/src/lib/dashboard-types.ts
+++ b/applications/website/src/lib/dashboard-types.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared types for the `/dashboard` page, its API endpoints, and its feeds.
+ *
+ * These types are client-safe: the page imports them for rendering, and the
+ * server-only modules under `$lib/server/dashboard/` produce them.
+ */
+
+/** The rolling twelve-month window a dashboard snapshot covers. */
+export type DashboardStatWindow = {
+  /** ISO 8601 timestamp; inclusive start of the window. */
+  from: string;
+  /** ISO 8601 timestamp; exclusive end of the window. */
+  to: string;
+};
+
+/** Commit volume for a single repository within the window. */
+export type GithubRepositoryCommits = {
+  nameWithOwner: string;
+  url: string;
+  stargazerCount: number;
+  commits: number;
+};
+
+/** GitHub activity for the window plus a few profile-level totals. */
+export type GithubStats = {
+  login: string;
+  profileUrl: string;
+  followers: number;
+  publicRepositories: number;
+  totalStars: number;
+  pullRequests: {
+    /** Pull requests currently open, regardless of when they were opened. */
+    openNow: number;
+    mergedLastYear: number;
+  };
+  commits: {
+    totalLastYear: number;
+    /** GitHub's `restrictedContributionsCount` — activity in private repositories. */
+    privateContributionsLastYear: number;
+    /** Sorted by commit count, descending. */
+    byRepository: GithubRepositoryCommits[];
+  };
+  issues: {
+    openedLastYear: number;
+    closedLastYear: number;
+  };
+  reviews: {
+    totalLastYear: number;
+  };
+};
+
+/** Download stats for a single npm package. */
+export type NpmPackageStats = {
+  name: string;
+  description?: string;
+  version: string;
+  url: string;
+  downloadsLastYear: number;
+};
+
+/** npm activity across every package Steve maintains. */
+export type NpmStats = {
+  packageCount: number;
+  totalDownloadsLastYear: number;
+  /** Sorted by downloads, descending. */
+  topPackages: NpmPackageStats[];
+};
+
+/** A course in this repository, annotated with its most recent commit. */
+export type CourseUpdate = {
+  slug: string;
+  title: string;
+  description: string;
+  /** Site path, e.g. `/courses/react-typescript`. */
+  path: string;
+  lessonCount: number;
+  /** ISO 8601 timestamp of the latest commit touching the course directory. */
+  lastUpdatedAt: string;
+  lastCommit: {
+    /** First line of the commit message. */
+    message: string;
+    url: string;
+    sha: string;
+  } | null;
+};
+
+/**
+ * A dashboard section either resolved or failed; failures carry a message so
+ * the page can render the healthy sections and explain the missing one.
+ */
+export type DashboardSection<T> = { status: 'ok'; data: T } | { status: 'error'; error: string };
+
+/** The full dashboard snapshot served by `/api/dashboard`. */
+export type DashboardData = {
+  /** ISO 8601 timestamp of when this snapshot was computed. */
+  generatedAt: string;
+  window: DashboardStatWindow;
+  github: DashboardSection<GithubStats>;
+  npm: DashboardSection<NpmStats>;
+  courses: DashboardSection<CourseUpdate[]>;
+};

--- a/applications/website/src/lib/llms-path.test.ts
+++ b/applications/website/src/lib/llms-path.test.ts
@@ -7,6 +7,10 @@ describe('createLlmsAlternatePath', () => {
     expect(createLlmsAlternatePath('/')).toBe('/llms.txt');
   });
 
+  it('returns a per-page llms route for the dashboard', () => {
+    expect(createLlmsAlternatePath('/dashboard')).toBe('/dashboard/llms.txt');
+  });
+
   it('returns a per-post llms route for writing detail pages', () => {
     expect(createLlmsAlternatePath('/writing/agent-loops')).toBe('/writing/agent-loops/llms.txt');
   });
@@ -38,5 +42,11 @@ describe('createLlmsAlternatePath', () => {
     expect(createLlmsAlternatePath('/writing/rss')).toBeNull();
     expect(createLlmsAlternatePath('/writing/open-graph.jpg')).toBeNull();
     expect(createLlmsAlternatePath('/projects/open-graph.jpg')).toBeNull();
+  });
+
+  it('does not emit llms alternates for the dashboard feed and its own mirror', () => {
+    expect(createLlmsAlternatePath('/dashboard/rss')).toBeNull();
+    expect(createLlmsAlternatePath('/dashboard/llms.txt')).toBeNull();
+    expect(createLlmsAlternatePath('/dashboard/open-graph.jpg')).toBeNull();
   });
 });

--- a/applications/website/src/lib/llms-path.ts
+++ b/applications/website/src/lib/llms-path.ts
@@ -14,6 +14,10 @@ export const createLlmsAlternatePath = (pathname: string): string | null => {
     return '/llms.txt';
   }
 
+  if (segments[0] === 'dashboard' && segments.length === 1) {
+    return `${normalizedPath}/llms.txt`;
+  }
+
   if (segments[0] === 'writing' && segments.length === 2 && !isReservedSegment(segments[1])) {
     return `${normalizedPath}/llms.txt`;
   }

--- a/applications/website/src/lib/server/dashboard/cache.test.ts
+++ b/applications/website/src/lib/server/dashboard/cache.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCachedLoader } from './cache';
+
+const TIME_TO_LIVE = 24 * 60 * 60 * 1000;
+const RETRY_TIME_TO_LIVE = 5 * 60 * 1000;
+
+type Value = { complete: boolean; id: number };
+
+const createLoader = (compute: () => Promise<Value>) =>
+  createCachedLoader(compute, {
+    timeToLive: TIME_TO_LIVE,
+    retryTimeToLive: RETRY_TIME_TO_LIVE,
+    isComplete: (value) => value.complete,
+  });
+
+describe('createCachedLoader', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes on first call and serves the cached value within the time to live', async () => {
+    const compute = vi.fn(async (): Promise<Value> => ({ complete: true, id: 1 }));
+    const load = createLoader(compute);
+
+    await expect(load()).resolves.toEqual({ complete: true, id: 1 });
+
+    vi.advanceTimersByTime(TIME_TO_LIVE - 1);
+
+    await expect(load()).resolves.toEqual({ complete: true, id: 1 });
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes once the time to live has elapsed', async () => {
+    let id = 0;
+    const compute = vi.fn(async (): Promise<Value> => ({ complete: true, id: (id += 1) }));
+    const load = createLoader(compute);
+
+    await expect(load()).resolves.toEqual({ complete: true, id: 1 });
+
+    vi.advanceTimersByTime(TIME_TO_LIVE);
+
+    await expect(load()).resolves.toEqual({ complete: true, id: 2 });
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes concurrent callers onto a single in-flight computation', async () => {
+    let resolve: ((value: Value) => void) | undefined;
+    const compute = vi.fn(
+      () =>
+        new Promise<Value>((promiseResolve) => {
+          resolve = promiseResolve;
+        }),
+    );
+    const load = createLoader(compute);
+
+    const first = load();
+    const second = load();
+
+    resolve?.({ complete: true, id: 1 });
+
+    await expect(first).resolves.toEqual({ complete: true, id: 1 });
+    await expect(second).resolves.toEqual({ complete: true, id: 1 });
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds an incomplete value only for the retry time to live', async () => {
+    let id = 0;
+    const compute = vi.fn(async (): Promise<Value> => ({ complete: false, id: (id += 1) }));
+    const load = createLoader(compute);
+
+    await expect(load()).resolves.toEqual({ complete: false, id: 1 });
+
+    vi.advanceTimersByTime(RETRY_TIME_TO_LIVE - 1);
+
+    await expect(load()).resolves.toEqual({ complete: false, id: 1 });
+
+    vi.advanceTimersByTime(1);
+
+    await expect(load()).resolves.toEqual({ complete: false, id: 2 });
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches nothing when the computation rejects, so the next caller retries', async () => {
+    const compute = vi
+      .fn<() => Promise<Value>>()
+      .mockRejectedValueOnce(new Error('upstream unavailable'))
+      .mockResolvedValueOnce({ complete: true, id: 2 });
+    const load = createLoader(compute);
+
+    await expect(load()).rejects.toThrow('upstream unavailable');
+    await expect(load()).resolves.toEqual({ complete: true, id: 2 });
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/applications/website/src/lib/server/dashboard/cache.ts
+++ b/applications/website/src/lib/server/dashboard/cache.ts
@@ -1,0 +1,49 @@
+type CachedLoaderOptions<T> = {
+  /** How long a complete snapshot is served before recomputing, in milliseconds. */
+  timeToLive: number;
+  /** How long an incomplete snapshot is served before retrying, in milliseconds. */
+  retryTimeToLive: number;
+  /** Decides which time-to-live applies to a freshly computed value. */
+  isComplete: (value: T) => boolean;
+};
+
+type Snapshot<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+/**
+ * Wraps an expensive computation in a time-based, per-instance memo.
+ *
+ * The returned function serves the cached value until it expires, dedupes
+ * concurrent callers onto a single in-flight computation, and — because a
+ * failed computation should not be served for a full day — applies the shorter
+ * `retryTimeToLive` when `isComplete` reports the value as partial. A rejected
+ * computation caches nothing, so the next caller retries immediately.
+ */
+export const createCachedLoader = <T>(
+  compute: () => Promise<T>,
+  options: CachedLoaderOptions<T>,
+): (() => Promise<T>) => {
+  let snapshot: Snapshot<T> | null = null;
+  let inFlight: Promise<T> | null = null;
+
+  return () => {
+    if (snapshot && Date.now() < snapshot.expiresAt) return Promise.resolve(snapshot.value);
+    if (inFlight) return inFlight;
+
+    inFlight = compute()
+      .then((value) => {
+        const timeToLive = options.isComplete(value) ? options.timeToLive : options.retryTimeToLive;
+
+        snapshot = { value, expiresAt: Date.now() + timeToLive };
+
+        return value;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+
+    return inFlight;
+  };
+};

--- a/applications/website/src/lib/server/dashboard/courses.test.ts
+++ b/applications/website/src/lib/server/dashboard/courses.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const env = vi.hoisted(() => ({ GITHUB_DASHBOARD_TOKEN: '', GITHUB_TOKEN: '' }));
+vi.mock('$env/dynamic/private', () => ({ env }));
+
+const content = vi.hoisted(() => ({
+  getCourseIndex: vi.fn(),
+  getGeneratedContent: vi.fn(),
+}));
+vi.mock('$lib/server/content', () => content);
+
+import { fetchCourseUpdates } from './courses';
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+const courseEntry = (overrides: Record<string, unknown> = {}) => {
+  const slug = (overrides.slug as string | undefined) ?? 'course-a';
+
+  return {
+    title: 'Course Title',
+    description: 'Course description',
+    date: '2025-01-01',
+    modified: '2025-02-01',
+    slug,
+    sourcePath: `courses/${slug}/README.md`,
+    sourceHash: 'hash',
+    path: `/courses/${slug}`,
+    ...overrides,
+  };
+};
+
+const commit = (overrides: Record<string, unknown> = {}) => ({
+  sha: 'abc123',
+  html_url: 'https://github.com/stevekinney/stevekinney.net/commit/abc123',
+  commit: {
+    message: 'Update lesson\n\nMore detail here.',
+    committer: { date: '2026-03-01T00:00:00.000Z' },
+  },
+  ...overrides,
+});
+
+describe('fetchCourseUpdates', () => {
+  beforeEach(() => {
+    env.GITHUB_DASHBOARD_TOKEN = '';
+    env.GITHUB_TOKEN = '';
+    content.getGeneratedContent.mockReturnValue({ lessons: [] });
+  });
+
+  it('maps the latest commit to a course update, taking only the first message line', async () => {
+    content.getCourseIndex.mockReturnValue([courseEntry()]);
+    content.getGeneratedContent.mockReturnValue({
+      lessons: [
+        { slug: 'lesson-1', courseSlug: 'course-a' },
+        { slug: 'lesson-2', courseSlug: 'course-a' },
+        { slug: 'lesson-3', courseSlug: 'other-course' },
+      ],
+    });
+
+    const fetchMock = vi.fn(async () => jsonResponse([commit()]));
+
+    const [update] = await fetchCourseUpdates(fetchMock);
+
+    expect(update).toEqual({
+      slug: 'course-a',
+      title: 'Course Title',
+      description: 'Course description',
+      path: '/courses/course-a',
+      lessonCount: 2,
+      lastUpdatedAt: '2026-03-01T00:00:00.000Z',
+      lastCommit: {
+        message: 'Update lesson',
+        url: 'https://github.com/stevekinney/stevekinney.net/commit/abc123',
+        sha: 'abc123',
+      },
+    });
+  });
+
+  it('requests the commits API with the URL-encoded course directory', async () => {
+    content.getCourseIndex.mockReturnValue([
+      courseEntry({ sourcePath: 'courses/foo bar/README.md' }),
+    ]);
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse([commit()]),
+    );
+
+    await fetchCourseUpdates(fetchMock);
+
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    const expectedUrl =
+      'https://api.github.com/repos/stevekinney/stevekinney.net/commits' +
+      '?path=courses%2Ffoo%20bar&per_page=1';
+    expect(String(url)).toBe(expectedUrl);
+  });
+
+  it('adds an Authorization header only when a token is configured', async () => {
+    content.getCourseIndex.mockReturnValue([courseEntry()]);
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse([commit()]),
+    );
+
+    await fetchCourseUpdates(fetchMock);
+    const [, initWithoutToken] = fetchMock.mock.calls[0] ?? [];
+    const headersWithoutToken = initWithoutToken?.headers as Record<string, string> | undefined;
+    expect(headersWithoutToken?.Authorization).toBeUndefined();
+
+    fetchMock.mockClear();
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+
+    await fetchCourseUpdates(fetchMock);
+    const [, initWithToken] = fetchMock.mock.calls[0] ?? [];
+    const headersWithToken = initWithToken?.headers as Record<string, string> | undefined;
+    expect(headersWithToken?.Authorization).toBe('Bearer test-token');
+  });
+
+  it('falls back to frontmatter modified when a course has no commits', async () => {
+    content.getCourseIndex.mockReturnValue([
+      courseEntry({ slug: 'course-b', date: '2025-01-01', modified: '2025-06-01' }),
+    ]);
+    const fetchMock = vi.fn(async () => jsonResponse([]));
+
+    const [update] = await fetchCourseUpdates(fetchMock);
+
+    expect(update?.lastCommit).toBeNull();
+    expect(update?.lastUpdatedAt).toBe('2025-06-01');
+  });
+
+  it('falls back to frontmatter date when modified is empty and the request failed', async () => {
+    content.getCourseIndex.mockReturnValue([
+      courseEntry({ slug: 'course-c', date: '2025-01-01', modified: '' }),
+      courseEntry({ slug: 'course-d' }),
+    ]);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('course-c')) throw new Error('network down');
+      return jsonResponse([commit()]);
+    });
+
+    const updates = await fetchCourseUpdates(fetchMock);
+    const failed = updates.find((update) => update.slug === 'course-c');
+
+    expect(failed?.lastCommit).toBeNull();
+    expect(failed?.lastUpdatedAt).toBe('2025-01-01');
+  });
+
+  it('throws when every course request fails with a non-2xx response', async () => {
+    content.getCourseIndex.mockReturnValue([courseEntry()]);
+    const fetchMock = vi.fn(async () => jsonResponse({}, 502));
+
+    await expect(fetchCourseUpdates(fetchMock)).rejects.toThrow(
+      'Failed to load commit history for every course.',
+    );
+  });
+
+  it('throws only when every course request fails', async () => {
+    content.getCourseIndex.mockReturnValue([
+      courseEntry({ slug: 'course-a' }),
+      courseEntry({ slug: 'course-b' }),
+    ]);
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network down');
+    });
+
+    await expect(fetchCourseUpdates(fetchMock)).rejects.toThrow(
+      'Failed to load commit history for every course.',
+    );
+  });
+
+  it('does not throw when only some course requests fail', async () => {
+    content.getCourseIndex.mockReturnValue([
+      courseEntry({ slug: 'course-a', modified: '2025-05-01' }),
+      courseEntry({ slug: 'course-b', modified: '2025-06-01' }),
+    ]);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('course-a')) throw new Error('network down');
+      return jsonResponse([commit()]);
+    });
+
+    const updates = await fetchCourseUpdates(fetchMock);
+
+    expect(updates).toHaveLength(2);
+    expect(updates.find((update) => update.slug === 'course-a')?.lastCommit).toBeNull();
+  });
+
+  it('sorts courses by lastUpdatedAt descending', async () => {
+    content.getCourseIndex.mockReturnValue([
+      courseEntry({ slug: 'older', modified: '2024-01-01' }),
+      courseEntry({ slug: 'newer', modified: '2026-01-01' }),
+    ]);
+    const fetchMock = vi.fn(async () => jsonResponse([]));
+
+    const updates = await fetchCourseUpdates(fetchMock);
+
+    expect(updates.map((update) => update.slug)).toEqual(['newer', 'older']);
+  });
+});

--- a/applications/website/src/lib/server/dashboard/courses.ts
+++ b/applications/website/src/lib/server/dashboard/courses.ts
@@ -103,10 +103,15 @@ export const fetchCourseUpdates = async (
     throw new Error('Failed to load commit history for every course.');
   }
 
+  const lessonCountsBySlug = new Map<string, number>();
+  for (const lesson of lessons) {
+    lessonCountsBySlug.set(lesson.courseSlug, (lessonCountsBySlug.get(lesson.courseSlug) ?? 0) + 1);
+  }
+
   const courseUpdates = entries.map((entry, index) => {
     const result = settled[index];
     const commit = result?.status === 'fulfilled' ? result.value : null;
-    const lessonCount = lessons.filter((lesson) => lesson.courseSlug === entry.slug).length;
+    const lessonCount = lessonCountsBySlug.get(entry.slug) ?? 0;
 
     return {
       slug: entry.slug,

--- a/applications/website/src/lib/server/dashboard/courses.ts
+++ b/applications/website/src/lib/server/dashboard/courses.ts
@@ -1,0 +1,125 @@
+import { env } from '$env/dynamic/private';
+import { z } from 'zod';
+
+import type { CourseUpdate } from '$lib/dashboard-types';
+import { getCourseIndex, getGeneratedContent } from '$lib/server/content';
+
+const GITHUB_COMMITS_URL = 'https://api.github.com/repos/stevekinney/stevekinney.net/commits';
+const REQUEST_TIMEOUT_MILLISECONDS = 10_000;
+
+const GithubCommitSchema = z.object({
+  sha: z.string(),
+  html_url: z.string(),
+  commit: z.object({
+    message: z.string(),
+    committer: z.object({ date: z.string() }),
+  }),
+});
+
+const GithubCommitsResponseSchema = z.array(GithubCommitSchema);
+
+type CourseCommit = {
+  sha: string;
+  url: string;
+  message: string;
+  lastUpdatedAt: string;
+};
+
+/** Strips the trailing filename from a source path, e.g. `courses/x/README.md` → `courses/x`. */
+const toRepositoryDirectory = (sourcePath: string): string => {
+  const segments = sourcePath.split('/');
+  segments.pop();
+
+  return segments.join('/');
+};
+
+/**
+ * Fetches the most recent commit touching a course's directory. Works
+ * unauthenticated — the token is only added when one is configured, and its
+ * absence is not treated as a failure here (unlike the GitHub dashboard
+ * section, which requires one).
+ */
+const fetchLatestCourseCommit = async (
+  fetchImpl: typeof globalThis.fetch,
+  token: string | undefined,
+  directory: string,
+): Promise<CourseCommit | null> => {
+  const url = `${GITHUB_COMMITS_URL}?path=${encodeURIComponent(directory)}&per_page=1`;
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'stevekinney.net-dashboard',
+  };
+
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetchImpl(url, {
+    headers,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MILLISECONDS),
+  });
+
+  if (!response.ok) {
+    const status = response.status;
+    throw new Error(`GitHub commits request for ${directory} failed with status ${status}`);
+  }
+
+  const parsed = GithubCommitsResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error(`GitHub commits response for ${directory} did not match the expected shape.`);
+  }
+
+  const [latest] = parsed.data;
+  if (!latest) return null;
+
+  return {
+    sha: latest.sha,
+    url: latest.html_url,
+    message: latest.commit.message.split('\n')[0],
+    lastUpdatedAt: latest.commit.committer.date,
+  };
+};
+
+/**
+ * Fetches every course, annotated with its latest commit and lesson count.
+ * A course with no commits (or a failed request for it) falls back to the
+ * entry's frontmatter `modified` (or `date`) for `lastUpdatedAt` and reports
+ * `lastCommit: null`. Throws only when every course's request failed — that
+ * signals an outage worth reporting rather than silently showing stale
+ * frontmatter for the whole section.
+ */
+export const fetchCourseUpdates = async (
+  fetchImpl: typeof globalThis.fetch,
+): Promise<CourseUpdate[]> => {
+  const token = env.GITHUB_DASHBOARD_TOKEN || env.GITHUB_TOKEN;
+  const entries = getCourseIndex();
+  const lessons = getGeneratedContent().lessons;
+
+  const settled = await Promise.allSettled(
+    entries.map((entry) =>
+      fetchLatestCourseCommit(fetchImpl, token, toRepositoryDirectory(entry.sourcePath)),
+    ),
+  );
+
+  if (entries.length > 0 && settled.every((result) => result.status === 'rejected')) {
+    throw new Error('Failed to load commit history for every course.');
+  }
+
+  const courseUpdates = entries.map((entry, index) => {
+    const result = settled[index];
+    const commit = result?.status === 'fulfilled' ? result.value : null;
+    const lessonCount = lessons.filter((lesson) => lesson.courseSlug === entry.slug).length;
+
+    return {
+      slug: entry.slug,
+      title: entry.title,
+      description: entry.description,
+      path: entry.path,
+      lessonCount,
+      lastUpdatedAt: commit?.lastUpdatedAt ?? (entry.modified || entry.date),
+      lastCommit: commit ? { message: commit.message, url: commit.url, sha: commit.sha } : null,
+    };
+  });
+
+  return courseUpdates.sort(
+    (a, b) => new Date(b.lastUpdatedAt).getTime() - new Date(a.lastUpdatedAt).getTime(),
+  );
+};

--- a/applications/website/src/lib/server/dashboard/github.test.ts
+++ b/applications/website/src/lib/server/dashboard/github.test.ts
@@ -1,0 +1,355 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DashboardStatWindow } from '$lib/dashboard-types';
+
+const env = vi.hoisted(() => ({
+  GITHUB_DASHBOARD_TOKEN: '',
+  GITHUB_TOKEN: '',
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env }));
+
+import { fetchGithubStats } from './github';
+
+const WINDOW: DashboardStatWindow = {
+  from: '2025-07-20T00:00:00.000Z',
+  to: '2026-07-20T00:00:00.000Z',
+};
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+const DEFAULT_REPO = {
+  nameWithOwner: 'stevekinney/example',
+  url: 'https://github.com/stevekinney/example',
+  stargazerCount: 5,
+};
+
+type GraphqlCall = { query: string; variables: Record<string, unknown> };
+
+const parseGraphqlBody = (body: unknown): GraphqlCall => JSON.parse(String(body));
+
+type Handlers = {
+  profile?: () => Response;
+  totalCommitContributions?: () => Response;
+  restrictedContributionsCount?: () => Response;
+  totalPullRequestReviewContributions?: () => Response;
+  commitContributionsByRepository?: (call: GraphqlCall) => Response;
+  searchCounts?: () => Response;
+  repositories?: (call: GraphqlCall) => Response;
+};
+
+/** Builds a fetch stub for every request `fetchGithubStats` makes, with overridable handlers. */
+const buildFetchMock = (handlers: Handlers = {}) =>
+  vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = String(input);
+
+    if (url === 'https://api.github.com/users/stevekinney') {
+      return (handlers.profile ?? (() => jsonResponse({ followers: 10, public_repos: 20 })))();
+    }
+
+    if (url !== 'https://api.github.com/graphql') {
+      throw new Error(`Unhandled fetch: ${url}`);
+    }
+
+    const call = parseGraphqlBody(init?.body);
+
+    if (call.query.includes('totalCommitContributions')) {
+      return (
+        handlers.totalCommitContributions ??
+        (() =>
+          jsonResponse({
+            data: { user: { contributionsCollection: { totalCommitContributions: 100 } } },
+          }))
+      )();
+    }
+
+    if (call.query.includes('restrictedContributionsCount')) {
+      return (
+        handlers.restrictedContributionsCount ??
+        (() =>
+          jsonResponse({
+            data: { user: { contributionsCollection: { restrictedContributionsCount: 7 } } },
+          }))
+      )();
+    }
+
+    if (call.query.includes('totalPullRequestReviewContributions')) {
+      return (
+        handlers.totalPullRequestReviewContributions ??
+        (() =>
+          jsonResponse({
+            data: {
+              user: { contributionsCollection: { totalPullRequestReviewContributions: 3 } },
+            },
+          }))
+      )();
+    }
+
+    if (call.query.includes('commitContributionsByRepository')) {
+      return (
+        handlers.commitContributionsByRepository ??
+        (() =>
+          jsonResponse({
+            data: {
+              user: {
+                contributionsCollection: {
+                  commitContributionsByRepository: [
+                    { repository: DEFAULT_REPO, contributions: { totalCount: 1 } },
+                  ],
+                },
+              },
+            },
+          }))
+      )(call);
+    }
+
+    if (call.query.includes('mergedLastYear:')) {
+      return (
+        handlers.searchCounts ??
+        (() =>
+          jsonResponse({
+            data: {
+              mergedLastYear: { issueCount: 1 },
+              openNow: { issueCount: 2 },
+              openedLastYear: { issueCount: 3 },
+              closedLastYear: { issueCount: 4 },
+            },
+          }))
+      )();
+    }
+
+    if (call.query.includes('repositories(ownerAffiliations')) {
+      return (
+        handlers.repositories ??
+        (() =>
+          jsonResponse({
+            data: {
+              user: {
+                repositories: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [{ stargazerCount: 5 }, { stargazerCount: 5 }],
+                },
+              },
+            },
+          }))
+      )(call);
+    }
+
+    throw new Error(`Unhandled GraphQL query: ${call.query}`);
+  });
+
+describe('fetchGithubStats', () => {
+  beforeEach(() => {
+    env.GITHUB_DASHBOARD_TOKEN = '';
+    env.GITHUB_TOKEN = '';
+  });
+
+  it('throws when no token is configured', async () => {
+    const fetchMock = vi.fn();
+
+    await expect(fetchGithubStats(fetchMock, WINDOW)).rejects.toThrow(
+      'Set GITHUB_DASHBOARD_TOKEN (or GITHUB_TOKEN) to enable the GitHub section of the dashboard.',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to GITHUB_TOKEN when GITHUB_DASHBOARD_TOKEN is unset', async () => {
+    env.GITHUB_TOKEN = 'fallback-token';
+    const fetchMock = buildFetchMock();
+
+    const stats = await fetchGithubStats(fetchMock, WINDOW);
+    expect(stats.login).toBe('stevekinney');
+  });
+
+  it('returns the full stats shape on a happy path', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    const fetchMock = buildFetchMock();
+
+    const stats = await fetchGithubStats(fetchMock, WINDOW);
+
+    expect(stats.login).toBe('stevekinney');
+    expect(stats.profileUrl).toBe('https://github.com/stevekinney');
+    expect(stats.followers).toBe(10);
+    expect(stats.publicRepositories).toBe(20);
+    expect(stats.commits.totalLastYear).toBe(100);
+    expect(stats.commits.privateContributionsLastYear).toBe(7);
+    expect(stats.reviews.totalLastYear).toBe(3);
+    expect(stats.totalStars).toBe(10);
+  });
+
+  it('throws including the status code on a non-2xx response', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    const fetchMock = buildFetchMock({ profile: () => jsonResponse({ message: 'nope' }, 503) });
+
+    await expect(fetchGithubStats(fetchMock, WINDOW)).rejects.toThrow(/503/);
+  });
+
+  it('throws the first message when the GraphQL errors array is non-empty', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    const fetchMock = buildFetchMock({
+      searchCounts: () => jsonResponse({ errors: [{ message: 'boom' }, { message: 'other' }] }),
+    });
+
+    await expect(fetchGithubStats(fetchMock, WINDOW)).rejects.toThrow('boom');
+  });
+
+  it('throws when a GraphQL response does not match the expected shape', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    const fetchMock = buildFetchMock({
+      totalCommitContributions: () => jsonResponse({ data: { user: {} } }),
+    });
+
+    await expect(fetchGithubStats(fetchMock, WINDOW)).rejects.toThrow(
+      /did not match the expected shape/,
+    );
+  });
+
+  it('throws when the profile response does not match the expected shape', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    const fetchMock = buildFetchMock({ profile: () => jsonResponse({ nope: true }) });
+
+    await expect(fetchGithubStats(fetchMock, WINDOW)).rejects.toThrow(
+      'GitHub profile response did not match the expected shape.',
+    );
+  });
+
+  it('maps each search alias to its corresponding pull request or issue stat', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    const fetchMock = buildFetchMock({
+      searchCounts: () =>
+        jsonResponse({
+          data: {
+            mergedLastYear: { issueCount: 11 },
+            openNow: { issueCount: 22 },
+            openedLastYear: { issueCount: 33 },
+            closedLastYear: { issueCount: 44 },
+          },
+        }),
+    });
+
+    const stats = await fetchGithubStats(fetchMock, WINDOW);
+
+    expect(stats.pullRequests).toEqual({ mergedLastYear: 11, openNow: 22 });
+    expect(stats.issues).toEqual({ openedLastYear: 33, closedLastYear: 44 });
+  });
+
+  it('stitches twelve monthly windows, aggregating commits by repository', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+
+    const repositories = Array.from({ length: 12 }, (_, index) => ({
+      repository: {
+        nameWithOwner: `stevekinney/repo-${index + 1}`,
+        url: `https://github.com/stevekinney/repo-${index + 1}`,
+        stargazerCount: index,
+      },
+      contributions: { totalCount: index + 1 },
+    }));
+
+    const fetchMock = buildFetchMock({
+      commitContributionsByRepository: () =>
+        jsonResponse({
+          data: {
+            user: { contributionsCollection: { commitContributionsByRepository: repositories } },
+          },
+        }),
+    });
+
+    const stats = await fetchGithubStats(fetchMock, WINDOW);
+    const byRepository = stats.commits.byRepository;
+
+    expect(byRepository).toHaveLength(10);
+    expect(byRepository[0]).toEqual({
+      nameWithOwner: 'stevekinney/repo-12',
+      url: 'https://github.com/stevekinney/repo-12',
+      stargazerCount: 11,
+      commits: 144,
+    });
+    expect(byRepository.at(-1)).toEqual({
+      nameWithOwner: 'stevekinney/repo-3',
+      url: 'https://github.com/stevekinney/repo-3',
+      stargazerCount: 2,
+      commits: 36,
+    });
+    expect(byRepository.some((repo) => repo.nameWithOwner === 'stevekinney/repo-1')).toBe(false);
+    expect(byRepository.some((repo) => repo.nameWithOwner === 'stevekinney/repo-2')).toBe(false);
+
+    const commitCalls = fetchMock.mock.calls.filter(([url, init]) => {
+      if (String(url) !== 'https://api.github.com/graphql') return false;
+      return parseGraphqlBody(init?.body).query.includes('commitContributionsByRepository');
+    });
+    expect(commitCalls).toHaveLength(12);
+
+    const firstWindow = parseGraphqlBody(commitCalls[0]?.[1]?.body).variables;
+    const lastWindow = parseGraphqlBody(commitCalls[11]?.[1]?.body).variables;
+    expect(firstWindow.from).toBe(WINDOW.from);
+    expect(lastWindow.to).toBe(WINDOW.to);
+  });
+
+  it('never issues concurrent GraphQL requests', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'token';
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const base = buildFetchMock();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) !== 'https://api.github.com/graphql') return base(input, init);
+
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      inFlight -= 1;
+
+      return base(input, init);
+    });
+
+    await fetchGithubStats(fetchMock, WINDOW);
+
+    const graphqlCalls = fetchMock.mock.calls.filter(
+      ([input]) => String(input) === 'https://api.github.com/graphql',
+    );
+    expect(graphqlCalls.length).toBeGreaterThanOrEqual(17);
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('paginates stargazer totals across pages until hasNextPage is false', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    let page = 0;
+
+    const fetchMock = buildFetchMock({
+      repositories: () => {
+        page += 1;
+
+        if (page === 1) {
+          return jsonResponse({
+            data: {
+              user: {
+                repositories: {
+                  pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+                  nodes: [{ stargazerCount: 3 }, { stargazerCount: 4 }],
+                },
+              },
+            },
+          });
+        }
+
+        return jsonResponse({
+          data: {
+            user: {
+              repositories: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [{ stargazerCount: 5 }],
+              },
+            },
+          },
+        });
+      },
+    });
+
+    const stats = await fetchGithubStats(fetchMock, WINDOW);
+    expect(stats.totalStars).toBe(12);
+  });
+});

--- a/applications/website/src/lib/server/dashboard/github.test.ts
+++ b/applications/website/src/lib/server/dashboard/github.test.ts
@@ -23,6 +23,7 @@ const DEFAULT_REPO = {
   nameWithOwner: 'stevekinney/example',
   url: 'https://github.com/stevekinney/example',
   stargazerCount: 5,
+  isPrivate: false,
 };
 
 type GraphqlCall = { query: string; variables: Record<string, unknown> };
@@ -242,6 +243,7 @@ describe('fetchGithubStats', () => {
         nameWithOwner: `stevekinney/repo-${index + 1}`,
         url: `https://github.com/stevekinney/repo-${index + 1}`,
         stargazerCount: index,
+        isPrivate: false,
       },
       contributions: { totalCount: index + 1 },
     }));
@@ -284,6 +286,54 @@ describe('fetchGithubStats', () => {
     const lastWindow = parseGraphqlBody(commitCalls[11]?.[1]?.body).variables;
     expect(firstWindow.from).toBe(WINDOW.from);
     expect(lastWindow.to).toBe(WINDOW.to);
+  });
+
+  it('excludes private repositories from the public commits-by-repository breakdown', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+
+    const repositories = [
+      {
+        repository: {
+          nameWithOwner: 'stevekinney/public-repo',
+          url: 'https://github.com/stevekinney/public-repo',
+          stargazerCount: 3,
+          isPrivate: false,
+        },
+        contributions: { totalCount: 5 },
+      },
+      {
+        repository: {
+          nameWithOwner: 'stevekinney/secret-repo',
+          url: 'https://github.com/stevekinney/secret-repo',
+          stargazerCount: 0,
+          isPrivate: true,
+        },
+        contributions: { totalCount: 99 },
+      },
+    ];
+
+    const fetchMock = buildFetchMock({
+      commitContributionsByRepository: () =>
+        jsonResponse({
+          data: {
+            user: { contributionsCollection: { commitContributionsByRepository: repositories } },
+          },
+        }),
+    });
+
+    const stats = await fetchGithubStats(fetchMock, WINDOW);
+
+    expect(stats.commits.byRepository).toEqual([
+      {
+        nameWithOwner: 'stevekinney/public-repo',
+        url: 'https://github.com/stevekinney/public-repo',
+        stargazerCount: 3,
+        commits: 60,
+      },
+    ]);
+    expect(
+      stats.commits.byRepository.some((repo) => repo.nameWithOwner === 'stevekinney/secret-repo'),
+    ).toBe(false);
   });
 
   it('never issues concurrent GraphQL requests', async () => {
@@ -351,5 +401,42 @@ describe('fetchGithubStats', () => {
 
     const stats = await fetchGithubStats(fetchMock, WINDOW);
     expect(stats.totalStars).toBe(12);
+  });
+
+  it('builds monotonically increasing monthly windows even when `to` falls on a day short months lack', async () => {
+    // `to` is the 31st: naively subtracting months with `setUTCMonth` would
+    // roll "February 31st" forward into early March, since Feb never has 31
+    // days — this window spans a February, so it exercises that overflow.
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+
+    const overflowWindow: DashboardStatWindow = {
+      from: '2025-07-31T00:00:00.000Z',
+      to: '2026-07-31T00:00:00.000Z',
+    };
+
+    const fetchMock = buildFetchMock();
+
+    await fetchGithubStats(fetchMock, overflowWindow);
+
+    const commitCalls = fetchMock.mock.calls.filter(([callUrl, init]) => {
+      if (String(callUrl) !== 'https://api.github.com/graphql') return false;
+      return parseGraphqlBody(init?.body).query.includes('commitContributionsByRepository');
+    });
+
+    const windows = commitCalls.map(([, init]) => parseGraphqlBody(init?.body).variables);
+
+    expect(windows).toHaveLength(12);
+    expect(windows[0].from).toBe(overflowWindow.from);
+    expect(windows.at(-1)?.to).toBe(overflowWindow.to);
+
+    for (let index = 0; index < windows.length; index += 1) {
+      const from = new Date(windows[index].from as string).getTime();
+      const to = new Date(windows[index].to as string).getTime();
+
+      expect(from).toBeLessThan(to);
+      if (index > 0) {
+        expect(from).toBe(new Date(windows[index - 1].to as string).getTime());
+      }
+    }
   });
 });

--- a/applications/website/src/lib/server/dashboard/github.test.ts
+++ b/applications/website/src/lib/server/dashboard/github.test.ts
@@ -288,6 +288,21 @@ describe('fetchGithubStats', () => {
     expect(lastWindow.to).toBe(WINDOW.to);
   });
 
+  it('stops requesting monthly commit windows after the first failure', async () => {
+    env.GITHUB_DASHBOARD_TOKEN = 'test-token';
+    let commitRequestCount = 0;
+
+    const fetchMock = buildFetchMock({
+      commitContributionsByRepository: () => {
+        commitRequestCount += 1;
+        return jsonResponse({ message: 'secondary rate limit' }, 403);
+      },
+    });
+
+    await expect(fetchGithubStats(fetchMock, WINDOW)).rejects.toThrow(/403/);
+    expect(commitRequestCount).toBe(1);
+  });
+
   it('excludes private repositories from the public commits-by-repository breakdown', async () => {
     env.GITHUB_DASHBOARD_TOKEN = 'test-token';
 

--- a/applications/website/src/lib/server/dashboard/github.ts
+++ b/applications/website/src/lib/server/dashboard/github.ts
@@ -1,0 +1,483 @@
+import { env } from '$env/dynamic/private';
+import { z } from 'zod';
+
+import type {
+  DashboardStatWindow,
+  GithubRepositoryCommits,
+  GithubStats,
+} from '$lib/dashboard-types';
+
+const GITHUB_LOGIN = 'stevekinney';
+const GITHUB_PROFILE_URL = 'https://github.com/stevekinney';
+const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
+const GITHUB_REST_URL = 'https://api.github.com';
+const REQUEST_TIMEOUT_MILLISECONDS = 10_000;
+const MONTHLY_WINDOW_COUNT = 12;
+const STARGAZER_PAGE_SIZE = 100;
+const MAX_STARGAZER_PAGES = 10;
+const TOP_REPOSITORY_COUNT = 10;
+
+const buildHeaders = (token: string): HeadersInit => ({
+  Authorization: `Bearer ${token}`,
+  'Content-Type': 'application/json',
+  'User-Agent': 'stevekinney.net-dashboard',
+});
+
+const GraphqlEnvelopeSchema = z.object({
+  data: z.unknown().optional(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
+});
+
+// GitHub's secondary rate limit rejects bursts of concurrent GraphQL requests
+// with a 403 (observed live), and its documentation asks for serial requests.
+// This queue threads every GraphQL call through one at a time; the compute
+// runs at most once a day, so the added seconds are irrelevant.
+let graphqlQueue: Promise<unknown> = Promise.resolve();
+
+const enqueueGraphql = <T>(task: () => Promise<T>): Promise<T> => {
+  const result = graphqlQueue.then(task, task);
+  graphqlQueue = result.catch(() => undefined);
+
+  return result;
+};
+
+/**
+ * POSTs a GraphQL query to the GitHub API — serially, never concurrently —
+ * and returns its `data`, validated against `schema`. Throws on a non-2xx
+ * response, a non-empty `errors` array, or a response shape that fails
+ * validation.
+ */
+const requestGraphql = <Schema extends z.ZodTypeAny>(
+  fetchImpl: typeof globalThis.fetch,
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+  schema: Schema,
+): Promise<z.infer<Schema>> =>
+  enqueueGraphql(() => performGraphqlRequest(fetchImpl, token, query, variables, schema));
+
+const performGraphqlRequest = async <Schema extends z.ZodTypeAny>(
+  fetchImpl: typeof globalThis.fetch,
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+  schema: Schema,
+): Promise<z.infer<Schema>> => {
+  const response = await fetchImpl(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers: buildHeaders(token),
+    body: JSON.stringify({ query, variables }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MILLISECONDS),
+  });
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 200);
+
+    throw new Error(`GitHub GraphQL request failed with status ${response.status}: ${body}`);
+  }
+
+  const envelope = GraphqlEnvelopeSchema.safeParse(await response.json());
+  if (!envelope.success) {
+    throw new Error('GitHub GraphQL response did not match the expected shape.');
+  }
+
+  const [firstError] = envelope.data.errors ?? [];
+  if (firstError) throw new Error(`GitHub GraphQL error: ${firstError.message}`);
+
+  const parsed = schema.safeParse(envelope.data.data);
+  if (!parsed.success) {
+    const message = parsed.error.message;
+    throw new Error(`GitHub GraphQL response did not match the expected shape: ${message}`);
+  }
+
+  return parsed.data;
+};
+
+const ContributionsScalarsSchema = z.object({
+  user: z.object({
+    contributionsCollection: z.object({
+      totalCommitContributions: z.number().optional(),
+      restrictedContributionsCount: z.number().optional(),
+      totalPullRequestReviewContributions: z.number().optional(),
+    }),
+  }),
+});
+
+type ContributionsScalars = z.infer<
+  typeof ContributionsScalarsSchema
+>['user']['contributionsCollection'];
+
+const TOTAL_COMMIT_CONTRIBUTIONS_QUERY = `
+	query($login: String!, $from: DateTime!, $to: DateTime!) {
+		user(login: $login) {
+			contributionsCollection(from: $from, to: $to) {
+				totalCommitContributions
+			}
+		}
+	}
+`;
+
+const RESTRICTED_CONTRIBUTIONS_QUERY = `
+	query($login: String!, $from: DateTime!, $to: DateTime!) {
+		user(login: $login) {
+			contributionsCollection(from: $from, to: $to) {
+				restrictedContributionsCount
+			}
+		}
+	}
+`;
+
+const TOTAL_REVIEW_CONTRIBUTIONS_QUERY = `
+	query($login: String!, $from: DateTime!, $to: DateTime!) {
+		user(login: $login) {
+			contributionsCollection(from: $from, to: $to) {
+				totalPullRequestReviewContributions
+			}
+		}
+	}
+`;
+
+/**
+ * Fetches a single `contributionsCollection` scalar field for the window.
+ * Each field is fetched with its own query — combining two or more of these
+ * fields in one query exceeds GitHub's resource limits for this account.
+ */
+const fetchContributionsScalar = async (
+  fetchImpl: typeof globalThis.fetch,
+  token: string,
+  window: DashboardStatWindow,
+  query: string,
+  pickField: (scalars: ContributionsScalars) => number | undefined,
+): Promise<number> => {
+  const data = await requestGraphql(
+    fetchImpl,
+    token,
+    query,
+    { login: GITHUB_LOGIN, from: window.from, to: window.to },
+    ContributionsScalarsSchema,
+  );
+
+  return pickField(data.user.contributionsCollection) ?? 0;
+};
+
+const CommitContributionsByRepositorySchema = z.object({
+  user: z.object({
+    contributionsCollection: z.object({
+      commitContributionsByRepository: z.array(
+        z.object({
+          repository: z.object({
+            nameWithOwner: z.string(),
+            url: z.string(),
+            stargazerCount: z.number(),
+          }),
+          contributions: z.object({ totalCount: z.number() }),
+        }),
+      ),
+    }),
+  }),
+});
+
+const COMMIT_CONTRIBUTIONS_BY_REPOSITORY_QUERY = `
+	query($login: String!, $from: DateTime!, $to: DateTime!) {
+		user(login: $login) {
+			contributionsCollection(from: $from, to: $to) {
+				commitContributionsByRepository(maxRepositories: 25) {
+					repository {
+						nameWithOwner
+						url
+						stargazerCount
+					}
+					contributions {
+						totalCount
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Splits the window into twelve consecutive ~1-month windows, using the
+ * window's own boundaries for the first `from` and the last `to` so the
+ * stitched windows span it exactly. `commitContributionsByRepository` fails
+ * outright at a 1-year window (even alone), so per-repository commits have
+ * to be gathered a month at a time and aggregated.
+ */
+const buildMonthlyWindows = (window: DashboardStatWindow): DashboardStatWindow[] => {
+  const to = new Date(window.to);
+  const boundaries = [new Date(window.from)];
+
+  for (let monthsBack = MONTHLY_WINDOW_COUNT - 1; monthsBack >= 1; monthsBack -= 1) {
+    const boundary = new Date(to);
+    boundary.setUTCMonth(boundary.getUTCMonth() - monthsBack);
+    boundaries.push(boundary);
+  }
+
+  boundaries.push(to);
+
+  const windows: DashboardStatWindow[] = [];
+  for (let index = 0; index < boundaries.length - 1; index += 1) {
+    windows.push({
+      from: boundaries[index].toISOString(),
+      to: boundaries[index + 1].toISOString(),
+    });
+  }
+
+  return windows;
+};
+
+/** Sums commits per repository across monthly pages, sorted by commits descending. */
+const aggregateRepositoryCommits = (
+  pages: z.infer<typeof CommitContributionsByRepositorySchema>[],
+): GithubRepositoryCommits[] => {
+  const totals = new Map<string, GithubRepositoryCommits>();
+
+  for (const page of pages) {
+    for (const entry of page.user.contributionsCollection.commitContributionsByRepository) {
+      const previous = totals.get(entry.repository.nameWithOwner);
+
+      totals.set(entry.repository.nameWithOwner, {
+        nameWithOwner: entry.repository.nameWithOwner,
+        url: entry.repository.url,
+        stargazerCount: entry.repository.stargazerCount,
+        commits: (previous?.commits ?? 0) + entry.contributions.totalCount,
+      });
+    }
+  }
+
+  return Array.from(totals.values())
+    .sort((a, b) => b.commits - a.commits)
+    .slice(0, TOP_REPOSITORY_COUNT);
+};
+
+/** Fetches per-repository commit counts for the window, stitched from monthly pages. */
+const fetchRepositoryCommits = async (
+  fetchImpl: typeof globalThis.fetch,
+  token: string,
+  window: DashboardStatWindow,
+): Promise<GithubRepositoryCommits[]> => {
+  const monthlyWindows = buildMonthlyWindows(window);
+
+  const pages = await Promise.all(
+    monthlyWindows.map((monthlyWindow) =>
+      requestGraphql(
+        fetchImpl,
+        token,
+        COMMIT_CONTRIBUTIONS_BY_REPOSITORY_QUERY,
+        { login: GITHUB_LOGIN, from: monthlyWindow.from, to: monthlyWindow.to },
+        CommitContributionsByRepositorySchema,
+      ),
+    ),
+  );
+
+  return aggregateRepositoryCommits(pages);
+};
+
+const SearchCountsSchema = z.object({
+  mergedLastYear: z.object({ issueCount: z.number() }),
+  openNow: z.object({ issueCount: z.number() }),
+  openedLastYear: z.object({ issueCount: z.number() }),
+  closedLastYear: z.object({ issueCount: z.number() }),
+});
+
+const SEARCH_COUNTS_QUERY = `
+	query($mergedQuery: String!, $openQuery: String!, $openedQuery: String!, $closedQuery: String!) {
+		mergedLastYear: search(query: $mergedQuery, type: ISSUE, first: 1) {
+			issueCount
+		}
+		openNow: search(query: $openQuery, type: ISSUE, first: 1) {
+			issueCount
+		}
+		openedLastYear: search(query: $openedQuery, type: ISSUE, first: 1) {
+			issueCount
+		}
+		closedLastYear: search(query: $closedQuery, type: ISSUE, first: 1) {
+			issueCount
+		}
+	}
+`;
+
+const toDateOnly = (iso: string): string => iso.slice(0, 10);
+
+/** Fetches merged/open pull request and opened/closed issue counts in one query. */
+const fetchSearchCounts = async (
+  fetchImpl: typeof globalThis.fetch,
+  token: string,
+  window: DashboardStatWindow,
+): Promise<z.infer<typeof SearchCountsSchema>> => {
+  const since = toDateOnly(window.from);
+
+  return requestGraphql(
+    fetchImpl,
+    token,
+    SEARCH_COUNTS_QUERY,
+    {
+      mergedQuery: `author:${GITHUB_LOGIN} is:pr is:merged merged:>=${since}`,
+      openQuery: `author:${GITHUB_LOGIN} is:pr is:open`,
+      openedQuery: `author:${GITHUB_LOGIN} is:issue created:>=${since}`,
+      closedQuery: `author:${GITHUB_LOGIN} is:issue is:closed closed:>=${since}`,
+    },
+    SearchCountsSchema,
+  );
+};
+
+const GithubProfileSchema = z.object({
+  followers: z.number(),
+  public_repos: z.number(),
+});
+
+/** Fetches follower and public repository counts from the REST profile endpoint. */
+const fetchProfile = async (
+  fetchImpl: typeof globalThis.fetch,
+  token: string,
+): Promise<{ followers: number; publicRepositories: number }> => {
+  const response = await fetchImpl(`${GITHUB_REST_URL}/users/${GITHUB_LOGIN}`, {
+    headers: buildHeaders(token),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MILLISECONDS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub profile request failed with status ${response.status}`);
+  }
+
+  const parsed = GithubProfileSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error('GitHub profile response did not match the expected shape.');
+  }
+
+  return { followers: parsed.data.followers, publicRepositories: parsed.data.public_repos };
+};
+
+const RepositoriesPageSchema = z.object({
+  user: z.object({
+    repositories: z.object({
+      pageInfo: z.object({ hasNextPage: z.boolean(), endCursor: z.string().nullable() }),
+      nodes: z.array(z.object({ stargazerCount: z.number() })),
+    }),
+  }),
+});
+
+const REPOSITORIES_QUERY = `
+	query($login: String!, $cursor: String) {
+		user(login: $login) {
+			repositories(ownerAffiliations: OWNER, first: ${STARGAZER_PAGE_SIZE}, after: $cursor) {
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+				nodes {
+					stargazerCount
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Sums stargazers across every owned repository, paginating up to
+ * `MAX_STARGAZER_PAGES` pages. If the cap is hit before the last page, the
+ * partial sum is returned rather than looping indefinitely.
+ */
+const fetchTotalStars = async (
+  fetchImpl: typeof globalThis.fetch,
+  token: string,
+): Promise<number> => {
+  let cursor: string | null = null;
+  let total = 0;
+
+  for (let page = 0; page < MAX_STARGAZER_PAGES; page += 1) {
+    const data: z.infer<typeof RepositoriesPageSchema> = await requestGraphql(
+      fetchImpl,
+      token,
+      REPOSITORIES_QUERY,
+      { login: GITHUB_LOGIN, cursor },
+      RepositoriesPageSchema,
+    );
+
+    total += data.user.repositories.nodes.reduce((sum, node) => sum + node.stargazerCount, 0);
+
+    if (!data.user.repositories.pageInfo.hasNextPage) return total;
+
+    cursor = data.user.repositories.pageInfo.endCursor;
+  }
+
+  return total;
+};
+
+/**
+ * Fetches Steve's GitHub activity for the given window: commit, pull request,
+ * issue, and review totals, the top repositories by commits, and
+ * profile-level totals like followers, public repositories, and stars.
+ */
+export const fetchGithubStats = async (
+  fetchImpl: typeof globalThis.fetch,
+  window: DashboardStatWindow,
+): Promise<GithubStats> => {
+  const token = env.GITHUB_DASHBOARD_TOKEN || env.GITHUB_TOKEN;
+
+  if (!token) {
+    throw new Error(
+      'Set GITHUB_DASHBOARD_TOKEN (or GITHUB_TOKEN) to enable the GitHub section of the dashboard.',
+    );
+  }
+
+  const [
+    totalCommitContributions,
+    privateContributionsLastYear,
+    totalReviewContributions,
+    byRepository,
+    searchCounts,
+    profile,
+    totalStars,
+  ] = await Promise.all([
+    fetchContributionsScalar(
+      fetchImpl,
+      token,
+      window,
+      TOTAL_COMMIT_CONTRIBUTIONS_QUERY,
+      (scalars) => scalars.totalCommitContributions,
+    ),
+    fetchContributionsScalar(
+      fetchImpl,
+      token,
+      window,
+      RESTRICTED_CONTRIBUTIONS_QUERY,
+      (scalars) => scalars.restrictedContributionsCount,
+    ),
+    fetchContributionsScalar(
+      fetchImpl,
+      token,
+      window,
+      TOTAL_REVIEW_CONTRIBUTIONS_QUERY,
+      (scalars) => scalars.totalPullRequestReviewContributions,
+    ),
+    fetchRepositoryCommits(fetchImpl, token, window),
+    fetchSearchCounts(fetchImpl, token, window),
+    fetchProfile(fetchImpl, token),
+    fetchTotalStars(fetchImpl, token),
+  ]);
+
+  return {
+    login: GITHUB_LOGIN,
+    profileUrl: GITHUB_PROFILE_URL,
+    followers: profile.followers,
+    publicRepositories: profile.publicRepositories,
+    totalStars,
+    pullRequests: {
+      openNow: searchCounts.openNow.issueCount,
+      mergedLastYear: searchCounts.mergedLastYear.issueCount,
+    },
+    commits: {
+      totalLastYear: totalCommitContributions,
+      privateContributionsLastYear,
+      byRepository,
+    },
+    issues: {
+      openedLastYear: searchCounts.openedLastYear.issueCount,
+      closedLastYear: searchCounts.closedLastYear.issueCount,
+    },
+    reviews: {
+      totalLastYear: totalReviewContributions,
+    },
+  };
+};

--- a/applications/website/src/lib/server/dashboard/github.ts
+++ b/applications/website/src/lib/server/dashboard/github.ts
@@ -282,18 +282,19 @@ const fetchRepositoryCommits = async (
   window: DashboardStatWindow,
 ): Promise<GithubRepositoryCommits[]> => {
   const monthlyWindows = buildMonthlyWindows(window);
+  const pages: z.infer<typeof CommitContributionsByRepositorySchema>[] = [];
 
-  const pages = await Promise.all(
-    monthlyWindows.map((monthlyWindow) =>
-      requestGraphql(
+  for (const monthlyWindow of monthlyWindows) {
+    pages.push(
+      await requestGraphql(
         fetchImpl,
         token,
         COMMIT_CONTRIBUTIONS_BY_REPOSITORY_QUERY,
         { login: GITHUB_LOGIN, from: monthlyWindow.from, to: monthlyWindow.to },
         CommitContributionsByRepositorySchema,
       ),
-    ),
-  );
+    );
+  }
 
   return aggregateRepositoryCommits(pages);
 };

--- a/applications/website/src/lib/server/dashboard/github.ts
+++ b/applications/website/src/lib/server/dashboard/github.ts
@@ -169,6 +169,7 @@ const CommitContributionsByRepositorySchema = z.object({
             nameWithOwner: z.string(),
             url: z.string(),
             stargazerCount: z.number(),
+            isPrivate: z.boolean(),
           }),
           contributions: z.object({ totalCount: z.number() }),
         }),
@@ -186,6 +187,7 @@ const COMMIT_CONTRIBUTIONS_BY_REPOSITORY_QUERY = `
 						nameWithOwner
 						url
 						stargazerCount
+						isPrivate
 					}
 					contributions {
 						totalCount
@@ -195,6 +197,22 @@ const COMMIT_CONTRIBUTIONS_BY_REPOSITORY_QUERY = `
 		}
 	}
 `;
+
+/**
+ * Subtracts `months` from `date` in UTC, clamping to the last day of the
+ * target month when the original day-of-month doesn't exist there (e.g.
+ * subtracting one month from Mar 31 would otherwise overflow "Feb 31"
+ * forward into early March via `setUTCMonth`'s normal rollover behavior).
+ */
+const subtractUtcMonths = (date: Date, months: number): Date => {
+  const shifted = new Date(date);
+  const dayOfMonth = shifted.getUTCDate();
+
+  shifted.setUTCMonth(shifted.getUTCMonth() - months);
+  if (shifted.getUTCDate() !== dayOfMonth) shifted.setUTCDate(0);
+
+  return shifted;
+};
 
 /**
  * Splits the window into twelve consecutive ~1-month windows, using the
@@ -208,9 +226,7 @@ const buildMonthlyWindows = (window: DashboardStatWindow): DashboardStatWindow[]
   const boundaries = [new Date(window.from)];
 
   for (let monthsBack = MONTHLY_WINDOW_COUNT - 1; monthsBack >= 1; monthsBack -= 1) {
-    const boundary = new Date(to);
-    boundary.setUTCMonth(boundary.getUTCMonth() - monthsBack);
-    boundaries.push(boundary);
+    boundaries.push(subtractUtcMonths(to, monthsBack));
   }
 
   boundaries.push(to);
@@ -226,7 +242,14 @@ const buildMonthlyWindows = (window: DashboardStatWindow): DashboardStatWindow[]
   return windows;
 };
 
-/** Sums commits per repository across monthly pages, sorted by commits descending. */
+/**
+ * Sums commits per repository across monthly pages, sorted by commits
+ * descending. Private repositories are excluded — this dashboard is public,
+ * and a token with private-repo access would otherwise leak private
+ * repository names, URLs, and commit counts through it. The token's private
+ * activity still counts toward `commits.privateContributionsLastYear`
+ * (fetched separately), just not broken out by name here.
+ */
 const aggregateRepositoryCommits = (
   pages: z.infer<typeof CommitContributionsByRepositorySchema>[],
 ): GithubRepositoryCommits[] => {
@@ -234,6 +257,8 @@ const aggregateRepositoryCommits = (
 
   for (const page of pages) {
     for (const entry of page.user.contributionsCollection.commitContributionsByRepository) {
+      if (entry.repository.isPrivate) continue;
+
       const previous = totals.get(entry.repository.nameWithOwner);
 
       totals.set(entry.repository.nameWithOwner, {

--- a/applications/website/src/lib/server/dashboard/index.ts
+++ b/applications/website/src/lib/server/dashboard/index.ts
@@ -1,0 +1,51 @@
+import type { DashboardData, DashboardSection } from '$lib/dashboard-types';
+
+import { createCachedLoader } from './cache';
+import { fetchCourseUpdates } from './courses';
+import { fetchGithubStats } from './github';
+import { fetchNpmStats } from './npm';
+import { lastYearWindow } from './stat-window';
+
+const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
+const RETRY_IN_MILLISECONDS = 5 * 60 * 1000;
+
+/** True when every dashboard section resolved successfully. */
+export const isDashboardComplete = (data: DashboardData): boolean =>
+  data.github.status === 'ok' && data.npm.status === 'ok' && data.courses.status === 'ok';
+
+const toSection = async <T>(promise: Promise<T>): Promise<DashboardSection<T>> => {
+  try {
+    return { status: 'ok', data: await promise };
+  } catch (error) {
+    return { status: 'error', error: error instanceof Error ? error.message : String(error) };
+  }
+};
+
+const computeDashboardData = async (): Promise<DashboardData> => {
+  const now = new Date();
+  const window = lastYearWindow(now);
+
+  const [github, npm, courses] = await Promise.all([
+    toSection(fetchGithubStats(fetch, window)),
+    toSection(fetchNpmStats(fetch)),
+    toSection(fetchCourseUpdates(fetch)),
+  ]);
+
+  return { generatedAt: now.toISOString(), window, github, npm, courses };
+};
+
+/**
+ * Returns the dashboard snapshot, computing it at most once every 24 hours per
+ * server instance and deduping concurrent requests onto one computation.
+ *
+ * Vercel's ISR cache (configured on the routes that call this) provides the
+ * durable, cross-instance 24-hour cache; this memo keeps a warm instance from
+ * recomputing and keeps a thundering herd down to a single upstream fan-out.
+ * Snapshots with failed sections are only held for five minutes so an outage
+ * or missing token is retried promptly instead of being served all day.
+ */
+export const getDashboardData = createCachedLoader(computeDashboardData, {
+  timeToLive: DAY_IN_MILLISECONDS,
+  retryTimeToLive: RETRY_IN_MILLISECONDS,
+  isComplete: isDashboardComplete,
+});

--- a/applications/website/src/lib/server/dashboard/npm.test.ts
+++ b/applications/website/src/lib/server/dashboard/npm.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchNpmStats } from './npm';
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+const searchObject = (name: string, downloads: number) => ({
+  name,
+  version: '1.0.0',
+  description: `${name} package`,
+  downloads,
+});
+
+type SearchPackage = ReturnType<typeof searchObject>;
+
+/** Builds the `-/v1/search` response body for the given packages. */
+const buildSearchResponse = (packages: SearchPackage[], total = packages.length) => ({
+  total,
+  objects: packages.map(({ name, version, description }) => ({
+    package: { name, version, description },
+  })),
+});
+
+type Handlers = {
+  search?: (url: string) => Response;
+  bulkDownloads?: (names: string[]) => Response;
+  singleDownloads?: (name: string) => Response;
+};
+
+/** Builds a fetch stub covering npm registry search and downloads requests. */
+const buildFetchMock = (packages: SearchPackage[], handlers: Handlers = {}) =>
+  vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+
+    if (url.startsWith('https://registry.npmjs.org/-/v1/search')) {
+      return (handlers.search ?? (() => jsonResponse(buildSearchResponse(packages))))(url);
+    }
+
+    const downloadsPrefix = 'https://api.npmjs.org/downloads/point/last-year/';
+    if (url.startsWith(downloadsPrefix)) {
+      const rest = url.slice(downloadsPrefix.length);
+      const names = rest.split(',').map(decodeURIComponent);
+
+      if (names.length === 1) {
+        const [name] = names;
+        const found = packages.find((pkg) => pkg.name === name);
+
+        if (handlers.singleDownloads) return handlers.singleDownloads(name);
+        if (!found) return jsonResponse({ error: 'not found' }, 404);
+
+        return jsonResponse({ downloads: found.downloads, package: name });
+      }
+
+      if (handlers.bulkDownloads) return handlers.bulkDownloads(names);
+
+      const body: Record<string, { downloads: number; package: string } | null> = {};
+      for (const name of names) {
+        const found = packages.find((pkg) => pkg.name === name);
+        body[name] = found ? { downloads: found.downloads, package: name } : null;
+      }
+
+      return jsonResponse(body);
+    }
+
+    throw new Error(`Unhandled fetch: ${url}`);
+  });
+
+describe('fetchNpmStats', () => {
+  it('throws including the status code when the registry search fails', async () => {
+    const fetchMock = buildFetchMock([], { search: () => jsonResponse({}, 500) });
+
+    await expect(fetchNpmStats(fetchMock)).rejects.toThrow(/500/);
+  });
+
+  it('throws when the search response does not match the expected shape', async () => {
+    const fetchMock = buildFetchMock([], { search: () => jsonResponse({ nope: true }) });
+
+    await expect(fetchNpmStats(fetchMock)).rejects.toThrow(/did not match the expected shape/);
+  });
+
+  it('sums downloads and returns the package count from the search total', async () => {
+    const packages = [searchObject('alpha', 100), searchObject('beta', 200)];
+    const fetchMock = buildFetchMock(packages, {
+      search: () => jsonResponse(buildSearchResponse(packages, 45)),
+    });
+
+    const stats = await fetchNpmStats(fetchMock);
+
+    expect(stats.packageCount).toBe(45);
+    expect(stats.totalDownloadsLastYear).toBe(300);
+  });
+
+  it('paginates the registry search so totals cover every package, not just the first page', async () => {
+    const allPackages = Array.from({ length: 150 }, (_, index) =>
+      searchObject(`package-${index}`, 1),
+    );
+    const fetchMock = buildFetchMock(allPackages, {
+      search: (url) => {
+        const offset = Number(new URL(url).searchParams.get('from') ?? 0);
+
+        return jsonResponse(buildSearchResponse(allPackages.slice(offset, offset + 100), 150));
+      },
+    });
+
+    const stats = await fetchNpmStats(fetchMock);
+
+    expect(stats.packageCount).toBe(150);
+    expect(stats.totalDownloadsLastYear).toBe(150);
+  });
+
+  it('sorts topPackages by downloads descending and caps at 10', async () => {
+    const packages = Array.from({ length: 12 }, (_, index) =>
+      searchObject(`package-${index}`, index * 10),
+    );
+    const fetchMock = buildFetchMock(packages);
+
+    const stats = await fetchNpmStats(fetchMock);
+
+    expect(stats.topPackages).toHaveLength(10);
+    expect(stats.topPackages[0]).toEqual({
+      name: 'package-11',
+      description: 'package-11 package',
+      version: '1.0.0',
+      url: 'https://www.npmjs.com/package/package-11',
+      downloadsLastYear: 110,
+    });
+    expect(stats.topPackages.at(-1)?.name).toBe('package-2');
+    expect(stats.topPackages.some((pkg) => pkg.name === 'package-0')).toBe(false);
+    expect(stats.topPackages.some((pkg) => pkg.name === 'package-1')).toBe(false);
+  });
+
+  it('treats a null bulk download entry as zero downloads', async () => {
+    const packages = [searchObject('has-downloads', 50), searchObject('missing', 0)];
+    const fetchMock = buildFetchMock(packages, {
+      bulkDownloads: (names) => {
+        const body: Record<string, { downloads: number; package: string } | null> = {};
+
+        for (const name of names) {
+          body[name] = name === 'missing' ? null : { downloads: 50, package: name };
+        }
+
+        return jsonResponse(body);
+      },
+    });
+
+    const stats = await fetchNpmStats(fetchMock);
+    const missing = stats.topPackages.find((pkg) => pkg.name === 'missing');
+
+    expect(missing?.downloadsLastYear).toBe(0);
+  });
+
+  it('fetches scoped packages individually instead of via the bulk endpoint', async () => {
+    const packages = [searchObject('@stevekinney/scoped', 25)];
+    const bulkDownloads = vi.fn();
+    const fetchMock = buildFetchMock(packages, { bulkDownloads });
+
+    const stats = await fetchNpmStats(fetchMock);
+
+    expect(bulkDownloads).not.toHaveBeenCalled();
+    expect(stats.topPackages[0]?.downloadsLastYear).toBe(25);
+  });
+
+  it('treats a 404 for an individual package as zero downloads rather than a failure', async () => {
+    const packages = [searchObject('@stevekinney/missing', 0)];
+    const fetchMock = buildFetchMock(packages, {
+      singleDownloads: () => jsonResponse({ error: 'not found' }, 404),
+    });
+
+    const stats = await fetchNpmStats(fetchMock);
+    expect(stats.topPackages[0]?.downloadsLastYear).toBe(0);
+  });
+
+  it('throws including the status code when an individual download request fails', async () => {
+    const packages = [searchObject('@stevekinney/broken', 0)];
+    const fetchMock = buildFetchMock(packages, {
+      singleDownloads: () => jsonResponse({}, 500),
+    });
+
+    await expect(fetchNpmStats(fetchMock)).rejects.toThrow(/500/);
+  });
+
+  it('chunks unscoped packages into bulk requests of 50 names', async () => {
+    const packages = Array.from({ length: 55 }, (_, index) => searchObject(`package-${index}`, 1));
+    const bulkDownloads = vi.fn((names: string[]) => {
+      const body: Record<string, { downloads: number; package: string }> = {};
+      for (const name of names) body[name] = { downloads: 1, package: name };
+      return jsonResponse(body);
+    });
+    const fetchMock = buildFetchMock(packages, { bulkDownloads });
+
+    await fetchNpmStats(fetchMock);
+
+    expect(bulkDownloads).toHaveBeenCalledTimes(2);
+    expect(bulkDownloads.mock.calls[0]?.[0]).toHaveLength(50);
+    expect(bulkDownloads.mock.calls[1]?.[0]).toHaveLength(5);
+  });
+
+  it('routes a single-name trailing chunk through the single-package endpoint', async () => {
+    const packages = Array.from({ length: 51 }, (_, index) =>
+      searchObject(`package-${index}`, index),
+    );
+    const bulkDownloads = vi.fn((names: string[]) => {
+      const body: Record<string, { downloads: number; package: string }> = {};
+      for (const name of names) body[name] = { downloads: 1, package: name };
+      return jsonResponse(body);
+    });
+    const singleDownloads = vi.fn((name: string) => {
+      const found = packages.find((pkg) => pkg.name === name);
+      return jsonResponse({ downloads: found?.downloads ?? 0, package: name });
+    });
+    const fetchMock = buildFetchMock(packages, { bulkDownloads, singleDownloads });
+
+    const stats = await fetchNpmStats(fetchMock);
+
+    // The 51st package lands alone in the second chunk, so it must go through
+    // the single-package endpoint (which npm returns in a flat, non-keyed shape).
+    expect(bulkDownloads).toHaveBeenCalledTimes(1);
+    expect(singleDownloads).toHaveBeenCalledWith('package-50');
+
+    const last = stats.topPackages.find((pkg) => pkg.name === 'package-50');
+    expect(last?.downloadsLastYear).toBe(50);
+  });
+});

--- a/applications/website/src/lib/server/dashboard/npm.ts
+++ b/applications/website/src/lib/server/dashboard/npm.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+
+import type { NpmPackageStats, NpmStats } from '$lib/dashboard-types';
+
+const NPM_MAINTAINER = 'stevekinney';
+const NPM_REGISTRY_SEARCH_URL = 'https://registry.npmjs.org/-/v1/search';
+const NPM_DOWNLOADS_BASE_URL = 'https://api.npmjs.org/downloads/point/last-year';
+const REQUEST_TIMEOUT_MILLISECONDS = 10_000;
+const SEARCH_PAGE_SIZE = 100;
+const MAX_SEARCH_PAGES = 5;
+const BULK_CHUNK_SIZE = 50;
+const TOP_PACKAGE_COUNT = 10;
+
+const NpmSearchResultSchema = z.object({
+  total: z.number(),
+  objects: z.array(
+    z.object({
+      package: z.object({
+        name: z.string(),
+        version: z.string(),
+        description: z.string().optional(),
+      }),
+    }),
+  ),
+});
+
+const NpmSingleDownloadsSchema = z.object({ downloads: z.number() });
+const NpmBulkDownloadsSchema = z.record(z.string(), NpmSingleDownloadsSchema.nullable());
+
+const isScopedPackageName = (name: string): boolean => name.startsWith('@');
+
+const chunk = <Item>(items: Item[], size: number): Item[][] => {
+  const chunks: Item[][] = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
+};
+
+/**
+ * Searches the npm registry for every package this maintainer publishes,
+ * following `from`-offset pagination (capped at `MAX_SEARCH_PAGES`) so the
+ * download totals cover the whole result set — otherwise `packageCount`
+ * could report more packages than the totals actually include.
+ */
+const fetchPackageSearch = async (
+  fetchImpl: typeof globalThis.fetch,
+): Promise<z.infer<typeof NpmSearchResultSchema>> => {
+  const objects: z.infer<typeof NpmSearchResultSchema>['objects'] = [];
+  let total = 0;
+
+  for (let page = 0; page < MAX_SEARCH_PAGES; page += 1) {
+    const offset = page * SEARCH_PAGE_SIZE;
+    const query = `text=maintainer:${NPM_MAINTAINER}&size=${SEARCH_PAGE_SIZE}&from=${offset}`;
+    const response = await fetchImpl(`${NPM_REGISTRY_SEARCH_URL}?${query}`, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MILLISECONDS),
+    });
+
+    if (!response.ok) {
+      throw new Error(`npm registry search failed with status ${response.status}`);
+    }
+
+    const parsed = NpmSearchResultSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new Error('npm registry search response did not match the expected shape.');
+    }
+
+    total = parsed.data.total;
+    objects.push(...parsed.data.objects);
+
+    if (objects.length >= total || parsed.data.objects.length < SEARCH_PAGE_SIZE) break;
+  }
+
+  return { total, objects };
+};
+
+/** Fetches last-year downloads for one package. A 404 means zero downloads, not a failure. */
+const fetchSingleDownloads = async (
+  fetchImpl: typeof globalThis.fetch,
+  name: string,
+): Promise<number> => {
+  const url = `${NPM_DOWNLOADS_BASE_URL}/${encodeURIComponent(name)}`;
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MILLISECONDS),
+  });
+
+  if (response.status === 404) return 0;
+
+  if (!response.ok) {
+    throw new Error(`npm downloads request for ${name} failed with status ${response.status}`);
+  }
+
+  const parsed = NpmSingleDownloadsSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error(`npm downloads response for ${name} did not match the expected shape.`);
+  }
+
+  return parsed.data.downloads;
+};
+
+/**
+ * Fetches last-year downloads for several unscoped packages in one request.
+ * A single-name chunk hits the same URL shape, but npm replies with the flat
+ * single-package object instead of a name-keyed map, so it is routed through
+ * `fetchSingleDownloads` instead of being parsed as a bulk response.
+ */
+const fetchBulkDownloads = async (
+  fetchImpl: typeof globalThis.fetch,
+  names: string[],
+): Promise<Map<string, number>> => {
+  if (names.length === 1) {
+    const [name] = names;
+    return new Map([[name, await fetchSingleDownloads(fetchImpl, name)]]);
+  }
+
+  const url = `${NPM_DOWNLOADS_BASE_URL}/${names.map(encodeURIComponent).join(',')}`;
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MILLISECONDS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`npm downloads request failed with status ${response.status}`);
+  }
+
+  const parsed = NpmBulkDownloadsSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error('npm downloads response did not match the expected shape.');
+  }
+
+  const downloads = new Map<string, number>();
+  for (const [name, stats] of Object.entries(parsed.data)) {
+    downloads.set(name, stats?.downloads ?? 0);
+  }
+
+  return downloads;
+};
+
+/**
+ * Fetches last-year downloads for every package. Unscoped packages are
+ * chunked into bulk requests of `BULK_CHUNK_SIZE`; scoped packages (rejected
+ * by the bulk endpoint) are fetched individually.
+ */
+const fetchDownloadsByPackage = async (
+  fetchImpl: typeof globalThis.fetch,
+  names: string[],
+): Promise<Map<string, number>> => {
+  const scopedNames = names.filter(isScopedPackageName);
+  const unscopedNames = names.filter((name) => !isScopedPackageName(name));
+  const unscopedChunks = chunk(unscopedNames, BULK_CHUNK_SIZE);
+
+  const [bulkResults, scopedResults] = await Promise.all([
+    Promise.all(unscopedChunks.map((chunkNames) => fetchBulkDownloads(fetchImpl, chunkNames))),
+    Promise.all(
+      scopedNames.map(async (name): Promise<[string, number]> => {
+        const downloads = await fetchSingleDownloads(fetchImpl, name);
+        return [name, downloads];
+      }),
+    ),
+  ]);
+
+  const downloads = new Map<string, number>();
+  for (const chunkResult of bulkResults) {
+    for (const [name, count] of chunkResult) downloads.set(name, count);
+  }
+  for (const [name, count] of scopedResults) downloads.set(name, count);
+
+  return downloads;
+};
+
+/**
+ * Fetches npm activity across every package Steve maintains: how many
+ * packages, last-year downloads per package, and the totals across all of
+ * them.
+ */
+export const fetchNpmStats = async (fetchImpl: typeof globalThis.fetch): Promise<NpmStats> => {
+  const searchResult = await fetchPackageSearch(fetchImpl);
+  const names = searchResult.objects.map((object) => object.package.name);
+  const downloadsByName = await fetchDownloadsByPackage(fetchImpl, names);
+
+  const topPackages: NpmPackageStats[] = searchResult.objects
+    .map((object) => ({
+      name: object.package.name,
+      description: object.package.description,
+      version: object.package.version,
+      url: `https://www.npmjs.com/package/${object.package.name}`,
+      downloadsLastYear: downloadsByName.get(object.package.name) ?? 0,
+    }))
+    .sort((a, b) => b.downloadsLastYear - a.downloadsLastYear)
+    .slice(0, TOP_PACKAGE_COUNT);
+
+  const totalDownloadsLastYear = Array.from(downloadsByName.values()).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+
+  return { packageCount: searchResult.total, totalDownloadsLastYear, topPackages };
+};

--- a/applications/website/src/lib/server/dashboard/stat-window.test.ts
+++ b/applications/website/src/lib/server/dashboard/stat-window.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { lastYearWindow } from './stat-window';
+
+describe('lastYearWindow', () => {
+  it('starts exactly one calendar year before an ordinary date', () => {
+    const window = lastYearWindow(new Date('2026-07-20T12:34:56.000Z'));
+
+    expect(window.from).toBe('2025-07-20T12:34:56.000Z');
+    expect(window.to).toBe('2026-07-20T12:34:56.000Z');
+  });
+
+  it('clamps a leap-day start to the last day of February instead of rolling into March', () => {
+    const window = lastYearWindow(new Date('2028-02-29T12:00:00.000Z'));
+
+    expect(window.from).toBe('2027-02-28T12:00:00.000Z');
+    expect(window.to).toBe('2028-02-29T12:00:00.000Z');
+  });
+});

--- a/applications/website/src/lib/server/dashboard/stat-window.ts
+++ b/applications/website/src/lib/server/dashboard/stat-window.ts
@@ -1,0 +1,18 @@
+import type { DashboardStatWindow } from '$lib/dashboard-types';
+
+/**
+ * Builds the rolling one-year window ending at `now`. When `now` is a UTC
+ * leap day, `setUTCFullYear` would roll the nonexistent Feb 29 forward into
+ * March in the target year, silently dropping a day from the window — so the
+ * start is clamped back to the last day of February instead.
+ */
+export const lastYearWindow = (now: Date): DashboardStatWindow => {
+  const from = new Date(now);
+  const dayOfMonth = from.getUTCDate();
+
+  from.setUTCFullYear(from.getUTCFullYear() - 1);
+
+  if (from.getUTCDate() !== dayOfMonth) from.setUTCDate(0);
+
+  return { from: from.toISOString(), to: now.toISOString() };
+};

--- a/applications/website/src/lib/server/open-graph-metadata.test.ts
+++ b/applications/website/src/lib/server/open-graph-metadata.test.ts
@@ -19,6 +19,9 @@ describe('resolveOpenGraphMetadata', () => {
     await expect(resolveOpenGraphMetadata('/projects')).resolves.toMatchObject({
       title: 'Projects',
     });
+    await expect(resolveOpenGraphMetadata('/dashboard')).resolves.toMatchObject({
+      title: 'Dashboard',
+    });
   });
 
   it('uses generated metadata for writing routes', async () => {

--- a/applications/website/src/lib/server/open-graph-metadata.ts
+++ b/applications/website/src/lib/server/open-graph-metadata.ts
@@ -31,11 +31,18 @@ const PROJECTS_INDEX: StaticRoute = {
     'A collection of tools, experiments, and open source projects that I maintain or keep nearby.',
 };
 
+const DASHBOARD_INDEX: StaticRoute = {
+  title: 'Dashboard',
+  description:
+    'A snapshot of GitHub activity, npm downloads, and course updates, updated automatically.',
+};
+
 const STATIC_ROUTES = new Map<string, StaticRoute>([
   ['/', { title: metadata.title, description: metadata.description }],
   ['/writing', WRITING_INDEX],
   ['/courses', COURSES_INDEX],
   ['/projects', PROJECTS_INDEX],
+  ['/dashboard', DASHBOARD_INDEX],
 ]);
 
 const safeDecode = (value: string): string => {

--- a/applications/website/src/routes/api/dashboard/+server.ts
+++ b/applications/website/src/routes/api/dashboard/+server.ts
@@ -26,6 +26,7 @@ const SUCCESS_HEADERS = {
 const FAILURE_HEADERS = {
   'Cache-Control': 'no-store',
   'Retry-After': '300',
+  'Access-Control-Allow-Origin': '*',
 };
 
 /**

--- a/applications/website/src/routes/api/dashboard/+server.ts
+++ b/applications/website/src/routes/api/dashboard/+server.ts
@@ -2,6 +2,8 @@ import { json } from '@sveltejs/kit';
 
 import { getDashboardData, isDashboardComplete } from '$lib/server/dashboard';
 
+import type { Config } from '@sveltejs/adapter-vercel';
+
 export const prerender = false;
 
 // Deliberately NOT Vercel ISR: prerender functions strip non-200 response
@@ -9,6 +11,12 @@ export const prerender = false;
 // 503-carries-body contract the dashboard page depends on. The s-maxage +
 // stale-while-revalidate headers on success responses provide the 24-hour
 // edge cache instead.
+//
+// maxDuration is raised because a cold compute fans out to GitHub GraphQL
+// (serialized to avoid its secondary rate limit — see github.ts), GitHub
+// REST, and the npm registry; measured live, that combination exceeded
+// Vercel's 15-second default and 504'd before ever producing a response.
+export const config: Config = { maxDuration: 60 };
 
 const SUCCESS_HEADERS = {
   'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',

--- a/applications/website/src/routes/api/dashboard/+server.ts
+++ b/applications/website/src/routes/api/dashboard/+server.ts
@@ -1,0 +1,39 @@
+import { json } from '@sveltejs/kit';
+
+import { getDashboardData, isDashboardComplete } from '$lib/server/dashboard';
+
+export const prerender = false;
+
+// Deliberately NOT Vercel ISR: prerender functions strip non-200 response
+// bodies (adapter-vercel cannot set exposeErrBody), which would break the
+// 503-carries-body contract the dashboard page depends on. The s-maxage +
+// stale-while-revalidate headers on success responses provide the 24-hour
+// edge cache instead.
+
+const SUCCESS_HEADERS = {
+  'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+  'Access-Control-Allow-Origin': '*',
+};
+
+const FAILURE_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Retry-After': '300',
+};
+
+/**
+ * Serves the full dashboard snapshot as JSON.
+ *
+ * Responds with 503 and no-store caching headers when any section failed
+ * to resolve, but the body always carries every section — healthy ones
+ * included — so the dashboard page can render a partial snapshot even
+ * from an unsuccessful response.
+ */
+export const GET = async (): Promise<Response> => {
+  const data = await getDashboardData();
+  const complete = isDashboardComplete(data);
+
+  return json(data, {
+    status: complete ? 200 : 503,
+    headers: complete ? SUCCESS_HEADERS : FAILURE_HEADERS,
+  });
+};

--- a/applications/website/src/routes/api/dashboard/courses/+server.ts
+++ b/applications/website/src/routes/api/dashboard/courses/+server.ts
@@ -2,6 +2,8 @@ import { json } from '@sveltejs/kit';
 
 import { getDashboardData } from '$lib/server/dashboard';
 
+import type { Config } from '@sveltejs/adapter-vercel';
+
 export const prerender = false;
 
 // Deliberately NOT Vercel ISR: prerender functions strip non-200 response
@@ -9,6 +11,12 @@ export const prerender = false;
 // 503-carries-body contract the dashboard page depends on. The s-maxage +
 // stale-while-revalidate headers on success responses provide the 24-hour
 // edge cache instead.
+//
+// maxDuration is raised because a cold compute fans out to GitHub GraphQL
+// (serialized to avoid its secondary rate limit — see github.ts), GitHub
+// REST, and the npm registry; measured live, that combination exceeded
+// Vercel's 15-second default and 504'd before ever producing a response.
+export const config: Config = { maxDuration: 60 };
 
 const SUCCESS_HEADERS = {
   'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',

--- a/applications/website/src/routes/api/dashboard/courses/+server.ts
+++ b/applications/website/src/routes/api/dashboard/courses/+server.ts
@@ -26,6 +26,7 @@ const SUCCESS_HEADERS = {
 const FAILURE_HEADERS = {
   'Cache-Control': 'no-store',
   'Retry-After': '300',
+  'Access-Control-Allow-Origin': '*',
 };
 
 /**

--- a/applications/website/src/routes/api/dashboard/courses/+server.ts
+++ b/applications/website/src/routes/api/dashboard/courses/+server.ts
@@ -1,0 +1,35 @@
+import { json } from '@sveltejs/kit';
+
+import { getDashboardData } from '$lib/server/dashboard';
+
+export const prerender = false;
+
+// Deliberately NOT Vercel ISR: prerender functions strip non-200 response
+// bodies (adapter-vercel cannot set exposeErrBody), which would break the
+// 503-carries-body contract the dashboard page depends on. The s-maxage +
+// stale-while-revalidate headers on success responses provide the 24-hour
+// edge cache instead.
+
+const SUCCESS_HEADERS = {
+  'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+  'Access-Control-Allow-Origin': '*',
+};
+
+const FAILURE_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Retry-After': '300',
+};
+
+/**
+ * Serves the course-updates section of the dashboard snapshot as JSON,
+ * keyed off that section's own status rather than the snapshot as a whole.
+ */
+export const GET = async (): Promise<Response> => {
+  const data = await getDashboardData();
+  const ok = data.courses.status === 'ok';
+
+  return json(
+    { generatedAt: data.generatedAt, window: data.window, courses: data.courses },
+    { status: ok ? 200 : 503, headers: ok ? SUCCESS_HEADERS : FAILURE_HEADERS },
+  );
+};

--- a/applications/website/src/routes/api/dashboard/dashboard-api.test.ts
+++ b/applications/website/src/routes/api/dashboard/dashboard-api.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  CourseUpdate,
+  DashboardData,
+  DashboardSection,
+  GithubStats,
+  NpmStats,
+} from '$lib/dashboard-types';
+
+vi.mock('$lib/server/dashboard', () => ({
+  getDashboardData: vi.fn(),
+  isDashboardComplete: (data: DashboardData): boolean =>
+    data.github.status === 'ok' && data.npm.status === 'ok' && data.courses.status === 'ok',
+}));
+
+import { getDashboardData } from '$lib/server/dashboard';
+
+import { GET as getCourses } from './courses/+server';
+import { GET as getGithub } from './github/+server';
+import { GET as getNpm } from './npm/+server';
+import { GET as getDashboard } from './+server';
+
+const mockGetDashboardData = vi.mocked(getDashboardData);
+
+const okGithub: DashboardSection<GithubStats> = {
+  status: 'ok',
+  data: {
+    login: 'stevekinney',
+    profileUrl: 'https://github.com/stevekinney',
+    followers: 100,
+    publicRepositories: 42,
+    totalStars: 500,
+    pullRequests: { openNow: 3, mergedLastYear: 40 },
+    commits: {
+      totalLastYear: 900,
+      privateContributionsLastYear: 200,
+      byRepository: [
+        {
+          nameWithOwner: 'stevekinney/website',
+          url: 'https://github.com/stevekinney/website',
+          stargazerCount: 12,
+          commits: 300,
+        },
+      ],
+    },
+    issues: { openedLastYear: 10, closedLastYear: 9 },
+    reviews: { totalLastYear: 20 },
+  },
+};
+
+const okNpm: DashboardSection<NpmStats> = {
+  status: 'ok',
+  data: {
+    packageCount: 5,
+    totalDownloadsLastYear: 10000,
+    topPackages: [
+      {
+        name: '@stevekinney/utilities',
+        version: '1.0.0',
+        url: 'https://www.npmjs.com/package/@stevekinney/utilities',
+        downloadsLastYear: 4000,
+      },
+    ],
+  },
+};
+
+const okCourseUpdates: CourseUpdate[] = [
+  {
+    slug: 'react-typescript',
+    title: 'React and TypeScript',
+    description: 'Learn React with TypeScript.',
+    path: '/courses/react-typescript',
+    lessonCount: 20,
+    lastUpdatedAt: '2026-06-01T00:00:00.000Z',
+    lastCommit: {
+      message: 'Fix typo in lesson three',
+      url: 'https://github.com/stevekinney/course/commit/abc123',
+      sha: 'abc123',
+    },
+  },
+];
+
+const okCourses: DashboardSection<CourseUpdate[]> = { status: 'ok', data: okCourseUpdates };
+
+/** Builds a complete, all-sections-healthy dashboard snapshot for tests. */
+const buildDashboardData = (overrides: Partial<DashboardData> = {}): DashboardData => ({
+  generatedAt: '2026-07-01T00:00:00.000Z',
+  window: { from: '2025-07-01T00:00:00.000Z', to: '2026-07-01T00:00:00.000Z' },
+  github: okGithub,
+  npm: okNpm,
+  courses: okCourses,
+  ...overrides,
+});
+
+const erroredSection = <T>(message: string): DashboardSection<T> => ({
+  status: 'error',
+  error: message,
+});
+
+beforeEach(() => {
+  mockGetDashboardData.mockReset();
+});
+
+describe('GET /api/dashboard', () => {
+  it('returns 200 with success headers when every section is healthy', async () => {
+    const data = buildDashboardData();
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getDashboard();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+    );
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Retry-After')).toBeNull();
+    expect(body).toEqual(data);
+  });
+
+  it('returns 503 with no-store headers when a section errored, keeping the full body', async () => {
+    const data = buildDashboardData({ npm: erroredSection('npm registry timed out') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getDashboard();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Retry-After')).toBe('300');
+    expect(body.github.status).toBe('ok');
+    expect(body.npm.status).toBe('error');
+    expect(body.courses.status).toBe('ok');
+  });
+});
+
+describe('GET /api/dashboard/github', () => {
+  it('returns 200 keyed off the github section even when other sections errored', async () => {
+    const data = buildDashboardData({ npm: erroredSection('npm registry timed out') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getGithub();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+    );
+    expect(body).toEqual({ generatedAt: data.generatedAt, window: data.window, github: okGithub });
+  });
+
+  it('returns 503 when the github section itself errored', async () => {
+    const data = buildDashboardData({ github: erroredSection('GitHub API rate limited') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getGithub();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Retry-After')).toBe('300');
+    expect(body.github.status).toBe('error');
+  });
+});
+
+describe('GET /api/dashboard/npm', () => {
+  it('returns 200 keyed off the npm section even when other sections errored', async () => {
+    const data = buildDashboardData({ github: erroredSection('GitHub API rate limited') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getNpm();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ generatedAt: data.generatedAt, window: data.window, npm: okNpm });
+  });
+
+  it('returns 503 when the npm section itself errored', async () => {
+    const data = buildDashboardData({ npm: erroredSection('npm registry timed out') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getNpm();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Retry-After')).toBe('300');
+  });
+});
+
+describe('GET /api/dashboard/courses', () => {
+  it('returns 200 keyed off the courses section even when other sections errored', async () => {
+    const data = buildDashboardData({ github: erroredSection('GitHub API rate limited') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getCourses();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      generatedAt: data.generatedAt,
+      window: data.window,
+      courses: okCourses,
+    });
+  });
+
+  it('returns 503 when the courses section itself errored', async () => {
+    const data = buildDashboardData({ courses: erroredSection('git log failed') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await getCourses();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Retry-After')).toBe('300');
+  });
+});

--- a/applications/website/src/routes/api/dashboard/github/+server.ts
+++ b/applications/website/src/routes/api/dashboard/github/+server.ts
@@ -2,6 +2,8 @@ import { json } from '@sveltejs/kit';
 
 import { getDashboardData } from '$lib/server/dashboard';
 
+import type { Config } from '@sveltejs/adapter-vercel';
+
 export const prerender = false;
 
 // Deliberately NOT Vercel ISR: prerender functions strip non-200 response
@@ -9,6 +11,12 @@ export const prerender = false;
 // 503-carries-body contract the dashboard page depends on. The s-maxage +
 // stale-while-revalidate headers on success responses provide the 24-hour
 // edge cache instead.
+//
+// maxDuration is raised because a cold compute fans out to GitHub GraphQL
+// (serialized to avoid its secondary rate limit — see github.ts), GitHub
+// REST, and the npm registry; measured live, that combination exceeded
+// Vercel's 15-second default and 504'd before ever producing a response.
+export const config: Config = { maxDuration: 60 };
 
 const SUCCESS_HEADERS = {
   'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',

--- a/applications/website/src/routes/api/dashboard/github/+server.ts
+++ b/applications/website/src/routes/api/dashboard/github/+server.ts
@@ -26,6 +26,7 @@ const SUCCESS_HEADERS = {
 const FAILURE_HEADERS = {
   'Cache-Control': 'no-store',
   'Retry-After': '300',
+  'Access-Control-Allow-Origin': '*',
 };
 
 /**

--- a/applications/website/src/routes/api/dashboard/github/+server.ts
+++ b/applications/website/src/routes/api/dashboard/github/+server.ts
@@ -1,0 +1,35 @@
+import { json } from '@sveltejs/kit';
+
+import { getDashboardData } from '$lib/server/dashboard';
+
+export const prerender = false;
+
+// Deliberately NOT Vercel ISR: prerender functions strip non-200 response
+// bodies (adapter-vercel cannot set exposeErrBody), which would break the
+// 503-carries-body contract the dashboard page depends on. The s-maxage +
+// stale-while-revalidate headers on success responses provide the 24-hour
+// edge cache instead.
+
+const SUCCESS_HEADERS = {
+  'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+  'Access-Control-Allow-Origin': '*',
+};
+
+const FAILURE_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Retry-After': '300',
+};
+
+/**
+ * Serves the GitHub section of the dashboard snapshot as JSON, keyed off
+ * that section's own status rather than the snapshot as a whole.
+ */
+export const GET = async (): Promise<Response> => {
+  const data = await getDashboardData();
+  const ok = data.github.status === 'ok';
+
+  return json(
+    { generatedAt: data.generatedAt, window: data.window, github: data.github },
+    { status: ok ? 200 : 503, headers: ok ? SUCCESS_HEADERS : FAILURE_HEADERS },
+  );
+};

--- a/applications/website/src/routes/api/dashboard/npm/+server.ts
+++ b/applications/website/src/routes/api/dashboard/npm/+server.ts
@@ -1,0 +1,35 @@
+import { json } from '@sveltejs/kit';
+
+import { getDashboardData } from '$lib/server/dashboard';
+
+export const prerender = false;
+
+// Deliberately NOT Vercel ISR: prerender functions strip non-200 response
+// bodies (adapter-vercel cannot set exposeErrBody), which would break the
+// 503-carries-body contract the dashboard page depends on. The s-maxage +
+// stale-while-revalidate headers on success responses provide the 24-hour
+// edge cache instead.
+
+const SUCCESS_HEADERS = {
+  'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+  'Access-Control-Allow-Origin': '*',
+};
+
+const FAILURE_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Retry-After': '300',
+};
+
+/**
+ * Serves the npm section of the dashboard snapshot as JSON, keyed off
+ * that section's own status rather than the snapshot as a whole.
+ */
+export const GET = async (): Promise<Response> => {
+  const data = await getDashboardData();
+  const ok = data.npm.status === 'ok';
+
+  return json(
+    { generatedAt: data.generatedAt, window: data.window, npm: data.npm },
+    { status: ok ? 200 : 503, headers: ok ? SUCCESS_HEADERS : FAILURE_HEADERS },
+  );
+};

--- a/applications/website/src/routes/api/dashboard/npm/+server.ts
+++ b/applications/website/src/routes/api/dashboard/npm/+server.ts
@@ -2,6 +2,8 @@ import { json } from '@sveltejs/kit';
 
 import { getDashboardData } from '$lib/server/dashboard';
 
+import type { Config } from '@sveltejs/adapter-vercel';
+
 export const prerender = false;
 
 // Deliberately NOT Vercel ISR: prerender functions strip non-200 response
@@ -9,6 +11,12 @@ export const prerender = false;
 // 503-carries-body contract the dashboard page depends on. The s-maxage +
 // stale-while-revalidate headers on success responses provide the 24-hour
 // edge cache instead.
+//
+// maxDuration is raised because a cold compute fans out to GitHub GraphQL
+// (serialized to avoid its secondary rate limit — see github.ts), GitHub
+// REST, and the npm registry; measured live, that combination exceeded
+// Vercel's 15-second default and 504'd before ever producing a response.
+export const config: Config = { maxDuration: 60 };
 
 const SUCCESS_HEADERS = {
   'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',

--- a/applications/website/src/routes/api/dashboard/npm/+server.ts
+++ b/applications/website/src/routes/api/dashboard/npm/+server.ts
@@ -26,6 +26,7 @@ const SUCCESS_HEADERS = {
 const FAILURE_HEADERS = {
   'Cache-Control': 'no-store',
   'Retry-After': '300',
+  'Access-Control-Allow-Origin': '*',
 };
 
 /**

--- a/applications/website/src/routes/dashboard/+page.server.ts
+++ b/applications/website/src/routes/dashboard/+page.server.ts
@@ -1,0 +1,46 @@
+import { getCourseIndex, getGeneratedContent } from '$lib/server/content';
+import type { PageServerLoad } from './$types';
+import type { DashboardCourseSummary } from './dashboard-page-types';
+
+export const prerender = true;
+
+const title = 'Dashboard';
+const description =
+  'A live look at my GitHub activity, npm downloads, and course updates over the past year, recomputed at most once a day.';
+
+/** Counts lessons per course by joining the flat lesson index on `courseSlug`. */
+const countLessonsByCourse = (): Map<string, number> => {
+  const counts = new Map<string, number>();
+
+  for (const lesson of getGeneratedContent().lessons) {
+    counts.set(lesson.courseSlug, (counts.get(lesson.courseSlug) ?? 0) + 1);
+  }
+
+  return counts;
+};
+
+/** Builds the course list the dashboard renders before any client data arrives. */
+const buildCourseSummaries = (): DashboardCourseSummary[] => {
+  const lessonCounts = countLessonsByCourse();
+
+  return getCourseIndex().map((course) => ({
+    slug: course.slug,
+    title: course.title,
+    description: course.description,
+    path: course.path,
+    lessonCount: lessonCounts.get(course.slug) ?? 0,
+  }));
+};
+
+/**
+ * Loads the static shell for `/dashboard`: title, description, and the
+ * course list built from content at build time so crawlers see real course
+ * content without waiting on the client-side `/api/dashboard` fetch.
+ */
+export const load: PageServerLoad = async () => {
+  return {
+    title,
+    description,
+    courses: buildCourseSummaries(),
+  };
+};

--- a/applications/website/src/routes/dashboard/+page.svelte
+++ b/applications/website/src/routes/dashboard/+page.svelte
@@ -8,7 +8,7 @@
   import type { DashboardData } from '$lib/dashboard-types';
 
   import DashboardCoursesSection from './dashboard-courses-section.svelte';
-  import { dashboardDataSchema } from './dashboard-data-schema';
+  import { isDashboardData } from './dashboard-data-schema';
   import DashboardGithubSection from './dashboard-github-section.svelte';
   import DashboardNpmSection from './dashboard-npm-section.svelte';
   import type { DashboardPageState } from './dashboard-section-state';
@@ -34,11 +34,10 @@
     try {
       const response = await fetch('/api/dashboard');
       const payload: unknown = await response.json();
-      const result = dashboardDataSchema.safeParse(payload);
 
-      if (!result.success) throw new Error('Unexpected dashboard response shape');
+      if (!isDashboardData(payload)) throw new Error('Unexpected dashboard response shape');
 
-      dashboardData = result.data;
+      dashboardData = payload;
       pageState = 'loaded';
     } catch {
       dashboardData = null;

--- a/applications/website/src/routes/dashboard/+page.svelte
+++ b/applications/website/src/routes/dashboard/+page.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import SEO from '$lib/components/seo.svelte';
+  import formatDate from '$lib/format-date';
+  import { url } from '$lib/metadata';
+  import { buildBreadcrumbSchema, buildPersonSchema } from '$lib/structured-data';
+  import type { DashboardData } from '$lib/dashboard-types';
+
+  import DashboardCoursesSection from './dashboard-courses-section.svelte';
+  import { dashboardDataSchema } from './dashboard-data-schema';
+  import DashboardGithubSection from './dashboard-github-section.svelte';
+  import DashboardNpmSection from './dashboard-npm-section.svelte';
+  import type { DashboardPageState } from './dashboard-section-state';
+  import { toSectionState } from './dashboard-section-state';
+
+  const { data } = $props();
+
+  let pageState = $state<DashboardPageState>('loading');
+  let retrying = $state(false);
+  let dashboardData = $state.raw<DashboardData | null>(null);
+
+  const githubSection = $derived(toSectionState(pageState, dashboardData?.github));
+  const npmSection = $derived(toSectionState(pageState, dashboardData?.npm));
+  const coursesSection = $derived(toSectionState(pageState, dashboardData?.courses));
+
+  const jsonLd = [
+    buildBreadcrumbSchema([{ name: 'Dashboard', url: `${url}/dashboard` }]),
+    buildPersonSchema(),
+  ];
+
+  /** Fetches `/api/dashboard`. Parses defensively — a network or parse failure just fails the page. */
+  async function loadDashboardData(): Promise<void> {
+    try {
+      const response = await fetch('/api/dashboard');
+      const payload: unknown = await response.json();
+      const result = dashboardDataSchema.safeParse(payload);
+
+      if (!result.success) throw new Error('Unexpected dashboard response shape');
+
+      dashboardData = result.data;
+      pageState = 'loaded';
+    } catch {
+      dashboardData = null;
+      pageState = 'failed';
+    }
+  }
+
+  /**
+   * Retries without leaving the 'failed' state, so the alert (and the focused
+   * button inside it) stays mounted for the whole attempt — unmounting it
+   * mid-click would strand keyboard focus at the top of the document.
+   */
+  async function retryDashboardData(): Promise<void> {
+    retrying = true;
+
+    await loadDashboardData();
+
+    retrying = false;
+  }
+
+  onMount(() => {
+    loadDashboardData();
+  });
+</script>
+
+<SEO title={data.title} description={data.description} {jsonLd}>
+  <link
+    rel="alternate"
+    type="application/atom+xml"
+    title="Dashboard updates"
+    href="/dashboard/rss"
+  />
+</SEO>
+
+<div class="space-y-10">
+  <div class="prose dark:prose-invert max-w-none">
+    <p>
+      This page pulls back the curtain on what I've actually been building: a live snapshot of my
+      GitHub activity, npm downloads, and course updates from the past year, recomputed at most once
+      a day so it stays fresh without hammering anyone's rate limits.
+    </p>
+  </div>
+
+  {#if pageState === 'failed'}
+    <div
+      class="rounded-md border border-slate-300 p-4 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-300"
+      role="alert"
+    >
+      <p>I couldn't load the live dashboard data just now.</p>
+      <button
+        type="button"
+        onclick={retryDashboardData}
+        disabled={retrying}
+        class="decoration-primary-700 mt-2 font-semibold underline-offset-2 hover:underline disabled:opacity-60"
+      >
+        {retrying ? 'Retrying…' : 'Try again'}
+      </button>
+    </div>
+  {/if}
+
+  <DashboardGithubSection section={githubSection} />
+
+  <DashboardNpmSection section={npmSection} />
+
+  <DashboardCoursesSection initialCourses={data.courses} section={coursesSection} />
+
+  <footer
+    class="space-y-2 border-t border-slate-200 pt-6 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400"
+  >
+    <p>Recomputed at most once every 24 hours.</p>
+    {#if dashboardData}
+      <p>Last computed {formatDate(dashboardData.generatedAt)}.</p>
+    {/if}
+    <p>
+      Machine-readable versions: <a href="/api/dashboard" class="underline-offset-2 hover:underline"
+        >JSON</a
+      >, <a href="/dashboard/rss" class="underline-offset-2 hover:underline">Atom</a>, and
+      <a href="/dashboard/llms.txt" class="underline-offset-2 hover:underline">plain text</a>.
+    </p>
+    <noscript>
+      <p>
+        View the raw data at <a href="/api/dashboard">/api/dashboard</a>, subscribe via
+        <a href="/dashboard/rss">/dashboard/rss</a>, or read the plain-text summary at
+        <a href="/dashboard/llms.txt">/dashboard/llms.txt</a>.
+      </p>
+    </noscript>
+  </footer>
+</div>

--- a/applications/website/src/routes/dashboard/dashboard-courses-section.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-courses-section.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import formatDate from '$lib/format-date';
+  import type { CourseUpdate } from '$lib/dashboard-types';
+
+  import type { DashboardCourseSummary } from './dashboard-page-types';
+  import type { SectionState } from './dashboard-section-state';
+
+  type DisplayCourse = DashboardCourseSummary & {
+    lastUpdatedAt: string | null;
+    lastCommit: CourseUpdate['lastCommit'];
+  };
+
+  type Props = {
+    /** The build-time course list from `load()`, in its original order. */
+    initialCourses: DashboardCourseSummary[];
+    section: SectionState<CourseUpdate[]>;
+  };
+
+  const { initialCourses, section }: Props = $props();
+
+  /** Places courses without a known update time last, without disturbing the rest of the order. */
+  const byMostRecentlyUpdated = (a: DisplayCourse, b: DisplayCourse): number => {
+    if (a.lastUpdatedAt === null && b.lastUpdatedAt === null) return 0;
+    if (a.lastUpdatedAt === null) return 1;
+    if (b.lastUpdatedAt === null) return -1;
+
+    return b.lastUpdatedAt.localeCompare(a.lastUpdatedAt);
+  };
+
+  const courses = $derived.by((): DisplayCourse[] => {
+    if (section.kind !== 'ok') {
+      return initialCourses.map((course) => ({
+        ...course,
+        lastUpdatedAt: null,
+        lastCommit: null,
+      }));
+    }
+
+    const updatesBySlug = new Map(section.data.map((update) => [update.slug, update]));
+
+    return initialCourses
+      .map((course) => {
+        const update = updatesBySlug.get(course.slug);
+
+        return {
+          ...course,
+          lastUpdatedAt: update?.lastUpdatedAt ?? null,
+          lastCommit: update?.lastCommit ?? null,
+        };
+      })
+      .sort(byMostRecentlyUpdated);
+  });
+</script>
+
+<section aria-labelledby="dashboard-courses-heading" class="space-y-4">
+  <h2 id="dashboard-courses-heading" class="prose dark:prose-invert text-2xl font-bold">
+    Recently Updated Courses
+  </h2>
+
+  {#if section.kind === 'error'}
+    <p class="text-sm text-slate-500 dark:text-slate-400">
+      Live update info is temporarily unavailable — showing what's on the site.
+    </p>
+  {/if}
+
+  <ul class="space-y-4">
+    {#each courses as course (course.slug)}
+      <li>
+        <a
+          href={course.path}
+          class="decoration-primary-700 font-semibold underline-offset-2 hover:underline"
+        >
+          {course.title}
+        </a>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">{course.description}</p>
+        {#if course.lessonCount > 0}
+          <p class="text-sm text-slate-500 dark:text-slate-400">{course.lessonCount} lessons</p>
+        {/if}
+        {#if course.lastUpdatedAt}
+          <p class="text-sm text-slate-500 dark:text-slate-400">
+            Updated {formatDate(course.lastUpdatedAt)}
+          </p>
+        {/if}
+        {#if course.lastCommit}
+          <p class="text-sm text-slate-500 italic dark:text-slate-400">
+            <a href={course.lastCommit.url} class="hover:underline">{course.lastCommit.message}</a>
+          </p>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+</section>

--- a/applications/website/src/routes/dashboard/dashboard-data-schema.test.ts
+++ b/applications/website/src/routes/dashboard/dashboard-data-schema.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import { isDashboardData } from './dashboard-data-schema';
+
+const validData = {
+  generatedAt: '2026-07-20T00:00:00.000Z',
+  window: { from: '2025-07-20T00:00:00.000Z', to: '2026-07-20T00:00:00.000Z' },
+  github: {
+    status: 'ok',
+    data: {
+      login: 'stevekinney',
+      profileUrl: 'https://github.com/stevekinney',
+      followers: 10,
+      publicRepositories: 20,
+      totalStars: 30,
+      pullRequests: { openNow: 1, mergedLastYear: 2 },
+      commits: {
+        totalLastYear: 3,
+        privateContributionsLastYear: 4,
+        byRepository: [
+          {
+            nameWithOwner: 'stevekinney/example',
+            url: 'https://github.com/x',
+            stargazerCount: 1,
+            commits: 5,
+          },
+        ],
+      },
+      issues: { openedLastYear: 6, closedLastYear: 7 },
+      reviews: { totalLastYear: 8 },
+    },
+  },
+  npm: {
+    status: 'ok',
+    data: {
+      packageCount: 1,
+      totalDownloadsLastYear: 100,
+      topPackages: [
+        {
+          name: 'phone-formatter',
+          version: '0.0.2',
+          url: 'https://npmjs.com/x',
+          downloadsLastYear: 100,
+        },
+      ],
+    },
+  },
+  courses: {
+    status: 'ok',
+    data: [
+      {
+        slug: 'testing',
+        title: 'Introduction to Testing',
+        description: 'A course.',
+        path: '/courses/testing',
+        lessonCount: 80,
+        lastUpdatedAt: '2026-06-01T00:00:00.000Z',
+        lastCommit: { message: 'Update', url: 'https://github.com/x/commit/abc', sha: 'abc' },
+      },
+    ],
+  },
+};
+
+describe('isDashboardData', () => {
+  it('accepts a fully populated, valid response', () => {
+    expect(isDashboardData(validData)).toBe(true);
+  });
+
+  it('accepts an errored section with no data field', () => {
+    const withError = { ...validData, github: { status: 'error', error: 'boom' } };
+
+    expect(isDashboardData(withError)).toBe(true);
+  });
+
+  it('accepts a null lastCommit on a course update', () => {
+    const withNullCommit = {
+      ...validData,
+      courses: {
+        status: 'ok',
+        data: [{ ...validData.courses.data[0], lastCommit: null }],
+      },
+    };
+
+    expect(isDashboardData(withNullCommit)).toBe(true);
+  });
+
+  it('accepts a package with no description', () => {
+    const withoutDescription = {
+      ...validData,
+      npm: {
+        status: 'ok',
+        data: {
+          ...validData.npm.data,
+          topPackages: [
+            { name: 'phone-formatter', version: '0.0.2', url: 'x', downloadsLastYear: 1 },
+          ],
+        },
+      },
+    };
+
+    expect(isDashboardData(withoutDescription)).toBe(true);
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(isDashboardData(null)).toBe(false);
+    expect(isDashboardData('nope')).toBe(false);
+    expect(isDashboardData(42)).toBe(false);
+  });
+
+  it('rejects a section missing both data and error', () => {
+    const malformed = { ...validData, npm: { status: 'ok' } };
+
+    expect(isDashboardData(malformed)).toBe(false);
+  });
+
+  it('rejects a section with an unknown status', () => {
+    const malformed = { ...validData, courses: { status: 'pending', data: [] } };
+
+    expect(isDashboardData(malformed)).toBe(false);
+  });
+
+  it('rejects when a required numeric field is a string', () => {
+    const malformed = {
+      ...validData,
+      github: {
+        status: 'ok',
+        data: { ...validData.github.data, followers: '10' },
+      },
+    };
+
+    expect(isDashboardData(malformed)).toBe(false);
+  });
+
+  it('rejects when commits.byRepository contains a malformed entry', () => {
+    const malformed = {
+      ...validData,
+      github: {
+        status: 'ok',
+        data: {
+          ...validData.github.data,
+          commits: {
+            ...validData.github.data.commits,
+            byRepository: [{ nameWithOwner: 'x', url: 'y', stargazerCount: 1 }],
+          },
+        },
+      },
+    };
+
+    expect(isDashboardData(malformed)).toBe(false);
+  });
+});

--- a/applications/website/src/routes/dashboard/dashboard-data-schema.ts
+++ b/applications/website/src/routes/dashboard/dashboard-data-schema.ts
@@ -1,89 +1,118 @@
-import { z } from 'zod';
+import type {
+  CourseUpdate,
+  DashboardData,
+  DashboardSection,
+  DashboardStatWindow,
+  GithubRepositoryCommits,
+  GithubStats,
+  NpmPackageStats,
+  NpmStats,
+} from '$lib/dashboard-types';
 
-import type { CourseUpdate, DashboardData, GithubStats, NpmStats } from '$lib/dashboard-types';
+// Manual type guards rather than zod: this validates `/api/dashboard`'s
+// response, which is our own server's output (not third-party input), and
+// zod's runtime was the single largest contributor to this route's client
+// bundle — pulling it in just to re-check our own API's shape blew the
+// project's build-size budget.
 
-const dashboardStatWindowSchema = z.object({
-  from: z.string(),
-  to: z.string(),
-});
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
 
-const githubRepositoryCommitsSchema = z.object({
-  nameWithOwner: z.string(),
-  url: z.string(),
-  stargazerCount: z.number(),
-  commits: z.number(),
-});
+const isString = (value: unknown): value is string => typeof value === 'string';
+const isNumber = (value: unknown): value is number => typeof value === 'number';
+const isArray = <Item>(value: unknown, isItem: (item: unknown) => item is Item): value is Item[] =>
+  Array.isArray(value) && value.every(isItem);
 
-const githubStatsSchema: z.ZodType<GithubStats> = z.object({
-  login: z.string(),
-  profileUrl: z.string(),
-  followers: z.number(),
-  publicRepositories: z.number(),
-  totalStars: z.number(),
-  pullRequests: z.object({
-    openNow: z.number(),
-    mergedLastYear: z.number(),
-  }),
-  commits: z.object({
-    totalLastYear: z.number(),
-    privateContributionsLastYear: z.number(),
-    byRepository: z.array(githubRepositoryCommitsSchema),
-  }),
-  issues: z.object({
-    openedLastYear: z.number(),
-    closedLastYear: z.number(),
-  }),
-  reviews: z.object({
-    totalLastYear: z.number(),
-  }),
-});
+const isDashboardStatWindow = (value: unknown): value is DashboardStatWindow =>
+  isRecord(value) && isString(value.from) && isString(value.to);
 
-const npmPackageStatsSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  version: z.string(),
-  url: z.string(),
-  downloadsLastYear: z.number(),
-});
+const isGithubRepositoryCommits = (value: unknown): value is GithubRepositoryCommits =>
+  isRecord(value) &&
+  isString(value.nameWithOwner) &&
+  isString(value.url) &&
+  isNumber(value.stargazerCount) &&
+  isNumber(value.commits);
 
-const npmStatsSchema: z.ZodType<NpmStats> = z.object({
-  packageCount: z.number(),
-  totalDownloadsLastYear: z.number(),
-  topPackages: z.array(npmPackageStatsSchema),
-});
+const isGithubStats = (value: unknown): value is GithubStats => {
+  if (!isRecord(value)) return false;
 
-const courseUpdateSchema: z.ZodType<CourseUpdate> = z.object({
-  slug: z.string(),
-  title: z.string(),
-  description: z.string(),
-  path: z.string(),
-  lessonCount: z.number(),
-  lastUpdatedAt: z.string(),
-  lastCommit: z
-    .object({
-      message: z.string(),
-      url: z.string(),
-      sha: z.string(),
-    })
-    .nullable(),
-});
+  const { pullRequests, commits, issues, reviews } = value;
 
-/** Builds the `{ status: 'ok', data } | { status: 'error', error }` shape shared by every section. */
-function dashboardSection<Schema extends z.ZodType>(schema: Schema) {
-  return z.discriminatedUnion('status', [
-    z.object({ status: z.literal('ok'), data: schema }),
-    z.object({ status: z.literal('error'), error: z.string() }),
-  ]);
-}
+  return (
+    isString(value.login) &&
+    isString(value.profileUrl) &&
+    isNumber(value.followers) &&
+    isNumber(value.publicRepositories) &&
+    isNumber(value.totalStars) &&
+    isRecord(pullRequests) &&
+    isNumber(pullRequests.openNow) &&
+    isNumber(pullRequests.mergedLastYear) &&
+    isRecord(commits) &&
+    isNumber(commits.totalLastYear) &&
+    isNumber(commits.privateContributionsLastYear) &&
+    isArray(commits.byRepository, isGithubRepositoryCommits) &&
+    isRecord(issues) &&
+    isNumber(issues.openedLastYear) &&
+    isNumber(issues.closedLastYear) &&
+    isRecord(reviews) &&
+    isNumber(reviews.totalLastYear)
+  );
+};
 
-/**
- * Validates an untrusted `/api/dashboard` response body against the shared
- * `DashboardData` contract before the page ever renders it.
- */
-export const dashboardDataSchema: z.ZodType<DashboardData> = z.object({
-  generatedAt: z.string(),
-  window: dashboardStatWindowSchema,
-  github: dashboardSection(githubStatsSchema),
-  npm: dashboardSection(npmStatsSchema),
-  courses: dashboardSection(z.array(courseUpdateSchema)),
-});
+const isNpmPackageStats = (value: unknown): value is NpmPackageStats =>
+  isRecord(value) &&
+  isString(value.name) &&
+  (value.description === undefined || isString(value.description)) &&
+  isString(value.version) &&
+  isString(value.url) &&
+  isNumber(value.downloadsLastYear);
+
+const isNpmStats = (value: unknown): value is NpmStats =>
+  isRecord(value) &&
+  isNumber(value.packageCount) &&
+  isNumber(value.totalDownloadsLastYear) &&
+  isArray(value.topPackages, isNpmPackageStats);
+
+const isCourseUpdate = (value: unknown): value is CourseUpdate => {
+  if (!isRecord(value)) return false;
+
+  const { lastCommit } = value;
+  const hasValidCommit =
+    lastCommit === null ||
+    (isRecord(lastCommit) &&
+      isString(lastCommit.message) &&
+      isString(lastCommit.url) &&
+      isString(lastCommit.sha));
+
+  return (
+    isString(value.slug) &&
+    isString(value.title) &&
+    isString(value.description) &&
+    isString(value.path) &&
+    isNumber(value.lessonCount) &&
+    isString(value.lastUpdatedAt) &&
+    hasValidCommit
+  );
+};
+
+const isDashboardSection = <T>(
+  value: unknown,
+  isData: (data: unknown) => data is T,
+): value is DashboardSection<T> => {
+  if (!isRecord(value)) return false;
+  if (value.status === 'ok') return isData(value.data);
+  if (value.status === 'error') return isString(value.error);
+
+  return false;
+};
+
+/** Validates an untrusted `/api/dashboard` response body before the page renders it. */
+export const isDashboardData = (value: unknown): value is DashboardData =>
+  isRecord(value) &&
+  isString(value.generatedAt) &&
+  isDashboardStatWindow(value.window) &&
+  isDashboardSection(value.github, isGithubStats) &&
+  isDashboardSection(value.npm, isNpmStats) &&
+  isDashboardSection(value.courses, (data): data is CourseUpdate[] =>
+    isArray(data, isCourseUpdate),
+  );

--- a/applications/website/src/routes/dashboard/dashboard-data-schema.ts
+++ b/applications/website/src/routes/dashboard/dashboard-data-schema.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+
+import type { CourseUpdate, DashboardData, GithubStats, NpmStats } from '$lib/dashboard-types';
+
+const dashboardStatWindowSchema = z.object({
+  from: z.string(),
+  to: z.string(),
+});
+
+const githubRepositoryCommitsSchema = z.object({
+  nameWithOwner: z.string(),
+  url: z.string(),
+  stargazerCount: z.number(),
+  commits: z.number(),
+});
+
+const githubStatsSchema: z.ZodType<GithubStats> = z.object({
+  login: z.string(),
+  profileUrl: z.string(),
+  followers: z.number(),
+  publicRepositories: z.number(),
+  totalStars: z.number(),
+  pullRequests: z.object({
+    openNow: z.number(),
+    mergedLastYear: z.number(),
+  }),
+  commits: z.object({
+    totalLastYear: z.number(),
+    privateContributionsLastYear: z.number(),
+    byRepository: z.array(githubRepositoryCommitsSchema),
+  }),
+  issues: z.object({
+    openedLastYear: z.number(),
+    closedLastYear: z.number(),
+  }),
+  reviews: z.object({
+    totalLastYear: z.number(),
+  }),
+});
+
+const npmPackageStatsSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  version: z.string(),
+  url: z.string(),
+  downloadsLastYear: z.number(),
+});
+
+const npmStatsSchema: z.ZodType<NpmStats> = z.object({
+  packageCount: z.number(),
+  totalDownloadsLastYear: z.number(),
+  topPackages: z.array(npmPackageStatsSchema),
+});
+
+const courseUpdateSchema: z.ZodType<CourseUpdate> = z.object({
+  slug: z.string(),
+  title: z.string(),
+  description: z.string(),
+  path: z.string(),
+  lessonCount: z.number(),
+  lastUpdatedAt: z.string(),
+  lastCommit: z
+    .object({
+      message: z.string(),
+      url: z.string(),
+      sha: z.string(),
+    })
+    .nullable(),
+});
+
+/** Builds the `{ status: 'ok', data } | { status: 'error', error }` shape shared by every section. */
+function dashboardSection<Schema extends z.ZodType>(schema: Schema) {
+  return z.discriminatedUnion('status', [
+    z.object({ status: z.literal('ok'), data: schema }),
+    z.object({ status: z.literal('error'), error: z.string() }),
+  ]);
+}
+
+/**
+ * Validates an untrusted `/api/dashboard` response body against the shared
+ * `DashboardData` contract before the page ever renders it.
+ */
+export const dashboardDataSchema: z.ZodType<DashboardData> = z.object({
+  generatedAt: z.string(),
+  window: dashboardStatWindowSchema,
+  github: dashboardSection(githubStatsSchema),
+  npm: dashboardSection(npmStatsSchema),
+  courses: dashboardSection(z.array(courseUpdateSchema)),
+});

--- a/applications/website/src/routes/dashboard/dashboard-github-section.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-github-section.svelte
@@ -42,7 +42,11 @@
         label="Open Pull Requests"
         value={formatMetric(stats.pullRequests.openNow)}
       />
-      <DashboardStatTile label="Issues Closed" value={formatMetric(stats.issues.closedLastYear)} />
+      <DashboardStatTile
+        label="Own Issues Closed"
+        value={formatMetric(stats.issues.closedLastYear)}
+        context="Issues I opened that are now closed"
+      />
       <DashboardStatTile
         label="Pull Requests Reviewed"
         value={formatMetric(stats.reviews.totalLastYear)}

--- a/applications/website/src/routes/dashboard/dashboard-github-section.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-github-section.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import type { GithubStats } from '$lib/dashboard-types';
+
+  import DashboardSkeleton from './dashboard-skeleton.svelte';
+  import DashboardStatTile from './dashboard-stat-tile.svelte';
+  import type { SectionState } from './dashboard-section-state';
+  import { formatMetric } from './format-metric';
+
+  type Props = {
+    section: SectionState<GithubStats>;
+  };
+
+  const { section }: Props = $props();
+
+  const maxRepositoryCommits = $derived(
+    section.kind === 'ok'
+      ? Math.max(1, ...section.data.commits.byRepository.map((repository) => repository.commits))
+      : 1,
+  );
+</script>
+
+<section aria-labelledby="dashboard-github-heading" class="space-y-4">
+  <h2 id="dashboard-github-heading" class="prose dark:prose-invert text-2xl font-bold">
+    GitHub — The Last Year
+  </h2>
+
+  {#if section.kind === 'loading'}
+    <DashboardSkeleton shape="tiles" label="GitHub stats" />
+  {:else if section.kind === 'error'}
+    <p class="text-sm text-slate-500 dark:text-slate-400">
+      GitHub stats are temporarily unavailable.
+    </p>
+  {:else}
+    {@const stats = section.data}
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <DashboardStatTile label="Commits" value={formatMetric(stats.commits.totalLastYear)} />
+      <DashboardStatTile
+        label="Merged Pull Requests"
+        value={formatMetric(stats.pullRequests.mergedLastYear)}
+      />
+      <DashboardStatTile
+        label="Open Pull Requests"
+        value={formatMetric(stats.pullRequests.openNow)}
+      />
+      <DashboardStatTile label="Issues Closed" value={formatMetric(stats.issues.closedLastYear)} />
+      <DashboardStatTile
+        label="Pull Requests Reviewed"
+        value={formatMetric(stats.reviews.totalLastYear)}
+      />
+      <DashboardStatTile label="Followers" value={formatMetric(stats.followers)} />
+      <DashboardStatTile label="Total Stars" value={formatMetric(stats.totalStars)} />
+      <DashboardStatTile
+        label="Public Repositories"
+        value={formatMetric(stats.publicRepositories)}
+      />
+    </div>
+    <p class="text-sm text-slate-500 dark:text-slate-400">
+      Plus {formatMetric(stats.issues.openedLastYear)} issues opened and {formatMetric(
+        stats.commits.privateContributionsLastYear,
+      )} private contributions.
+    </p>
+  {/if}
+</section>
+
+<section aria-labelledby="dashboard-commits-heading" class="space-y-4">
+  <h2 id="dashboard-commits-heading" class="prose dark:prose-invert text-2xl font-bold">
+    Commits by Repository
+  </h2>
+
+  {#if section.kind === 'loading'}
+    <DashboardSkeleton shape="bars" label="commits by repository" />
+  {:else if section.kind === 'error'}
+    <p class="text-sm text-slate-500 dark:text-slate-400">
+      Commit activity is temporarily unavailable.
+    </p>
+  {:else}
+    <ul class="space-y-3">
+      {#each section.data.commits.byRepository as repository (repository.nameWithOwner)}
+        <li>
+          <div class="flex items-baseline justify-between gap-4">
+            <a
+              href={repository.url}
+              class="decoration-primary-700 font-semibold underline-offset-2 hover:underline"
+            >
+              {repository.nameWithOwner}
+            </a>
+            <span class="text-sm whitespace-nowrap text-slate-500 dark:text-slate-400">
+              {formatMetric(repository.commits)}
+              {repository.commits === 1 ? 'commit' : 'commits'} &middot; {formatMetric(
+                repository.stargazerCount,
+              )}
+              {repository.stargazerCount === 1 ? 'star' : 'stars'}
+            </span>
+          </div>
+          <div class="mt-1 h-2 rounded bg-slate-200 dark:bg-slate-700" aria-hidden="true">
+            <div
+              class="bg-primary-600 dark:bg-primary-400 h-2 rounded"
+              style:width={`${(repository.commits / maxRepositoryCommits) * 100}%`}
+            ></div>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>

--- a/applications/website/src/routes/dashboard/dashboard-npm-section.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-npm-section.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { NpmStats } from '$lib/dashboard-types';
+
+  import DashboardSkeleton from './dashboard-skeleton.svelte';
+  import DashboardStatTile from './dashboard-stat-tile.svelte';
+  import type { SectionState } from './dashboard-section-state';
+  import { formatMetric } from './format-metric';
+
+  const TOP_PACKAGE_COUNT = 10;
+
+  type Props = {
+    section: SectionState<NpmStats>;
+  };
+
+  const { section }: Props = $props();
+
+  const topPackages = $derived(
+    section.kind === 'ok' ? section.data.topPackages.slice(0, TOP_PACKAGE_COUNT) : [],
+  );
+</script>
+
+<section aria-labelledby="dashboard-npm-heading" class="space-y-4">
+  <h2 id="dashboard-npm-heading" class="prose dark:prose-invert text-2xl font-bold">npm</h2>
+
+  {#if section.kind === 'loading'}
+    <DashboardSkeleton shape="tiles" label="npm stats" count={2} />
+    <DashboardSkeleton shape="rows" label="top npm packages" />
+  {:else if section.kind === 'error'}
+    <p class="text-sm text-slate-500 dark:text-slate-400">npm stats are temporarily unavailable.</p>
+  {:else}
+    <div class="grid gap-4 sm:grid-cols-2">
+      <DashboardStatTile
+        label="Downloads (Last Year)"
+        value={formatMetric(section.data.totalDownloadsLastYear)}
+      />
+      <DashboardStatTile label="Packages" value={formatMetric(section.data.packageCount)} />
+    </div>
+    <ol class="space-y-3">
+      {#each topPackages as pkg (pkg.name)}
+        <li>
+          <div class="flex items-baseline justify-between gap-4">
+            <a
+              href={pkg.url}
+              class="decoration-primary-700 font-semibold underline-offset-2 hover:underline"
+            >
+              {pkg.name}
+            </a>
+            <span class="text-sm whitespace-nowrap text-slate-500 dark:text-slate-400">
+              {formatMetric(pkg.downloadsLastYear)} downloads
+            </span>
+          </div>
+          {#if pkg.description}
+            <p class="truncate text-sm text-slate-600 dark:text-slate-300">{pkg.description}</p>
+          {/if}
+        </li>
+      {/each}
+    </ol>
+  {/if}
+</section>

--- a/applications/website/src/routes/dashboard/dashboard-page-types.ts
+++ b/applications/website/src/routes/dashboard/dashboard-page-types.ts
@@ -1,0 +1,8 @@
+/** A course as known at build time, before the client enriches it with live update data. */
+export type DashboardCourseSummary = {
+  slug: string;
+  title: string;
+  description: string;
+  path: string;
+  lessonCount: number;
+};

--- a/applications/website/src/routes/dashboard/dashboard-section-state.ts
+++ b/applications/website/src/routes/dashboard/dashboard-section-state.ts
@@ -1,0 +1,30 @@
+import type { DashboardSection } from '$lib/dashboard-types';
+
+/** Overall lifecycle of the client-side `/api/dashboard` fetch. */
+export type DashboardPageState = 'loading' | 'loaded' | 'failed';
+
+/**
+ * View-model for a single section: it mirrors the fetch lifecycle, not just
+ * the resolved `DashboardSection`, so a section component can render a
+ * skeleton before the request settles and a quiet notice if it never does.
+ */
+export type SectionState<T> = { kind: 'loading' } | { kind: 'ok'; data: T } | { kind: 'error' };
+
+/**
+ * Converts the page's fetch lifecycle plus an optional resolved
+ * `DashboardSection` into the `SectionState` a section component renders.
+ * The upstream `section.error` message is intentionally dropped — sections
+ * show their own friendly, static notice instead of surfacing server errors.
+ */
+export function toSectionState<T>(
+  pageState: DashboardPageState,
+  section: DashboardSection<T> | undefined,
+): SectionState<T> {
+  if (pageState === 'loading') return { kind: 'loading' };
+
+  if (pageState === 'failed' || !section) return { kind: 'error' };
+
+  if (section.status === 'ok') return { kind: 'ok', data: section.data };
+
+  return { kind: 'error' };
+}

--- a/applications/website/src/routes/dashboard/dashboard-skeleton.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-skeleton.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  type SkeletonShape = 'tiles' | 'bars' | 'rows';
+
+  type Props = {
+    /** Which placeholder shape to draw — matches the section it stands in for. */
+    shape: SkeletonShape;
+    /** Announced to screen readers while the section is still loading. */
+    label: string;
+    count?: number;
+  };
+
+  const defaultCounts: Record<SkeletonShape, number> = { tiles: 8, bars: 5, rows: 5 };
+
+  const { shape, label, count = defaultCounts[shape] }: Props = $props();
+
+  const placeholders = $derived(Array.from({ length: count }, (_, index) => index));
+</script>
+
+<div class="animate-pulse motion-reduce:animate-none" aria-busy="true">
+  <span class="sr-only" role="status">Loading {label}…</span>
+
+  {#if shape === 'tiles'}
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4" aria-hidden="true">
+      {#each placeholders as placeholder (placeholder)}
+        <div class="h-24 rounded-md bg-slate-200 dark:bg-slate-700"></div>
+      {/each}
+    </div>
+  {:else if shape === 'bars'}
+    <div class="space-y-3" aria-hidden="true">
+      {#each placeholders as placeholder (placeholder)}
+        <div class="space-y-1.5">
+          <div class="h-4 w-2/5 rounded bg-slate-200 dark:bg-slate-700"></div>
+          <div class="h-2 rounded bg-slate-200 dark:bg-slate-700"></div>
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <div class="space-y-3" aria-hidden="true">
+      {#each placeholders as placeholder (placeholder)}
+        <div class="h-14 rounded-md bg-slate-200 dark:bg-slate-700"></div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/applications/website/src/routes/dashboard/dashboard-stat-tile.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-stat-tile.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  type Props = {
+    label: string;
+    value: string;
+    context?: string;
+  };
+
+  const { label, value, context }: Props = $props();
+</script>
+
+<div class="rounded-md bg-slate-100 p-4 dark:bg-slate-800">
+  <p class="text-sm text-slate-500 dark:text-slate-400">{label}</p>
+  <p class="font-header text-4xl">{value}</p>
+  {#if context}
+    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">{context}</p>
+  {/if}
+</div>

--- a/applications/website/src/routes/dashboard/format-metric.test.ts
+++ b/applications/website/src/routes/dashboard/format-metric.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatMetric } from './format-metric';
+
+describe('formatMetric', () => {
+  test('formats numbers below 10,000 with plain grouping', () => {
+    expect(formatMetric(0)).toBe('0');
+    expect(formatMetric(999)).toBe('999');
+    expect(formatMetric(1234)).toBe('1,234');
+    expect(formatMetric(9999)).toBe('9,999');
+  });
+
+  test('formats numbers at or above 10,000 with compact notation', () => {
+    expect(formatMetric(10_000)).toBe('10K');
+    expect(formatMetric(12_345)).toBe('12.3K');
+    expect(formatMetric(1_500_000)).toBe('1.5M');
+  });
+});

--- a/applications/website/src/routes/dashboard/format-metric.ts
+++ b/applications/website/src/routes/dashboard/format-metric.ts
@@ -1,0 +1,12 @@
+const COMPACT_NOTATION_THRESHOLD = 10_000;
+
+/**
+ * Formats a dashboard metric for display: compact notation (e.g. `12.3K`)
+ * once a value reaches five digits, plain grouped digits (e.g. `1,234`)
+ * below that.
+ */
+export function formatMetric(value: number): string {
+  const notation = value >= COMPACT_NOTATION_THRESHOLD ? 'compact' : 'standard';
+
+  return new Intl.NumberFormat('en-US', { notation, maximumFractionDigits: 1 }).format(value);
+}

--- a/applications/website/src/routes/dashboard/llms.txt/+server.ts
+++ b/applications/website/src/routes/dashboard/llms.txt/+server.ts
@@ -1,0 +1,148 @@
+import { url } from '$lib/metadata';
+import { getDashboardData, isDashboardComplete } from '$lib/server/dashboard';
+
+import type {
+  CourseUpdate,
+  DashboardData,
+  DashboardSection,
+  GithubStats,
+  NpmStats,
+} from '$lib/dashboard-types';
+export const prerender = false;
+
+// Deliberately NOT Vercel ISR: prerender functions strip non-200 response
+// bodies (adapter-vercel cannot set exposeErrBody), and this route serves
+// its partial snapshot with a 503. The s-maxage + stale-while-revalidate
+// headers on success responses provide the 24-hour edge cache instead.
+
+const TOP_REPOSITORY_COUNT = 5;
+
+const SUCCESS_HEADERS = {
+  'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+  'Access-Control-Allow-Origin': '*',
+};
+
+const FAILURE_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Retry-After': '300',
+};
+
+/** Renders the GitHub section, or an unavailable marker when it errored. */
+const renderGithubSection = (section: DashboardSection<GithubStats>): string[] => {
+  if (section.status === 'error') {
+    return ['## GitHub', '', '- GitHub activity (temporarily unavailable)', ''];
+  }
+
+  const { data } = section;
+  const topRepositories = data.commits.byRepository.slice(0, TOP_REPOSITORY_COUNT);
+
+  return [
+    '## GitHub',
+    '',
+    `- [${data.login}](${data.profileUrl}): ${data.followers} followers, ` +
+      `${data.publicRepositories} public repositories, ${data.totalStars} total stars.`,
+    `- Commits in the last year: ${data.commits.totalLastYear} ` +
+      `(${data.commits.privateContributionsLastYear} in private repositories).`,
+    `- Pull requests: ${data.pullRequests.openNow} open now, ` +
+      `${data.pullRequests.mergedLastYear} merged in the last year.`,
+    `- Issues: ${data.issues.openedLastYear} opened, ${data.issues.closedLastYear} closed ` +
+      'in the last year.',
+    `- Reviews: ${data.reviews.totalLastYear} in the last year.`,
+    ...(topRepositories.length > 0
+      ? [
+          '- Top repositories by commits:',
+          ...topRepositories.map(
+            (repository) =>
+              `  - [${repository.nameWithOwner}](${repository.url}): ${repository.commits} commits, ` +
+              `${repository.stargazerCount} stars`,
+          ),
+        ]
+      : []),
+    '',
+  ];
+};
+
+/** Renders the npm section, or an unavailable marker when it errored. */
+const renderNpmSection = (section: DashboardSection<NpmStats>): string[] => {
+  if (section.status === 'error') {
+    return ['## npm', '', '- npm downloads (temporarily unavailable)', ''];
+  }
+
+  const { data } = section;
+
+  return [
+    '## npm',
+    '',
+    `- ${data.packageCount} packages, ${data.totalDownloadsLastYear} downloads in the last year.`,
+    ...(data.topPackages.length > 0
+      ? [
+          '- Top packages by downloads:',
+          ...data.topPackages.map(
+            (pkg) => `  - [${pkg.name}](${pkg.url}): ${pkg.downloadsLastYear} downloads`,
+          ),
+        ]
+      : []),
+    '',
+  ];
+};
+
+/** Renders the course-updates section, or an unavailable marker when it errored. */
+const renderCoursesSection = (section: DashboardSection<CourseUpdate[]>): string[] => {
+  if (section.status === 'error') {
+    return ['## Course Updates', '', '- Course updates (temporarily unavailable)', ''];
+  }
+
+  if (section.data.length === 0) {
+    return ['## Course Updates', '', '- No recent course commits.', ''];
+  }
+
+  return [
+    '## Course Updates',
+    '',
+    ...section.data.map(
+      (course) => `- [${course.title}](${url}${course.path}): updated ${course.lastUpdatedAt}`,
+    ),
+    '',
+  ];
+};
+
+/** Renders the full markdown-style body for LLM consumers. */
+const buildBody = (data: DashboardData): string => {
+  const lines = [
+    '# Steve Kinney — Dashboard',
+    '',
+    '> A snapshot of GitHub activity, npm downloads, and course updates.',
+    '',
+    `Last computed: ${data.generatedAt}`,
+    '',
+    ...renderGithubSection(data.github),
+    ...renderNpmSection(data.npm),
+    ...renderCoursesSection(data.courses),
+    '## Links',
+    '',
+    `- [JSON API](${url}/api/dashboard)`,
+    `- [Atom Feed](${url}/dashboard/rss)`,
+  ];
+
+  return lines.join('\n');
+};
+
+/**
+ * Serves a markdown-style rendering of the dashboard snapshot for LLM
+ * consumers. Responds with 503 when any section failed to resolve, but the
+ * body is the same either way — errored sections render as
+ * "(temporarily unavailable)" bullets rather than being omitted.
+ */
+export const GET = async (): Promise<Response> => {
+  const data = await getDashboardData();
+  const complete = isDashboardComplete(data);
+  const body = buildBody(data);
+
+  return new Response(body, {
+    status: complete ? 200 : 503,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      ...(complete ? SUCCESS_HEADERS : FAILURE_HEADERS),
+    },
+  });
+};

--- a/applications/website/src/routes/dashboard/llms.txt/+server.ts
+++ b/applications/website/src/routes/dashboard/llms.txt/+server.ts
@@ -8,12 +8,20 @@ import type {
   GithubStats,
   NpmStats,
 } from '$lib/dashboard-types';
+import type { Config } from '@sveltejs/adapter-vercel';
+
 export const prerender = false;
 
 // Deliberately NOT Vercel ISR: prerender functions strip non-200 response
 // bodies (adapter-vercel cannot set exposeErrBody), and this route serves
 // its partial snapshot with a 503. The s-maxage + stale-while-revalidate
 // headers on success responses provide the 24-hour edge cache instead.
+//
+// maxDuration is raised because a cold compute fans out to GitHub GraphQL
+// (serialized to avoid its secondary rate limit — see github.ts), GitHub
+// REST, and the npm registry; measured live, that combination exceeded
+// Vercel's 15-second default and 504'd before ever producing a response.
+export const config: Config = { maxDuration: 60 };
 
 const TOP_REPOSITORY_COUNT = 5;
 

--- a/applications/website/src/routes/dashboard/llms.txt/+server.ts
+++ b/applications/website/src/routes/dashboard/llms.txt/+server.ts
@@ -53,8 +53,9 @@ const renderGithubSection = (section: DashboardSection<GithubStats>): string[] =
       `(${data.commits.privateContributionsLastYear} in private repositories).`,
     `- Pull requests: ${data.pullRequests.openNow} open now, ` +
       `${data.pullRequests.mergedLastYear} merged in the last year.`,
-    `- Issues: ${data.issues.openedLastYear} opened, ${data.issues.closedLastYear} closed ` +
-      'in the last year.',
+    `- Issues opened in the last year: ${data.issues.openedLastYear}.`,
+    `- My own issues closed in the last year: ${data.issues.closedLastYear} ` +
+      '(issues I authored — regardless of when opened — that were closed in the window).',
     `- Reviews: ${data.reviews.totalLastYear} in the last year.`,
     ...(topRepositories.length > 0
       ? [

--- a/applications/website/src/routes/dashboard/llms.txt/+server.ts
+++ b/applications/website/src/routes/dashboard/llms.txt/+server.ts
@@ -33,6 +33,7 @@ const SUCCESS_HEADERS = {
 const FAILURE_HEADERS = {
   'Cache-Control': 'no-store',
   'Retry-After': '300',
+  'Access-Control-Allow-Origin': '*',
 };
 
 /** Renders the GitHub section, or an unavailable marker when it errored. */

--- a/applications/website/src/routes/dashboard/llms.txt/llms.test.ts
+++ b/applications/website/src/routes/dashboard/llms.txt/llms.test.ts
@@ -120,6 +120,7 @@ describe('GET /dashboard/llms.txt', () => {
     expect(response.status).toBe(503);
     expect(response.headers.get('Cache-Control')).toBe('no-store');
     expect(response.headers.get('Retry-After')).toBe('300');
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
     expect(body).toContain('GitHub activity (temporarily unavailable)');
     expect(body).toContain('@stevekinney/utilities');
     expect(body).toContain('React and TypeScript');

--- a/applications/website/src/routes/dashboard/llms.txt/llms.test.ts
+++ b/applications/website/src/routes/dashboard/llms.txt/llms.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  CourseUpdate,
+  DashboardData,
+  DashboardSection,
+  GithubStats,
+  NpmStats,
+} from '$lib/dashboard-types';
+
+vi.mock('$lib/server/dashboard', () => ({
+  getDashboardData: vi.fn(),
+  isDashboardComplete: (data: DashboardData): boolean =>
+    data.github.status === 'ok' && data.npm.status === 'ok' && data.courses.status === 'ok',
+}));
+
+import { getDashboardData } from '$lib/server/dashboard';
+
+import { GET } from './+server';
+
+const mockGetDashboardData = vi.mocked(getDashboardData);
+
+const okGithub: GithubStats = {
+  login: 'stevekinney',
+  profileUrl: 'https://github.com/stevekinney',
+  followers: 100,
+  publicRepositories: 42,
+  totalStars: 500,
+  pullRequests: { openNow: 3, mergedLastYear: 40 },
+  commits: {
+    totalLastYear: 900,
+    privateContributionsLastYear: 200,
+    byRepository: [
+      {
+        nameWithOwner: 'stevekinney/website',
+        url: 'https://github.com/stevekinney/website',
+        stargazerCount: 12,
+        commits: 300,
+      },
+    ],
+  },
+  issues: { openedLastYear: 10, closedLastYear: 9 },
+  reviews: { totalLastYear: 20 },
+};
+
+const okNpm: NpmStats = {
+  packageCount: 5,
+  totalDownloadsLastYear: 10000,
+  topPackages: [
+    {
+      name: '@stevekinney/utilities',
+      version: '1.0.0',
+      url: 'https://www.npmjs.com/package/@stevekinney/utilities',
+      downloadsLastYear: 4000,
+    },
+  ],
+};
+
+const okCourses: CourseUpdate[] = [
+  {
+    slug: 'react-typescript',
+    title: 'React and TypeScript',
+    description: 'Learn React with TypeScript.',
+    path: '/courses/react-typescript',
+    lessonCount: 20,
+    lastUpdatedAt: '2026-06-01T00:00:00.000Z',
+    lastCommit: {
+      message: 'Fix typo in lesson three',
+      url: 'https://github.com/stevekinney/course/commit/abc123',
+      sha: 'abc123',
+    },
+  },
+];
+
+const okSection = <T>(data: T): DashboardSection<T> => ({ status: 'ok', data });
+const erroredSection = <T>(error: string): DashboardSection<T> => ({ status: 'error', error });
+
+const buildDashboardData = (overrides: Partial<DashboardData> = {}): DashboardData => ({
+  generatedAt: '2026-07-01T00:00:00.000Z',
+  window: { from: '2025-07-01T00:00:00.000Z', to: '2026-07-01T00:00:00.000Z' },
+  github: okSection(okGithub),
+  npm: okSection(okNpm),
+  courses: okSection(okCourses),
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockGetDashboardData.mockReset();
+});
+
+describe('GET /dashboard/llms.txt', () => {
+  it('returns 200 with success headers and every section rendered when all are healthy', async () => {
+    const data = buildDashboardData();
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/plain');
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+    );
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(body).toContain('Last computed: 2026-07-01T00:00:00.000Z');
+    expect(body).toContain('stevekinney/website');
+    expect(body).toContain('@stevekinney/utilities');
+    expect(body).toContain('React and TypeScript');
+    expect(body).toContain('https://stevekinney.com/api/dashboard');
+    expect(body).toContain('https://stevekinney.com/dashboard/rss');
+  });
+
+  it('renders unavailable markers for errored sections and still returns 503', async () => {
+    const data = buildDashboardData({ github: erroredSection('GitHub API rate limited') });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Retry-After')).toBe('300');
+    expect(body).toContain('GitHub activity (temporarily unavailable)');
+    expect(body).toContain('@stevekinney/utilities');
+    expect(body).toContain('React and TypeScript');
+  });
+
+  it('renders an unavailable marker for courses and npm independently', async () => {
+    const data = buildDashboardData({
+      npm: erroredSection('npm registry timed out'),
+      courses: erroredSection('git log failed'),
+    });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).toContain('npm downloads (temporarily unavailable)');
+    expect(body).toContain('Course updates (temporarily unavailable)');
+    expect(body).toContain('stevekinney/website');
+  });
+
+  it('renders a no-commits message when the courses section is ok but empty', async () => {
+    const data = buildDashboardData({ courses: okSection([]) });
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('No recent course commits.');
+  });
+});

--- a/applications/website/src/routes/dashboard/rss/+server.ts
+++ b/applications/website/src/routes/dashboard/rss/+server.ts
@@ -6,6 +6,7 @@ import prettier from 'prettier';
 
 import type { CourseUpdate } from '$lib/dashboard-types';
 import type { Element } from 'hast';
+import type { Config } from '@sveltejs/adapter-vercel';
 
 export const prerender = false;
 
@@ -13,6 +14,12 @@ export const prerender = false;
 // bodies (adapter-vercel cannot set exposeErrBody), and this route's 503
 // path carries an explanatory body. The s-maxage + stale-while-revalidate
 // headers on success responses provide the 24-hour edge cache instead.
+//
+// maxDuration is raised because a cold compute fans out to GitHub GraphQL
+// (serialized to avoid its secondary rate limit — see github.ts), GitHub
+// REST, and the npm registry; measured live, that combination exceeded
+// Vercel's 15-second default and 504'd before ever producing a response.
+export const config: Config = { maxDuration: 60 };
 
 const FEED_TITLE = 'Steve Kinney — Dashboard: Course Updates';
 

--- a/applications/website/src/routes/dashboard/rss/+server.ts
+++ b/applications/website/src/routes/dashboard/rss/+server.ts
@@ -1,0 +1,97 @@
+import { author, title as siteTitle, url } from '$lib/metadata';
+import { getDashboardData } from '$lib/server/dashboard';
+import { toHtml } from 'hast-util-to-html';
+import { h } from 'hastscript';
+import prettier from 'prettier';
+
+import type { CourseUpdate } from '$lib/dashboard-types';
+import type { Element } from 'hast';
+
+export const prerender = false;
+
+// Deliberately NOT Vercel ISR: prerender functions strip non-200 response
+// bodies (adapter-vercel cannot set exposeErrBody), and this route's 503
+// path carries an explanatory body. The s-maxage + stale-while-revalidate
+// headers on success responses provide the 24-hour edge cache instead.
+
+const FEED_TITLE = 'Steve Kinney — Dashboard: Course Updates';
+
+const FAILURE_HEADERS = {
+  'Content-Type': 'text/plain; charset=utf-8',
+  'Cache-Control': 'no-store',
+  'Retry-After': '300',
+};
+
+/** First non-empty line of a commit message, used as the entry summary. */
+const firstLine = (message: string): string => message.trim().split('\n')[0]?.trim() ?? '';
+
+/** Builds a single Atom entry for a course's latest commit. */
+const buildEntry = (course: CourseUpdate): Element => {
+  const commit = course.lastCommit;
+  const link = `${url}${course.path}`;
+  const published = new Date(course.lastUpdatedAt).toISOString();
+  const summary = (commit && firstLine(commit.message)) || course.description;
+
+  return h('entry', [
+    h('title', `${course.title} updated`),
+    h('summary', summary),
+    h('link', { type: 'text/html', href: link }),
+    h('id', `${link}#commit-${commit?.sha}`),
+    h('published', published),
+    h('updated', published),
+    h('author', [h('name', author), h('uri', url)]),
+  ]);
+};
+
+/**
+ * Serves an Atom feed of the most recent commit to each course.
+ *
+ * Responds with a plain-text 503 when the courses section failed to
+ * resolve; GitHub and npm section status have no bearing on this feed.
+ */
+export const GET = async (): Promise<Response> => {
+  const data = await getDashboardData();
+
+  if (data.courses.status === 'error') {
+    return new Response('Course updates are temporarily unavailable.', {
+      status: 503,
+      headers: FAILURE_HEADERS,
+    });
+  }
+
+  const courses = [...data.courses.data]
+    .filter((course) => course.lastCommit !== null)
+    .sort((a, b) => new Date(b.lastUpdatedAt).getTime() - new Date(a.lastUpdatedAt).getTime());
+
+  const updated = new Date(courses[0]?.lastUpdatedAt ?? data.generatedAt);
+
+  const feed = h('feed', { xmlns: 'http://www.w3.org/2005/Atom' }, [
+    h('title', FEED_TITLE),
+    h('subtitle', 'Recent commits across the courses in this repository.'),
+    h('author', [h('name', author)]),
+    h('id', `${url}/dashboard/rss`),
+    h('link', { type: 'text/html', href: `${url}/dashboard` }),
+    h('updated', updated.toISOString()),
+    h('rights', `Copyright © ${new Date().getFullYear()}, ${siteTitle}`),
+    ...courses.map(buildEntry),
+  ]);
+
+  const xml = await prettier.format(`<?xml version="1.0" encoding="utf-8"?>\n${toHtml(feed)}`, {
+    parser: 'html',
+    printWidth: 100,
+    tabWidth: 2,
+    htmlWhitespaceSensitivity: 'ignore',
+  });
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/atom+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=86400',
+      'Access-Control-Allow-Origin': '*',
+      'Last-Modified': updated.toUTCString(),
+      'X-Robots-Tag': 'all',
+      'Content-Length': Buffer.byteLength(xml).toString(),
+      ETag: `W/"${updated.getTime()}"`,
+    },
+  });
+};

--- a/applications/website/src/routes/dashboard/rss/rss.test.ts
+++ b/applications/website/src/routes/dashboard/rss/rss.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CourseUpdate, DashboardData, DashboardSection } from '$lib/dashboard-types';
+
+vi.mock('$lib/server/dashboard', () => ({
+  getDashboardData: vi.fn(),
+  isDashboardComplete: (data: DashboardData): boolean =>
+    data.github.status === 'ok' && data.npm.status === 'ok' && data.courses.status === 'ok',
+}));
+
+import { getDashboardData } from '$lib/server/dashboard';
+
+import { GET } from './+server';
+
+const mockGetDashboardData = vi.mocked(getDashboardData);
+
+const okSection = <T>(data: T): DashboardSection<T> => ({ status: 'ok', data });
+const erroredSection = <T>(error: string): DashboardSection<T> => ({ status: 'error', error });
+
+const buildCourse = (overrides: Partial<CourseUpdate> = {}): CourseUpdate => ({
+  slug: 'testing',
+  title: 'Introduction to Testing',
+  description: 'Learn how to test your code.',
+  path: '/courses/testing',
+  lessonCount: 10,
+  lastUpdatedAt: '2026-01-01T00:00:00.000Z',
+  lastCommit: {
+    message: 'Update lesson three\n\nLonger explanation here.',
+    url: 'https://github.com/stevekinney/courses/commit/abc123',
+    sha: 'abc123',
+  },
+  ...overrides,
+});
+
+const buildDashboardData = (courses: DashboardSection<CourseUpdate[]>): DashboardData => ({
+  generatedAt: '2026-07-01T00:00:00.000Z',
+  window: { from: '2025-07-01T00:00:00.000Z', to: '2026-07-01T00:00:00.000Z' },
+  github: okSection({
+    login: 'stevekinney',
+    profileUrl: 'https://github.com/stevekinney',
+    followers: 1,
+    publicRepositories: 1,
+    totalStars: 1,
+    pullRequests: { openNow: 0, mergedLastYear: 0 },
+    commits: { totalLastYear: 0, privateContributionsLastYear: 0, byRepository: [] },
+    issues: { openedLastYear: 0, closedLastYear: 0 },
+    reviews: { totalLastYear: 0 },
+  }),
+  npm: okSection({ packageCount: 0, totalDownloadsLastYear: 0, topPackages: [] }),
+  courses,
+});
+
+/** Pulls the feed-level `<updated>` value, i.e. the one before any entry. */
+const feedLevelUpdated = (xml: string): string | undefined => {
+  const beforeFirstEntry = xml.split('<entry>')[0];
+  return beforeFirstEntry.match(/<updated>([^<]+)<\/updated>/)?.[1];
+};
+
+beforeEach(() => {
+  mockGetDashboardData.mockReset();
+});
+
+describe('GET /dashboard/rss', () => {
+  it('renders one entry per course with a commit, sorted by lastUpdatedAt descending', async () => {
+    const older = buildCourse({
+      slug: 'testing',
+      title: 'Introduction to Testing',
+      path: '/courses/testing',
+      lastUpdatedAt: '2026-01-01T00:00:00.000Z',
+      lastCommit: {
+        message: 'Fix typo',
+        url: 'https://github.com/stevekinney/courses/commit/older',
+        sha: 'older-sha',
+      },
+    });
+    const newer = buildCourse({
+      slug: 'react-typescript',
+      title: 'React and TypeScript',
+      path: '/courses/react-typescript',
+      lastUpdatedAt: '2026-06-01T00:00:00.000Z',
+      lastCommit: {
+        message: 'Add new lesson\n\nWith details.',
+        url: 'https://github.com/stevekinney/courses/commit/newer',
+        sha: 'newer-sha',
+      },
+    });
+    const withoutCommit = buildCourse({
+      slug: 'no-commit-yet',
+      title: 'Untouched Course',
+      path: '/courses/no-commit-yet',
+      lastCommit: null,
+    });
+
+    mockGetDashboardData.mockResolvedValue(
+      buildDashboardData(okSection([older, newer, withoutCommit])),
+    );
+
+    const response = await GET();
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/atom+xml');
+    expect(xml).toContain('React and TypeScript updated');
+    expect(xml).toContain('Introduction to Testing updated');
+    expect(xml).not.toContain('Untouched Course');
+    expect(xml.indexOf('React and TypeScript updated')).toBeLessThan(
+      xml.indexOf('Introduction to Testing updated'),
+    );
+    expect(xml).toContain('https://stevekinney.com/courses/react-typescript#commit-newer-sha');
+    expect(xml).toContain('https://stevekinney.com/courses/testing#commit-older-sha');
+    expect(xml).toContain('Add new lesson');
+    expect(feedLevelUpdated(xml)).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('falls back to the commit description and generatedAt when appropriate', async () => {
+    const course = buildCourse({
+      lastUpdatedAt: '2026-03-01T00:00:00.000Z',
+      lastCommit: { message: '', url: 'https://github.com/stevekinney/courses/commit/x', sha: 'x' },
+    });
+
+    mockGetDashboardData.mockResolvedValue(buildDashboardData(okSection([course])));
+
+    const response = await GET();
+    const xml = await response.text();
+
+    expect(xml).toContain(course.description);
+  });
+
+  it('does not crash and falls back to generatedAt when no course has a commit yet', async () => {
+    const course = buildCourse({ lastCommit: null });
+    const data = buildDashboardData(okSection([course]));
+    mockGetDashboardData.mockResolvedValue(data);
+
+    const response = await GET();
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml).not.toContain('<entry>');
+    expect(feedLevelUpdated(xml)).toBe(data.generatedAt);
+  });
+
+  it('returns a plain-text 503 when the courses section errored', async () => {
+    mockGetDashboardData.mockResolvedValue(buildDashboardData(erroredSection('git log failed')));
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Content-Type')).toContain('text/plain');
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Retry-After')).toBe('300');
+    expect(body).not.toContain('<feed');
+  });
+});

--- a/applications/website/src/routes/llms.txt/+server.ts
+++ b/applications/website/src/routes/llms.txt/+server.ts
@@ -38,6 +38,7 @@ export function GET() {
     '',
     '## Links',
     '',
+    `- [Dashboard](${url}/dashboard): A live snapshot of GitHub activity, npm downloads, and course updates, with a JSON API at ${url}/api/dashboard and an Atom feed at ${url}/dashboard/rss ([llms.txt](${url}/dashboard/llms.txt))`,
     `- [RSS Feed](${url}/writing/rss)`,
     `- [Sitemap](${url}/sitemap.xml)`,
     `- [Full Content](${url}/llms-full.txt)`,

--- a/applications/website/tests/dashboard.spec.ts
+++ b/applications/website/tests/dashboard.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from '@playwright/test';
+
+// The preview environment has no GitHub token configured, so these specs
+// never assert on live data values — only on structure, headings, and the
+// page settling out of its loading state.
+
+test('/dashboard responds with 200', async ({ page }) => {
+  const response = await page.goto('/dashboard');
+
+  expect(response?.status()).toBe(200);
+});
+
+test('document title mentions Dashboard', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page).toHaveTitle(/Dashboard/);
+});
+
+test('main navigation includes a link to the dashboard', async ({ page }) => {
+  await page.goto('/');
+
+  const nav = page.getByRole('navigation', { name: 'Main Navigation' });
+
+  await expect(nav.getByRole('link', { name: /dashboard/i })).toBeVisible();
+});
+
+test('all four dashboard section headings are visible', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'GitHub — The Last Year' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'Commits by Repository' }),
+  ).toBeVisible();
+  await expect(page.getByRole('heading', { level: 2, name: 'npm' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'Recently Updated Courses' }),
+  ).toBeVisible();
+});
+
+// A DashboardData fixture matching the page's response schema: one healthy
+// section and one errored section, so both render paths are exercised. The
+// live endpoint's first compute can take tens of seconds when GitHub is
+// throttling, so this spec stubs the API — the client's skeleton-to-settled
+// behavior is what's under test, and the unmocked spec below still covers the
+// real endpoint.
+const dashboardFixture = {
+  generatedAt: '2026-07-20T00:00:00.000Z',
+  window: { from: '2025-07-20T00:00:00.000Z', to: '2026-07-20T00:00:00.000Z' },
+  github: { status: 'error', error: 'stubbed outage' },
+  npm: {
+    status: 'ok',
+    data: {
+      packageCount: 1,
+      totalDownloadsLastYear: 1234,
+      topPackages: [
+        {
+          name: 'phone-formatter',
+          description: 'Parse and format telephone numbers.',
+          version: '0.0.2',
+          url: 'https://www.npmjs.com/package/phone-formatter',
+          downloadsLastYear: 1234,
+        },
+      ],
+    },
+  },
+  courses: {
+    status: 'ok',
+    data: [
+      {
+        slug: 'testing',
+        title: 'Introduction to Testing',
+        description: 'A course about testing.',
+        path: '/courses/testing',
+        lessonCount: 80,
+        lastUpdatedAt: '2026-06-01T00:00:00.000Z',
+        lastCommit: {
+          message: 'Update testing course',
+          url: 'https://github.com/stevekinney/stevekinney.net/commit/abc123',
+          sha: 'abc123',
+        },
+      },
+    ],
+  },
+};
+
+test('dashboard sections settle into data or a quiet unavailable notice, never a permanent skeleton', async ({
+  page,
+}) => {
+  await page.route('**/api/dashboard', (route) =>
+    route.fulfill({ status: 503, contentType: 'application/json', json: dashboardFixture }),
+  );
+
+  await page.goto('/dashboard');
+
+  // Skeletons mark their container `aria-busy="true"` while loading; once the
+  // client-side fetch settles (success or failure), none should remain.
+  await expect(page.locator('[aria-busy="true"]')).toHaveCount(0);
+
+  // The errored section shows its quiet notice while healthy sections render
+  // their data — a 503 body must not blank the whole page.
+  const githubSection = page.locator('section[aria-labelledby="dashboard-github-heading"]');
+  await expect(githubSection).toContainText(/temporarily unavailable/);
+
+  const npmSection = page.locator('section[aria-labelledby="dashboard-npm-heading"]');
+  await expect(npmSection).toContainText('phone-formatter');
+});
+
+test('a failed load shows the retry button, and retrying recovers into data', async ({ page }) => {
+  let failNextRequest = true;
+
+  await page.route('**/api/dashboard', (route) => {
+    if (failNextRequest) {
+      failNextRequest = false;
+      return route.abort();
+    }
+
+    return route.fulfill({ status: 200, contentType: 'application/json', json: dashboardFixture });
+  });
+
+  await page.goto('/dashboard');
+
+  const retryButton = page.getByRole('button', { name: 'Try again' });
+  await expect(retryButton).toBeVisible();
+
+  await retryButton.click();
+
+  const npmSection = page.locator('section[aria-labelledby="dashboard-npm-heading"]');
+  await expect(npmSection).toContainText('phone-formatter');
+});
+
+test('/api/dashboard returns parseable JSON with a generatedAt field', async ({ page }) => {
+  const response = await page.request.get('/api/dashboard');
+
+  expect([200, 503]).toContain(response.status());
+
+  const body = await response.json();
+
+  expect(typeof body.generatedAt).toBe('string');
+});
+
+test('RSS alternate link is present in the document head', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const rssLink = page.locator(
+    'link[rel="alternate"][type="application/atom+xml"][href="/dashboard/rss"]',
+  );
+
+  await expect(rssLink).toHaveCount(1);
+});

--- a/packages/components/navigation.svelte
+++ b/packages/components/navigation.svelte
@@ -11,6 +11,7 @@
   <Link href="/writing">Writing</Link>
   <Link href="/courses">Courses</Link>
   <Link href="/projects">Projects</Link>
+  <Link href="/dashboard">Dashboard</Link>
   <Link
     href="https://cinder.website/"
     target="_blank"


### PR DESCRIPTION
## Summary

- Adds a `/dashboard` page showing pull requests merged/open, commits, and issues opened/closed over the last year (GitHub), download counts across every maintained npm package, and a "recently updated courses" section driven by actual commit history in this repo.
- Data is computed at most once every 24 hours: an in-process memo dedupes concurrent requests onto a single computation, and edge caching (`Cache-Control: s-maxage=86400, stale-while-revalidate`) keeps it fresh across instances without hammering GitHub/npm. A failed section retries after 5 minutes rather than staying stale for a day.
- The page itself is a prerendered static shell — course data is server-rendered at build time, and the live stats hydrate client-side from `/api/dashboard` with skeleton loading states, so nobody waits on an API call to see the page.
- Ships machine-readable surfaces: `/api/dashboard` (+ `/github`, `/npm`, `/courses` slices), an Atom feed of course updates (`/dashboard/rss`), and an `llms.txt` mirror — plus the usual top-nav, sitemap, and SEO registrations.

## Notes for reviewers

- GitHub's GraphQL API rejects combined year-long `contributionsCollection` queries for this account (too much activity to fit GitHub's per-query resource limits), so yearly totals are fetched one field per query and per-repository commits are stitched from 12 monthly windows. All GraphQL requests are serialized through a queue after live testing showed concurrent bursts trip GitHub's secondary rate limit.
- Vercel's ISR strips response bodies on non-200 status codes and `adapter-vercel` has no way to opt out of that — since this feature's 503 responses deliberately carry a partial JSON body (healthy sections + an error marker), the dashboard routes skip ISR and rely on `s-maxage`/`stale-while-revalidate` headers instead.

## Test plan

- [x] `bun run continuous-integration:validate` (content validation, lint, svelte-check, unit tests) — passing
- [x] Full Vitest suite for the new data fetchers, cache, and endpoints (47 new tests)
- [x] Playwright spec for `/dashboard` (page load, section headings, settle-out-of-skeleton, retry-after-failure, RSS link, API JSON shape) — passing against a production build
- [x] Manual verification in the browser: live data rendering, dark mode, mobile viewport, RSS/llms.txt/sitemap/OG-image output
- [x] Set `GITHUB_DASHBOARD_TOKEN` in Vercel's environment before merge — without it, the GitHub section reports "temporarily unavailable" (a fine-grained PAT with public read access is sufficient)