### PR TITLE
Improve dashboard and project links

### DIFF
--- a/applications/website/src/lib/remark-fix-urls.test.ts
+++ b/applications/website/src/lib/remark-fix-urls.test.ts
@@ -175,6 +175,50 @@ describe('fixMarkdownUrls', () => {
     expect(url).toBe('/writing/next');
   });
 
+  it('adds affiliate parameters to supported course platforms', () => {
+    const urls = apply(
+      '[Frontend Masters](https://frontendmasters.com/courses/typescript-v4/) [Master.dev](https://master.dev/teachers/steve-kinney/)',
+    );
+
+    expect(urls).toEqual([
+      'https://frontendmasters.com/courses/typescript-v4/?utm_source=kinney&utm_medium=social&code=kinney',
+      'https://master.dev/teachers/steve-kinney/?utm_source=kinney&utm_medium=social&code=kinney',
+    ]);
+  });
+
+  it('preserves existing query strings and hashes when adding affiliate parameters', () => {
+    const [url] = apply('[Master.dev](https://master.dev/courses/typescript?preview=true#lessons)');
+
+    expect(url).toBe(
+      'https://master.dev/courses/typescript?preview=true&utm_source=kinney&utm_medium=social&code=kinney#lessons',
+    );
+  });
+
+  it('does not duplicate existing affiliate parameters', () => {
+    const [url] = apply(
+      '[Master.dev](https://master.dev/?utm_source=kinney&utm_medium=social&code=kinney)',
+    );
+
+    expect(url).toBe('https://master.dev/?utm_source=kinney&utm_medium=social&code=kinney');
+  });
+
+  it('adds affiliate parameters to supported reference-style definitions', () => {
+    const [url] = applyDefinitions('[Master.dev][master]\n\n[master]: https://master.dev/');
+
+    expect(url).toBe('https://master.dev/?utm_source=kinney&utm_medium=social&code=kinney');
+  });
+
+  it('does not add affiliate parameters to lookalike domains', () => {
+    const urls = apply(
+      '[Frontend Masters](https://frontendmasters.com.example.com/) [Master.dev](https://master.dev.example.com/)',
+    );
+
+    expect(urls).toEqual([
+      'https://frontendmasters.com.example.com/',
+      'https://master.dev.example.com/',
+    ]);
+  });
+
   it('normalizes content paths with leading or trailing slashes', () => {
     const [url] = apply('[Next](./next.md)', '/repository/writing/post.md', '/writing/');
     expect(url).toBe('/writing/next');

--- a/applications/website/src/lib/server/content.test.ts
+++ b/applications/website/src/lib/server/content.test.ts
@@ -51,6 +51,7 @@ describe('generated content lookups', () => {
       projectSlug: 'weft',
       sourcePath: 'projects/weft.md',
       githubUrl: 'https://github.com/stevekinney/weft',
+      npmPackages: ['@lostgradient/weft'],
     });
   });
 

--- a/applications/website/src/routes/+layout.svelte
+++ b/applications/website/src/routes/+layout.svelte
@@ -83,13 +83,13 @@
   aria-label={ariaLabel}
   aria-labelledby={ariaLabelledby}
   class={merge(
-    'mx-auto my-6 grid max-w-7xl grid-cols-1 items-center gap-6 px-4 sm:my-10 sm:grid-cols-2 md:px-8 lg:grid-cols-3',
+    'mx-auto my-6 grid max-w-7xl grid-cols-1 items-center gap-6 px-4 sm:my-10 sm:grid-cols-2 md:px-8 xl:grid-cols-3',
     className,
   )}
 >
   <!-- Site header -->
   <header>
-    <h1 class="whitespace-nowrap lg:order-1">
+    <h1 class="whitespace-nowrap xl:order-1">
       <a
         href="/"
         class="font-header decoration-primary-700 dark:decoration-primary-400 text-6xl text-black hover:underline dark:text-white"
@@ -102,7 +102,7 @@
 
   <!-- Social links -->
   <div
-    class="order-1 flex items-center justify-between gap-4 sm:order-none sm:justify-end lg:order-3"
+    class="order-1 flex items-center justify-between gap-4 sm:order-none sm:justify-end xl:order-3"
     data-social-links
     role="complementary"
     aria-label="Social media links"
@@ -113,15 +113,15 @@
   </div>
 
   <!-- Navigation -->
-  <Navigation class="sm:col-start-2 sm:justify-end lg:order-2 lg:justify-center" />
+  <Navigation class="sm:col-start-2 sm:justify-end xl:order-2 xl:justify-center" />
 
   <!-- Main content container -->
-  <main id="main-content" class="my-6 sm:col-span-full lg:order-3" data-content-container>
+  <main id="main-content" class="my-6 sm:col-span-full xl:order-3" data-content-container>
     {@render children?.()}
   </main>
 
   <!-- Email subscription -->
-  <footer class="sm:col-span-full lg:order-4">
+  <footer class="sm:col-span-full xl:order-4">
     <form
       action="https://buttondown.com/api/emails/embed-subscribe/stevekinney"
       method="post"

--- a/applications/website/src/routes/+page.svelte
+++ b/applications/website/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Rss } from '@lucide/svelte';
+  import { addAffiliateParameters } from '@stevekinney/utilities/affiliate-url';
   import Card from '$lib/components/card';
   import PostLink from '$lib/components/post-link.svelte';
   import SEO from '$lib/components/seo.svelte';
@@ -89,12 +90,15 @@
 
       <p>
         I am lucky enough to teach a bunch of courses with my friends at <a
-          href="https://master.dev/"
+          href={addAffiliateParameters('https://master.dev/')}
           target="_blank">Master.dev</a
         >. We've been working together since 2016. Before I was a teacher, I was a customer back
         when I was learning the ropes. I can't recommend them highly enough. You can find the most
         up-to-date list
-        <a href="https://master.dev/teachers/steve-kinney/" target="_blank">here</a>.
+        <a
+          href={addAffiliateParameters('https://master.dev/teachers/steve-kinney/')}
+          target="_blank">here</a
+        >.
       </p>
     </div>
 
@@ -103,7 +107,7 @@
         <Card
           title={recording.title}
           description={recording.description}
-          url={recording.href}
+          url={addAffiliateParameters(recording.href)}
           imageSource={recording.imageSource}
           imageAlternativeText={recording.title}
           as="li"

--- a/applications/website/src/routes/courses/+page.svelte
+++ b/applications/website/src/routes/courses/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { addAffiliateParameters } from '@stevekinney/utilities/affiliate-url';
+
   import Card from '$lib/components/card';
   import SEO from '$lib/components/seo.svelte';
   import coursesData from '$lib/courses.toml';
@@ -43,12 +45,15 @@
 
       <p>
         I am lucky enough to teach a bunch of courses with my friends at <a
-          href="https://master.dev/"
+          href={addAffiliateParameters('https://master.dev/')}
           target="_blank">Master.dev</a
         >. We've been working together since 2016. Before I was a teacher, I was a customer back
         when I was learning the ropes. I can't recommend them highly enough. Below, I've listed out
         the courses that I've taught over the last few years. You can find the most up-to-date list
-        <a href="https://master.dev/teachers/steve-kinney/" target="_blank">here</a>.
+        <a
+          href={addAffiliateParameters('https://master.dev/teachers/steve-kinney/')}
+          target="_blank">here</a
+        >.
       </p>
     </div>
 
@@ -57,7 +62,7 @@
         <Card
           title={recording.title}
           description={recording.description}
-          url={recording.href}
+          url={addAffiliateParameters(recording.href)}
           imageSource={recording.imageSource}
           imageAlternativeText={recording.title}
           as="li"

--- a/applications/website/src/routes/dashboard/+page.svelte
+++ b/applications/website/src/routes/dashboard/+page.svelte
@@ -73,14 +73,6 @@
 </SEO>
 
 <div class="space-y-10">
-  <div class="prose dark:prose-invert max-w-none">
-    <p>
-      This page pulls back the curtain on what I've actually been building: a live snapshot of my
-      GitHub activity, npm downloads, and course updates from the past year, recomputed at most once
-      a day so it stays fresh without hammering anyone's rate limits.
-    </p>
-  </div>
-
   {#if pageState === 'failed'}
     <div
       class="rounded-md border border-slate-300 p-4 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-300"
@@ -107,7 +99,6 @@
   <footer
     class="space-y-2 border-t border-slate-200 pt-6 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400"
   >
-    <p>Recomputed at most once every 24 hours.</p>
     {#if dashboardData}
       <p>Last computed {formatDate(dashboardData.generatedAt)}.</p>
     {/if}

--- a/applications/website/src/routes/dashboard/dashboard-github-section.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-github-section.svelte
@@ -45,7 +45,6 @@
       <DashboardStatTile
         label="Own Issues Closed"
         value={formatMetric(stats.issues.closedLastYear)}
-        context="Issues I opened that are now closed"
       />
       <DashboardStatTile
         label="Pull Requests Reviewed"

--- a/applications/website/src/routes/dashboard/dashboard-stat-tile.svelte
+++ b/applications/website/src/routes/dashboard/dashboard-stat-tile.svelte
@@ -2,16 +2,12 @@
   type Props = {
     label: string;
     value: string;
-    context?: string;
   };
 
-  const { label, value, context }: Props = $props();
+  const { label, value }: Props = $props();
 </script>
 
 <div class="rounded-md bg-slate-100 p-4 dark:bg-slate-800">
   <p class="text-sm text-slate-500 dark:text-slate-400">{label}</p>
-  <p class="font-header text-4xl">{value}</p>
-  {#if context}
-    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">{context}</p>
-  {/if}
+  <p class="font-sans text-4xl">{value}</p>
 </div>

--- a/applications/website/src/routes/projects/+page.svelte
+++ b/applications/website/src/routes/projects/+page.svelte
@@ -42,6 +42,16 @@
           >
             GitHub
           </a>
+          {#each project.npmPackages ?? [] as npmPackage (npmPackage)}
+            <a
+              class="font-semibold underline decoration-2 underline-offset-4"
+              href={`https://www.npmjs.com/package/${npmPackage}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              npm: {npmPackage}
+            </a>
+          {/each}
           {#if project.productionUrl}
             <a
               class="font-semibold underline decoration-2 underline-offset-4"

--- a/applications/website/src/routes/projects/[project]/+page.server.ts
+++ b/applications/website/src/routes/projects/[project]/+page.server.ts
@@ -37,6 +37,7 @@ export const load: PageServerLoad = async ({ params }) => {
       name: route.name,
       description: route.description,
       githubUrl: route.githubUrl,
+      npmPackages: route.npmPackages,
       productionUrl: route.productionUrl,
       writingPath: route.writingPath,
       youtubeUrl: route.youtubeUrl,

--- a/applications/website/src/routes/projects/[project]/+page.svelte
+++ b/applications/website/src/routes/projects/[project]/+page.svelte
@@ -42,6 +42,16 @@
     >
       GitHub
     </a>
+    {#each data.project.npmPackages ?? [] as npmPackage (npmPackage)}
+      <a
+        class="font-semibold underline decoration-4 underline-offset-8"
+        href={`https://www.npmjs.com/package/${npmPackage}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        npm: {npmPackage}
+      </a>
+    {/each}
     {#if data.project.productionUrl}
       <a
         class="font-semibold underline decoration-4 underline-offset-8"

--- a/applications/website/tests/content-pages.spec.ts
+++ b/applications/website/tests/content-pages.spec.ts
@@ -71,6 +71,25 @@ test('project pages link package-backed projects to npm', async ({ page }) => {
   );
 });
 
+test('course recording links include affiliate parameters', async ({ page }) => {
+  await page.goto('/courses');
+
+  await expect(page.getByRole('link', { name: 'Master.dev' })).toHaveAttribute(
+    'href',
+    'https://master.dev/?utm_source=kinney&utm_medium=social&code=kinney',
+  );
+  await expect(page.getByRole('link', { name: 'here' })).toHaveAttribute(
+    'href',
+    'https://master.dev/teachers/steve-kinney/?utm_source=kinney&utm_medium=social&code=kinney',
+  );
+  await expect(
+    page.getByRole('link', { name: /Deploying Web Applications on AWS, v3/ }),
+  ).toHaveAttribute(
+    'href',
+    'https://master.dev/courses/aws-v3/?utm_source=kinney&utm_medium=social&code=kinney',
+  );
+});
+
 test.describe('exactly one content document wrapper per content page', () => {
   // Regression: a shared markdown layout briefly added its own
   // `data-content-document` wrapper on top of the per-route one, which caused

--- a/applications/website/tests/content-pages.spec.ts
+++ b/applications/website/tests/content-pages.spec.ts
@@ -47,6 +47,30 @@ test('writing post page has no accessibility violations', async ({ page }) => {
   await checkA11y(page);
 });
 
+test('project pages link package-backed projects to npm', async ({ page }) => {
+  await page.goto('/projects');
+
+  await expect(page.getByRole('link', { name: 'npm: armorer' })).toHaveAttribute(
+    'href',
+    'https://www.npmjs.com/package/armorer',
+  );
+  await expect(page.getByRole('link', { name: 'npm: prose-writer' })).toHaveAttribute(
+    'href',
+    'https://www.npmjs.com/package/prose-writer',
+  );
+
+  await page.goto('/projects/cinder');
+
+  await expect(page.getByRole('link', { name: 'npm: @lostgradient/cinder' })).toHaveAttribute(
+    'href',
+    'https://www.npmjs.com/package/@lostgradient/cinder',
+  );
+  await expect(page.getByRole('link', { name: 'npm: @lostgradient/chat' })).toHaveAttribute(
+    'href',
+    'https://www.npmjs.com/package/@lostgradient/chat',
+  );
+});
+
 test.describe('exactly one content document wrapper per content page', () => {
   // Regression: a shared markdown layout briefly added its own
   // `data-content-document` wrapper on top of the per-route one, which caused

--- a/applications/website/tests/dashboard.spec.ts
+++ b/applications/website/tests/dashboard.spec.ts
@@ -24,6 +24,32 @@ test('main navigation includes a link to the dashboard', async ({ page }) => {
   await expect(nav.getByRole('link', { name: /dashboard/i })).toBeVisible();
 });
 
+test('social links do not overlap the main navigation near the desktop breakpoint', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 800 });
+  await page.goto('/dashboard');
+
+  const newsletterBox = await page
+    .getByRole('navigation', { name: 'Main Navigation' })
+    .getByRole('link', { name: 'Newsletter' })
+    .boundingBox();
+  const githubBox = await page.getByRole('link', { name: 'Visit GitHub profile' }).boundingBox();
+
+  expect(newsletterBox).not.toBeNull();
+  expect(githubBox).not.toBeNull();
+
+  const overlaps =
+    newsletterBox !== null &&
+    githubBox !== null &&
+    newsletterBox.x < githubBox.x + githubBox.width &&
+    newsletterBox.x + newsletterBox.width > githubBox.x &&
+    newsletterBox.y < githubBox.y + githubBox.height &&
+    newsletterBox.y + newsletterBox.height > githubBox.y;
+
+  expect(overlaps).toBe(false);
+});
+
 test('all four dashboard section headings are visible', async ({ page }) => {
   await page.goto('/dashboard');
 
@@ -84,6 +110,53 @@ const dashboardFixture = {
     ],
   },
 };
+
+const dashboardWithGithubStats = {
+  ...dashboardFixture,
+  github: {
+    status: 'ok',
+    data: {
+      login: 'stevekinney',
+      profileUrl: 'https://github.com/stevekinney',
+      followers: 10,
+      publicRepositories: 20,
+      totalStars: 30,
+      pullRequests: { openNow: 1, mergedLastYear: 2 },
+      commits: {
+        totalLastYear: 3,
+        privateContributionsLastYear: 4,
+        byRepository: [
+          {
+            nameWithOwner: 'stevekinney/example',
+            url: 'https://github.com/stevekinney/example',
+            stargazerCount: 1,
+            commits: 5,
+          },
+        ],
+      },
+      issues: { openedLastYear: 6, closedLastYear: 7 },
+      reviews: { totalLastYear: 8 },
+    },
+  },
+};
+
+test('dashboard uses concise copy and the system font for stat values', async ({ page }) => {
+  await page.route('**/api/dashboard', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', json: dashboardWithGithubStats }),
+  );
+
+  await page.goto('/dashboard');
+
+  await expect(page.getByText(/This page pulls back the curtain/)).toHaveCount(0);
+  await expect(page.getByText('Issues I opened that are now closed')).toHaveCount(0);
+  await expect(page.getByText('Recomputed at most once every 24 hours.')).toHaveCount(0);
+
+  const commitsTile = page.getByText('Commits', { exact: true }).locator('..');
+  const statValue = commitsTile.locator('p').nth(1);
+  const fontFamily = await statValue.evaluate((element) => getComputedStyle(element).fontFamily);
+
+  expect(fontFamily).toMatch(/^system-ui/);
+});
 
 test('dashboard sections settle into data or a quiet unavailable notice, never a permanent skeleton', async ({
   page,

--- a/packages/markdown/src/remark-fix-urls.ts
+++ b/packages/markdown/src/remark-fix-urls.ts
@@ -4,6 +4,8 @@ import type { Transformer } from 'unified';
 import type { Root, Link, Definition } from 'mdast';
 import type { VFile } from 'vfile';
 
+import { addAffiliateParameters } from '@stevekinney/utilities/affiliate-url';
+
 /**
  * Constants for URL processing
  */
@@ -16,9 +18,6 @@ const URL_PATTERNS = {
 const MARKDOWN_EXTENSIONS = ['.mdx', '.markdown', '.md'];
 
 const DEFAULT_CONTENT_PATHS = ['content'];
-
-const AFFILIATE_ORIGINS = ['https://frontendmasters.com', 'https://master.dev'];
-const AFFILIATE_PARAMETERS = 'utm_source=kinney&utm_medium=social&code=kinney';
 
 type VFileWithFilename = VFile & { filename?: string };
 
@@ -155,21 +154,7 @@ const getBaseUrl = (fileData: FileData, contentPaths: string[]): string | null =
  * Appends affiliate tracking parameters to supported course platform URLs.
  */
 const appendAffiliateParameters = (node: Link | Definition): void => {
-  const { url } = node;
-  const hasSupportedOrigin = AFFILIATE_ORIGINS.some(
-    (origin) =>
-      url === origin ||
-      url.startsWith(`${origin}/`) ||
-      url.startsWith(`${origin}?`) ||
-      url.startsWith(`${origin}#`),
-  );
-
-  if (!url || !hasSupportedOrigin) return;
-  if (url.includes(AFFILIATE_PARAMETERS)) return;
-
-  const { path, query, hash } = splitUrl(url);
-  const newQuery = query ? `${query}&${AFFILIATE_PARAMETERS}` : `?${AFFILIATE_PARAMETERS}`;
-  node.url = `${path}${newQuery}${hash}`;
+  node.url = addAffiliateParameters(node.url);
 };
 
 /**

--- a/packages/markdown/src/remark-fix-urls.ts
+++ b/packages/markdown/src/remark-fix-urls.ts
@@ -17,8 +17,8 @@ const MARKDOWN_EXTENSIONS = ['.mdx', '.markdown', '.md'];
 
 const DEFAULT_CONTENT_PATHS = ['content'];
 
-const FRONTEND_MASTERS_ORIGIN = 'https://frontendmasters.com';
-const FRONTEND_MASTERS_UTM = 'utm_source=kinney&utm_medium=social&code=kinney';
+const AFFILIATE_ORIGINS = ['https://frontendmasters.com', 'https://master.dev'];
+const AFFILIATE_PARAMETERS = 'utm_source=kinney&utm_medium=social&code=kinney';
 
 type VFileWithFilename = VFile & { filename?: string };
 
@@ -152,15 +152,23 @@ const getBaseUrl = (fileData: FileData, contentPaths: string[]): string | null =
 };
 
 /**
- * Appends UTM tracking parameters to Frontend Masters URLs.
+ * Appends affiliate tracking parameters to supported course platform URLs.
  */
-const appendFrontendMastersUtm = (node: Link | Definition): void => {
+const appendAffiliateParameters = (node: Link | Definition): void => {
   const { url } = node;
-  if (!url || !url.startsWith(FRONTEND_MASTERS_ORIGIN)) return;
-  if (url.includes(FRONTEND_MASTERS_UTM)) return;
+  const hasSupportedOrigin = AFFILIATE_ORIGINS.some(
+    (origin) =>
+      url === origin ||
+      url.startsWith(`${origin}/`) ||
+      url.startsWith(`${origin}?`) ||
+      url.startsWith(`${origin}#`),
+  );
+
+  if (!url || !hasSupportedOrigin) return;
+  if (url.includes(AFFILIATE_PARAMETERS)) return;
 
   const { path, query, hash } = splitUrl(url);
-  const newQuery = query ? `${query}&${FRONTEND_MASTERS_UTM}` : `?${FRONTEND_MASTERS_UTM}`;
+  const newQuery = query ? `${query}&${AFFILIATE_PARAMETERS}` : `?${AFFILIATE_PARAMETERS}`;
   node.url = `${path}${newQuery}${hash}`;
 };
 
@@ -181,8 +189,8 @@ export function fixMarkdownUrls(
       cwd: anyFile?.cwd ?? process.cwd(),
     };
 
-    visit(tree, 'link', (node) => appendFrontendMastersUtm(node));
-    visit(tree, 'definition', (node) => appendFrontendMastersUtm(node));
+    visit(tree, 'link', (node) => appendAffiliateParameters(node));
+    visit(tree, 'definition', (node) => appendAffiliateParameters(node));
 
     if (!fileData.filename) return;
 

--- a/packages/scripts/content-repository.test.ts
+++ b/packages/scripts/content-repository.test.ts
@@ -55,6 +55,11 @@ describe('collectContentRepository', () => {
       contentType: 'project',
       projectSlug: 'weft',
       sourcePath: 'projects/weft.md',
+      npmPackages: ['@lostgradient/weft'],
+    });
+
+    expect(repository.routes['/projects/agent-bureau']).toMatchObject({
+      npmPackages: ['armorer', 'conversationalist'],
     });
   });
 
@@ -65,6 +70,28 @@ describe('collectContentRepository', () => {
     expect(route.sourceHash).toMatch(/^[a-f0-9]{64}$/);
     expect(route.llmsPath).toBe('/writing/setup-python/llms.txt');
     expect(route.openGraphPath).toBe('/writing/setup-python/open-graph.jpg');
+  });
+
+  test('includes npm package metadata for every package-backed project', async () => {
+    const repository = await repositoryPromise;
+    const npmPackagesByProject = Object.fromEntries(
+      repository.projects
+        .filter((project) => project.npmPackages)
+        .map((project) => [project.slug, project.npmPackages]),
+    );
+
+    expect(npmPackagesByProject).toEqual({
+      'agent-bureau': ['armorer', 'conversationalist'],
+      cinder: ['@lostgradient/cinder', '@lostgradient/chat'],
+      'eslint-plugin-temporal': ['eslint-plugin-temporal'],
+      'github-webhook-schemas': ['github-webhook-schemas'],
+      octavian: ['octavian'],
+      'prose-writer': ['prose-writer'],
+      'temporal-explorer': ['temporal-explorer'],
+      'temporal-mcp': ['temporal-mcp'],
+      'vector-frankl': ['vector-frankl'],
+      weft: ['@lostgradient/weft'],
+    });
   });
 
   test('includes canonical and legacy prerender entries for long-form content routes', async () => {

--- a/packages/scripts/content-repository/builders.ts
+++ b/packages/scripts/content-repository/builders.ts
@@ -34,6 +34,7 @@ import type {
 } from './types.ts';
 import {
   optionalString,
+  optionalStringArray,
   requiredString,
   safeDateString,
   validateCourseContents,
@@ -196,6 +197,7 @@ export const buildProjectEntry = async (
   const { data, sourceHash, sourcePath } = source;
   const slug = path.basename(source.absolutePath, '.md');
   const githubUrl = requiredString(sourcePath, data.githubUrl, 'githubUrl', issues);
+  const npmPackages = optionalStringArray(sourcePath, data.npmPackages, 'npmPackages', issues);
   const productionUrl = optionalString(sourcePath, data.productionUrl, 'productionUrl', issues);
   const writingPath = optionalString(sourcePath, data.writingPath, 'writingPath', issues);
   const youtubeUrl = optionalString(sourcePath, data.youtubeUrl, 'youtubeUrl', issues);
@@ -208,6 +210,7 @@ export const buildProjectEntry = async (
     name: requiredString(sourcePath, data.name, 'name', issues),
     description: requiredString(sourcePath, data.description, 'description', issues),
     githubUrl,
+    ...(npmPackages ? { npmPackages } : {}),
     ...(productionUrl ? { productionUrl } : {}),
     ...(writingPath ? { writingPath } : {}),
     ...(youtubeUrl ? { youtubeUrl } : {}),
@@ -284,6 +287,7 @@ export const buildRoutes = (
       projectSlug: project.slug,
       name: project.name,
       githubUrl: project.githubUrl,
+      ...(project.npmPackages ? { npmPackages: project.npmPackages } : {}),
       ...(project.productionUrl ? { productionUrl: project.productionUrl } : {}),
       ...(project.writingPath ? { writingPath: project.writingPath } : {}),
       ...(project.youtubeUrl ? { youtubeUrl: project.youtubeUrl } : {}),

--- a/packages/scripts/content-repository/validation.test.ts
+++ b/packages/scripts/content-repository/validation.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import type { CourseContentsData } from '@stevekinney/utilities/content-types';
 
 import type { ContentValidationIssue } from './types.ts';
-import { validateCourseContents } from './validation.ts';
+import { optionalStringArray, validateCourseContents } from './validation.ts';
 
 const collect = (
   contents: CourseContentsData | undefined,
@@ -129,5 +129,35 @@ describe('validateCourseContents', () => {
       file: 'courses/example/index.toml',
       message: "index.toml references missing related lesson 'missing-related.md'.",
     });
+  });
+});
+
+describe('optionalStringArray', () => {
+  test('normalizes non-empty string arrays', () => {
+    const issues: ContentValidationIssue[] = [];
+
+    expect(
+      optionalStringArray(
+        'projects/example.md',
+        [' package-one ', '@scope/package-two'],
+        'npmPackages',
+        issues,
+      ),
+    ).toEqual(['package-one', '@scope/package-two']);
+    expect(issues).toEqual([]);
+  });
+
+  test('reports malformed package metadata', () => {
+    const issues: ContentValidationIssue[] = [];
+
+    expect(
+      optionalStringArray('projects/example.md', ['package-one', ''], 'npmPackages', issues),
+    ).toBeUndefined();
+    expect(issues).toEqual([
+      {
+        file: 'projects/example.md',
+        message: "Invalid 'npmPackages' frontmatter.",
+      },
+    ]);
   });
 });

--- a/packages/scripts/content-repository/validation.test.ts
+++ b/packages/scripts/content-repository/validation.test.ts
@@ -133,6 +133,13 @@ describe('validateCourseContents', () => {
 });
 
 describe('optionalStringArray', () => {
+  test('treats an empty array as unset', () => {
+    const issues: ContentValidationIssue[] = [];
+
+    expect(optionalStringArray('projects/example.md', [], 'npmPackages', issues)).toBeUndefined();
+    expect(issues).toEqual([]);
+  });
+
   test('normalizes non-empty string arrays', () => {
     const issues: ContentValidationIssue[] = [];
 

--- a/packages/scripts/content-repository/validation.ts
+++ b/packages/scripts/content-repository/validation.ts
@@ -98,9 +98,12 @@ export const optionalStringArray = (
     return undefined;
   }
 
+  if (Array.isArray(value) && value.length === 0) {
+    return undefined;
+  }
+
   if (
     Array.isArray(value) &&
-    value.length > 0 &&
     value.every((item) => typeof item === 'string' && item.trim().length > 0)
   ) {
     return value.map((item) => item.trim());

--- a/packages/scripts/content-repository/validation.ts
+++ b/packages/scripts/content-repository/validation.ts
@@ -88,6 +88,32 @@ export const optionalString = (
   return undefined;
 };
 
+export const optionalStringArray = (
+  file: string,
+  value: unknown,
+  field: 'npmPackages',
+  issues: ContentValidationIssue[],
+): string[] | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => typeof item === 'string' && item.trim().length > 0)
+  ) {
+    return value.map((item) => item.trim());
+  }
+
+  issues.push({
+    file,
+    message: `Invalid '${field}' frontmatter.`,
+  });
+
+  return undefined;
+};
+
 const isUrl = (value: string): boolean => {
   try {
     const url = new URL(value);

--- a/packages/utilities/affiliate-url.ts
+++ b/packages/utilities/affiliate-url.ts
@@ -1,0 +1,25 @@
+const AFFILIATE_ORIGINS = new Set(['https://frontendmasters.com', 'https://master.dev']);
+
+const AFFILIATE_PARAMETERS = {
+  utm_source: 'kinney',
+  utm_medium: 'social',
+  code: 'kinney',
+} as const;
+
+export const addAffiliateParameters = (value: string): string => {
+  let url: URL;
+
+  try {
+    url = new URL(value);
+  } catch {
+    return value;
+  }
+
+  if (!AFFILIATE_ORIGINS.has(url.origin)) return value;
+
+  for (const [name, parameterValue] of Object.entries(AFFILIATE_PARAMETERS)) {
+    if (!url.searchParams.has(name)) url.searchParams.set(name, parameterValue);
+  }
+
+  return url.toString();
+};

--- a/packages/utilities/content-types.ts
+++ b/packages/utilities/content-types.ts
@@ -65,6 +65,7 @@ export type ProjectIndexEntry = {
   name: string;
   description: string;
   githubUrl: string;
+  npmPackages?: string[];
   productionUrl?: string;
   writingPath?: string;
   youtubeUrl?: string;
@@ -118,6 +119,7 @@ export type ProjectContentRoute = Omit<ContentRouteBase, 'date' | 'modified'> & 
   projectSlug: string;
   name: string;
   githubUrl: string;
+  npmPackages?: string[];
   productionUrl?: string;
   writingPath?: string;
   youtubeUrl?: string;

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./affiliate-url": "./affiliate-url.ts",
     "./content-types": "./content-types.ts",
     "./frontmatter": "./frontmatter.ts",
     "./image-discovery": "./image-discovery.ts",

--- a/projects/agent-bureau.md
+++ b/projects/agent-bureau.md
@@ -1,6 +1,9 @@
 ---
 name: Agent Bureau
 githubUrl: https://github.com/stevekinney/agent-bureau
+npmPackages:
+  - armorer
+  - conversationalist
 writingPath: /writing/ai-gateway-durable-workflows
 description: 'A playground for durable agent infrastructure: queues, schedules, memory, gateways, and all the glue code that stops being glue once it matters.'
 ---

--- a/projects/cinder.md
+++ b/projects/cinder.md
@@ -1,6 +1,9 @@
 ---
 name: Cinder
 githubUrl: https://github.com/stevekinney/cinder
+npmPackages:
+  - '@lostgradient/cinder'
+  - '@lostgradient/chat'
 productionUrl: https://cinder.website
 description: 'A Svelte design system for the components I keep rebuilding anyway, packaged as something I can use across real projects instead of copying snippets around.'
 ---

--- a/projects/eslint-plugin-temporal.md
+++ b/projects/eslint-plugin-temporal.md
@@ -1,6 +1,8 @@
 ---
 name: ESLint Plugin Temporal
 githubUrl: https://github.com/stevekinney/eslint-plugin-temporal
+npmPackages:
+  - eslint-plugin-temporal
 writingPath: /writing/cursor-rules-temporal-typescript
 description: 'ESLint rules for catching Temporal workflow mistakes before they become replay bugs, which is the polite time to learn about them.'
 ---

--- a/projects/github-webhook-schemas.md
+++ b/projects/github-webhook-schemas.md
@@ -1,6 +1,8 @@
 ---
 name: GitHub Webhook Schemas
 githubUrl: https://github.com/stevekinney/github-webhook-schemas
+npmPackages:
+  - github-webhook-schemas
 description: 'TypeScript schemas for GitHub webhook payloads, so webhook handlers can validate reality instead of trusting whatever just hit the endpoint.'
 ---
 

--- a/projects/octavian.md
+++ b/projects/octavian.md
@@ -1,6 +1,8 @@
 ---
 name: Octavian
 githubUrl: https://github.com/stevekinney/octavian
+npmPackages:
+  - octavian
 description: 'Utilities for reasoning about musical notes, frequencies, and intervals in JavaScript without making every project relearn the circle of fifths.'
 ---
 

--- a/projects/prose-writer.md
+++ b/projects/prose-writer.md
@@ -1,0 +1,11 @@
+---
+name: Prose Writer
+githubUrl: https://github.com/stevekinney/prose-writer
+npmPackages:
+  - prose-writer
+description: 'A chainable TypeScript library for building formatted text and Markdown without turning every prompt or document into a pile of string concatenation.'
+---
+
+[Prose Writer](https://github.com/stevekinney/prose-writer) is a chainable TypeScript library for building formatted text and Markdown. It is useful for prompts, generated documents, and anywhere else that a growing collection of string fragments starts looking suspiciously like a formatting system with no rules.
+
+The API keeps that structure explicit: add prose, headings, lists, and other blocks in order, then render the result as a string. The goal is not to invent another document format. It is to make the format you already need easier to assemble, inspect, and change.

--- a/projects/temporal-explorer.md
+++ b/projects/temporal-explorer.md
@@ -1,6 +1,8 @@
 ---
 name: Temporal Explorer
 githubUrl: https://github.com/stevekinney/temporal-explorer
+npmPackages:
+  - temporal-explorer
 writingPath: /writing/build-temporal-workflow
 description: 'An experimental interface for poking at Temporal workflows, histories, and runtime state without turning every debugging session into a scavenger hunt.'
 ---

--- a/projects/temporal-mcp.md
+++ b/projects/temporal-mcp.md
@@ -1,6 +1,8 @@
 ---
 name: Temporal MCP
 githubUrl: https://github.com/stevekinney/temporal-mcp
+npmPackages:
+  - temporal-mcp
 writingPath: /writing/temporal-developer-skill
 description: 'A Model Context Protocol server for working with Temporal from agent tools, because workflow state is easier to inspect when the agent can ask directly.'
 ---

--- a/projects/vector-frankl.md
+++ b/projects/vector-frankl.md
@@ -1,6 +1,8 @@
 ---
 name: Vector Frankl
 githubUrl: https://github.com/stevekinney/vector-frankl
+npmPackages:
+  - vector-frankl
 writingPath: /writing/using-a-vector-database
 description: "A semantic search and vector database experiment, because sometimes the question is not 'what matched?' but 'what was this kind of like?'"
 ---

--- a/projects/weft.md
+++ b/projects/weft.md
@@ -1,6 +1,8 @@
 ---
 name: Weft
 githubUrl: https://github.com/stevekinney/weft
+npmPackages:
+  - '@lostgradient/weft'
 description: 'Durable execution primitives for TypeScript applications that need workflows, retries, timers, and real state without pretending distributed systems are easy.'
 ---
 


### PR DESCRIPTION
## Summary

- support affiliate parameters for `master.dev` links alongside Frontend Masters
- add npm package metadata and links to package-backed projects
- prevent social links from overlapping the main navigation at intermediate widths
- simplify dashboard copy and use the system font for statistic values

## Why

Project pages were missing package destinations, `master.dev` links did not receive affiliate attribution, and the dashboard/header presentation needed responsive and copy cleanup.

## Validation

- `bun run continuous-integration:validate`
- `bun run build`
- focused Playwright dashboard regression tests
- pre-commit repository guards, formatting, and lint checks