### PR TITLE
chore: track .worktreeinclude and document the Turborepo cache wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 .env
 .env.*
 !.env.example
+.envrc
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 **/.obsidian/*

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,8 @@
+# Gitignored files copied into each new worktree Claude Code creates.
+# Uses .gitignore syntax. Only files that match AND are gitignored are
+# copied, so tracked files (e.g. .env.example) are never duplicated.
+# A pattern without a slash matches at any depth, covering monorepo packages.
+.env
+.env.local
+.env.*.local
+.envrc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@ The remote cache credential is **not ambient**. Prefix with the wrapper to get i
 with-turborepo-cache bun run build
 ```
 
+`with-turborepo-cache` is a personal macOS helper on `PATH`, not a script in this
+repository, so it will not exist in a fresh clone. It is a convenience, not a
+requirement: the portable equivalent is exporting `TURBO_TOKEN` and `TURBO_TEAM`
+yourself, and CI does exactly that from repository secrets rather than using the wrapper.
+
 The wrapper reads `TURBO_TOKEN` from the macOS login Keychain (service
 `turborepo-remote-cache`, account `TURBO_TOKEN`) and exports it along with `TURBO_TEAM`.
 The Keychain item grants read access to `/usr/bin/security`, so the lookup never prompts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,41 @@
 - `bun storybook` - Run Storybook on port 6006
 - `bun run build:report` - Write `tmp/build-report/website-build-report.{json,md}` after a build
 
+### Turborepo remote cache
+
+The remote cache credential is **not ambient**. Prefix with the wrapper to get it:
+
+```sh
+with-turborepo-cache bun run build
+```
+
+The wrapper reads `TURBO_TOKEN` from the macOS login Keychain (service
+`turborepo-remote-cache`, account `TURBO_TOKEN`) and exports it along with `TURBO_TEAM`.
+The Keychain item grants read access to `/usr/bin/security`, so the lookup never prompts
+— backgrounded, detached, and unattended runs all work. Rotate the token with:
+
+```sh
+security add-generic-password -U -s turborepo-remote-cache -a TURBO_TOKEN -T /usr/bin/security -w
+```
+
+Without the wrapper there is no `TURBO_TOKEN`, and Turbo emits two warnings that
+describe one condition — no credentials:
+
+```
+WARNING • Remote caching unavailable (Authentication failed — check TURBO_TOKEN ...)
+WARNING Insufficient permissions to write to remote cache. Please verify that your role ...
+```
+
+**"Insufficient permissions" does not mean the Vercel account lacks write access.** It is
+the downstream symptom of never having authenticated. A wrapped run prints
+`• Remote caching enabled` and no warnings. Unwrapped runs still work — they just
+fall back to the local `.turbo/cache`, so a cold build takes ~90s instead of restoring.
+
+Two stale credentials exist on this machine and are _not_ used for caching — ignore them
+when debugging cache behavior: an expired Vercel CLI token in
+`~/Library/Application Support/com.vercel.cli/auth.json`, and an expired `VERCEL_OIDC_TOKEN`
+in `.env.local`.
+
 ## Code Style
 
 - **Formatting**: Use tabs, single quotes, 100 char line length


### PR DESCRIPTION
Commits two things that had been sitting uncommitted in the working tree.

## `.worktreeinclude`

Lists the gitignored files Claude Code copies into each new worktree, so a fresh worktree comes up with the local env files it needs instead of silently missing them. It records **patterns only** — no env file and no secret value is committed by this.

## Turborepo cache documentation

Documents that the remote cache credential is not ambient and has to come from the `with-turborepo-cache` wrapper, plus the failure mode that is genuinely confusing: without credentials Turbo prints two warnings that read as an access-control problem, when both just mean no token was ever supplied. Worth writing down, because "Insufficient permissions" invites you to go audit the Vercel account instead of checking whether you authenticated at all.

## One correction to the draft

The version in my working tree described the wrapper as 1Password-backed, and warned that Touch ID cannot be satisfied by a background process, so wrapped commands must run in the foreground and should be batched to avoid repeated auth checks. That is no longer true, and I corrected it rather than commit it.

The wrapper reads `TURBO_TOKEN` from the macOS login Keychain. Its own header records why:

> Credentials come from the macOS login Keychain rather than 1Password so that unattended and backgrounded runs work: Touch ID cannot be satisfied by a process without a UI session, which made `op run` fail with "error initializing client: authorization timeout".

The Keychain item is created with `-T /usr/bin/security`, so reads do not prompt. I confirmed the behavior rather than just the source, by resolving the token from a detached background process — it succeeds.

The stale guidance had a real cost: I ran every wrapped command in the foreground during this session because of it. The batching advice went with it, since its whole rationale was an auth check per invocation that no longer happens. The section now documents the Keychain lookup and the rotation command instead.

`bun run lint` passes.

https://claude.ai/code/session_01GnBamDXuW1ectE37sCUUiU
