### PR TITLE
fix(a11y): make scrollable code blocks reachable by keyboard

### DIFF
--- a/applications/website/svelte.config.ts
+++ b/applications/website/svelte.config.ts
@@ -90,7 +90,7 @@ const mdsvexOptions: MdsvexOptions = {
       // The client-side renderer reads via textContent, which decodes entities automatically.
       if (lang === 'mermaid') {
         const escaped = escapeSvelte(code.replace(/</g, '&lt;').replace(/>/g, '&gt;'));
-        return `<div data-mermaid class="not-prose overflow-x-auto rounded-md border-2 border-slate-800 bg-[#011627] p-4 not-last:mb-4"><pre class="mermaid-source" style="margin:0;color:#d6deeb;white-space:pre-wrap">${escaped}</pre></div>`;
+        return `<!-- svelte-ignore a11y_no_noninteractive_tabindex --><div data-mermaid tabindex="0" class="not-prose overflow-x-auto rounded-md border-2 border-slate-800 bg-[#011627] p-4 not-last:mb-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500"><pre class="mermaid-source" style="margin:0;color:#d6deeb;white-space:pre-wrap">${escaped}</pre></div>`;
       }
 
       const { title, remaining: remainingMeta } = parseTitle(metastring);
@@ -105,6 +105,23 @@ const mdsvexOptions: MdsvexOptions = {
         'not-last:mb-4',
       ];
 
+      // A horizontally scrolling region has to be reachable by keyboard, or the
+      // code that overflows it can only be read with a pointer. Shiki's own
+      // tabindex is stripped below because the <pre> is not what scrolls — one
+      // of these wrappers is — so the tab stop belongs here instead.
+      const scrollFocusClasses = [
+        'focus-visible:outline-2',
+        'focus-visible:outline-offset-2',
+        'focus-visible:outline-slate-500',
+      ];
+      const scrollAttributes = `tabindex="0"`;
+      // Svelte's a11y_no_noninteractive_tabindex rule rejects tabindex on any
+      // noninteractive element, and the only roles it accepts (button, link)
+      // would be semantically wrong here. The rule does not model scrollable
+      // regions, which WCAG requires to be focusable, so this is a false
+      // positive — silenced per element rather than globally.
+      const scrollIgnoreComment = '<!-- svelte-ignore a11y_no_noninteractive_tabindex -->';
+
       // Unsupported Shiki languages (e.g. "text") get a plain <pre>
       // wrapper so whitespace and newlines are preserved.
       if (!(lang in bundledLanguages)) {
@@ -116,10 +133,15 @@ const mdsvexOptions: MdsvexOptions = {
         const titleHtml = title
           ? `<div class="code-block-header">${escapeSvelte(title)}</div>`
           : '';
-        const wrapperClasses = title ? baseClasses : [...baseClasses, 'overflow-x-scroll', 'p-4'];
-        const contentWrapper = title ? `<div class="overflow-x-auto p-4">${inner}</div>` : inner;
+        const wrapperClasses = title
+          ? baseClasses
+          : [...baseClasses, 'overflow-x-scroll', 'p-4', ...scrollFocusClasses];
+        const contentWrapper = title
+          ? `${scrollIgnoreComment}<div class="overflow-x-auto p-4 ${scrollFocusClasses.join(' ')}" ${scrollAttributes}>${inner}</div>`
+          : inner;
+        const wrapperAttributes = title ? '' : ` ${scrollAttributes}`;
 
-        return `<div class="${wrapperClasses.join(' ')}" data-language="${lang}">${titleHtml}${contentWrapper}</div>`;
+        return `${title ? '' : scrollIgnoreComment}<div class="${wrapperClasses.join(' ')}" data-language="${lang}"${wrapperAttributes}>${titleHtml}${contentWrapper}</div>`;
       }
 
       const transformers = [];
@@ -141,10 +163,15 @@ const mdsvexOptions: MdsvexOptions = {
       }
 
       const titleHtml = title ? `<div class="code-block-header">${escapeSvelte(title)}</div>` : '';
-      const wrapperClasses = title ? baseClasses : [...baseClasses, 'overflow-x-scroll', 'p-4'];
-      const contentWrapper = title ? `<div class="overflow-x-auto p-4">${html}</div>` : html;
+      const wrapperClasses = title
+        ? baseClasses
+        : [...baseClasses, 'overflow-x-scroll', 'p-4', ...scrollFocusClasses];
+      const contentWrapper = title
+        ? `${scrollIgnoreComment}<div class="overflow-x-auto p-4 ${scrollFocusClasses.join(' ')}" ${scrollAttributes}>${html}</div>`
+        : html;
+      const wrapperAttributes = title ? '' : ` ${scrollAttributes}`;
 
-      return `<div class="${wrapperClasses.join(' ')}" data-language="${lang}">${titleHtml}${contentWrapper}</div>`;
+      return `${title ? '' : scrollIgnoreComment}<div class="${wrapperClasses.join(' ')}" data-language="${lang}"${wrapperAttributes}>${titleHtml}${contentWrapper}</div>`;
     },
   },
 };

--- a/applications/website/tests/content-pages.spec.ts
+++ b/applications/website/tests/content-pages.spec.ts
@@ -45,7 +45,9 @@ test('scrollable code blocks are reachable by keyboard', async ({ page }) => {
   await page.goto('/writing/setup-python');
   // Whether a block actually overflows depends on font metrics, so wait for
   // fonts before measuring — otherwise this silently checks nothing.
-  await page.evaluate(() => document.fonts.ready);
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
 
   const scrollable = await page.evaluate(() =>
     Array.from(document.querySelectorAll('[data-language], [data-mermaid]'))
@@ -68,7 +70,9 @@ test('writing post page has no accessibility violations', async ({ page }) => {
   // Overflow, and therefore the scrollable-region-focusable rule, depends on
   // font metrics. Without this the check races font loading and fails ~4% of
   // runs on whichever violations happen to be live at that instant.
-  await page.evaluate(() => document.fonts.ready);
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
   await injectAxe(page);
   // Report the offending rules and nodes on failure; without this a violation
   // surfaces only as "1 !== 0", which says nothing about what to fix.

--- a/applications/website/tests/content-pages.spec.ts
+++ b/applications/website/tests/content-pages.spec.ts
@@ -41,8 +41,34 @@ test('tailwind playground previews are progressively enhanced on content pages',
   await expect(playground).not.toHaveAttribute('inert', '');
 });
 
+test('scrollable code blocks are reachable by keyboard', async ({ page }) => {
+  await page.goto('/writing/setup-python');
+  // Whether a block actually overflows depends on font metrics, so wait for
+  // fonts before measuring — otherwise this silently checks nothing.
+  await page.evaluate(() => document.fonts.ready);
+
+  const scrollable = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('[data-language], [data-mermaid]'))
+      .flatMap((element) => [element, ...element.querySelectorAll('div')])
+      .filter((element) => element.scrollWidth > element.clientWidth)
+      .map((element) => ({
+        tabIndex: (element as HTMLElement).tabIndex,
+        html: element.outerHTML.slice(0, 120),
+      })),
+  );
+
+  expect(scrollable.length).toBeGreaterThan(0);
+  for (const region of scrollable) {
+    expect(region.tabIndex, `not keyboard focusable: ${region.html}`).toBe(0);
+  }
+});
+
 test('writing post page has no accessibility violations', async ({ page }) => {
   await page.goto('/writing/setup-python');
+  // Overflow, and therefore the scrollable-region-focusable rule, depends on
+  // font metrics. Without this the check races font loading and fails ~4% of
+  // runs on whichever violations happen to be live at that instant.
+  await page.evaluate(() => document.fonts.ready);
   await injectAxe(page);
   // Report the offending rules and nodes on failure; without this a violation
   // surfaces only as "1 !== 0", which says nothing about what to fix.


### PR DESCRIPTION
Code blocks that overflow horizontally were scroll containers with no tab stop, so any code past the right edge could only be reached with a pointer. Keyboard and switch users had no way to scroll them.

Shiki emits `tabindex="0"` on its `<pre>` for exactly this reason. The pipeline strips it — correctly, because the `<pre>` is not the element that scrolls — but nothing ever put the tab stop back on the wrapper that does.

## The fix

`tabindex="0"` plus a `focus-visible` outline on each element that actually scrolls, which is three distinct places in `svelte.config.ts`: the unwrapped block (`overflow-x-scroll` on the wrapper), the inner content wrapper used when a block has a title (`overflow-x-auto`), and the mermaid container.

## This was also the intermittent CI failure

The axe rule that catches this, `scrollable-region-focusable`, only fires when a block *genuinely* overflows, and whether it overflows depends on font metrics being settled. So the violation showed up in roughly 4% of runs and looked like an unrelated flake. The a11y test now waits for `document.fonts.ready` before asserting, which removes the race rather than hiding it.

## How this was verified

I confirmed the regression test actually catches the bug by reverting the fix and re-running it — it fails with `tabIndex` `-1` against an expected `0`, naming the offending element. With the fix in place, `content-pages.spec.ts` passes **120 consecutive runs** under the same 4-worker parallel load that reliably reproduced the flake beforehand.

The measurement that identified it, taken identically on `main` and on the dependency branch where it surfaced: one `sh` block on `/writing/setup-python`, `scrollWidth` 931 vs `clientWidth` 898, `tabindex` `null`. Identical on both, which is what established the bug as pre-existing rather than something the dependency updates introduced.

Full suite green: `continuous-integration:validate` and `test:integration` (54 specs, up one from the new regression test).

## Scope

Found while investigating a flaky test during dependency updates; unrelated to those bumps and split out so it can be reviewed on its own.

https://claude.ai/code/session_01GnBamDXuW1ectE37sCUUiU
