### PR TITLE
build(deps-dev): upgrade satori to 0.33 and bundle its harfbuzz wasm

### DIFF
--- a/applications/website/package.json
+++ b/applications/website/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "NODE_OPTIONS=\"--import tsx --disable-warning=ExperimentalWarning\" bunx vite dev --port 4444",
-    "build": "NODE_OPTIONS=\"--max-old-space-size=4096 --import tsx --disable-warning=ExperimentalWarning\" bunx run-with-sharp-runtime node \"$(bun pm bin)/vite\" build && bunx sync-generated-browser-assets",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=4096 --import tsx --disable-warning=ExperimentalWarning\" bunx run-with-sharp-runtime node \"$(bun pm bin)/vite\" build && bunx sync-generated-browser-assets && bun ../../packages/scripts/sync-serverless-wasm.ts",
     "build:stats": "BUNDLE_STATS=1 bun run build",
     "preview": "bunx vite preview",
     "test": "bun run test:integration && bun run test:unit",

--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
         "rehype-unwrap-images": "^1.0.0",
         "remark-gfm": "^4.0.1",
         "rollup-plugin-visualizer": "^7.1.1",
-        "satori": "^0.18.4",
+        "satori": "^0.33.4",
         "shiki": "^4.4.3",
         "storybook": "^10.6.0",
         "svelte": "^5.57.0",
@@ -1537,7 +1537,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fflate": ["fflate@0.7.5", "", {}, "sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g=="],
+    "fflate": ["fflate@0.7.3", "", {}, "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="],
 
     "file-entry-cache": ["file-entry-cache@11.1.5", "", { "dependencies": { "flat-cache": "^6.1.23" } }, "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q=="],
 
@@ -1612,6 +1612,8 @@
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "harfbuzzjs": ["harfbuzzjs@0.10.0", "", {}, "sha512-SN8LVwCOzvTq3OPNd0+EAghgXugItz56wst567D1vs7LnnKGWprhi3EG58aVOBwhN8HEbQxL4I9NDWkcXUutRw=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2287,7 +2289,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "satori": ["satori@0.18.4", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-HanEzgXHlX3fzpGgxPoR3qI7FDpc/B+uE/KplzA6BkZGlWMaH98B/1Amq+OBF1pYPlGNzAXPYNHlrEVBvRBnHQ=="],
+    "satori": ["satori@0.33.4", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "fflate": "0.7.3", "harfbuzzjs": "0.10.0", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-dCnaW6D/tkCJxG5UvpZPWnnvfTdGTVVSAq1tzH6xC5MeOhAeeswRcSq5zT7C6lRCdTGow9PRGus7PCzdp5JJYw=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
@@ -2634,6 +2636,8 @@
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg=="],
+
+    "@shuding/opentype.js/fflate": ["fflate@0.7.5", "", {}, "sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g=="],
 
     "@storybook/addon-coverage/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rehype-unwrap-images": "^1.0.0",
     "remark-gfm": "^4.0.1",
     "rollup-plugin-visualizer": "^7.1.1",
-    "satori": "^0.18.4",
+    "satori": "^0.33.4",
     "shiki": "^4.4.3",
     "storybook": "^10.6.0",
     "svelte": "^5.57.0",

--- a/packages/scripts/content-paths.ts
+++ b/packages/scripts/content-paths.ts
@@ -20,6 +20,12 @@ export const websiteSvelteKitClientRoot = path.resolve(
   'client',
 );
 export const websiteVercelStaticRoot = path.resolve(websiteRoot, '.vercel', 'output', 'static');
+export const websiteVercelFunctionsRoot = path.resolve(
+  websiteRoot,
+  '.vercel',
+  'output',
+  'functions',
+);
 export const generatedContentDirectory = path.resolve(websiteRoot, '.generated');
 export const generatedContentDataPath = path.resolve(
   generatedContentDirectory,

--- a/packages/scripts/sync-serverless-wasm.ts
+++ b/packages/scripts/sync-serverless-wasm.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+import { copyFile, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import { directoryExists, repositoryRoot, websiteVercelFunctionsRoot } from './content-paths.ts';
+
+/**
+ * Vercel traces serverless dependencies with @vercel/nft, which follows static
+ * requires. harfbuzzjs resolves its WebAssembly binary as `scriptDirectory +
+ * "hb.wasm"` — a path built at runtime — so nothing static points at the file
+ * and it is left out of the function bundle. satori (0.33+) imports harfbuzzjs
+ * for text shaping, so every Open Graph route then fails at runtime with
+ * `ENOENT ... /var/task/node_modules/harfbuzzjs/hb.wasm`.
+ *
+ * The binary sits next to the JS that loads it, so copying it into each traced
+ * copy of the package restores the layout harfbuzzjs expects. This runs after
+ * `vite build`, before the root build copies `.vercel/output` upward.
+ */
+const untracedAssets = [{ packageName: 'harfbuzzjs', fileName: 'hb.wasm' }];
+
+const findTracedPackageDirectories = async (
+  root: string,
+  packageName: string,
+): Promise<string[]> => {
+  const found: string[] = [];
+
+  const walk = async (directory: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const child = path.join(directory, entry.name);
+
+      if (path.relative(root, child).endsWith(path.join('node_modules', packageName))) {
+        found.push(child);
+        continue;
+      }
+
+      await walk(child);
+    }
+  };
+
+  await walk(root);
+  return found;
+};
+
+const syncServerlessWasm = async (): Promise<void> => {
+  // Only the Vercel adapter produces this tree; the static build has no functions.
+  if (!(await directoryExists(websiteVercelFunctionsRoot))) {
+    console.log('No Vercel functions output; skipping serverless wasm sync.');
+    return;
+  }
+
+  for (const { packageName, fileName } of untracedAssets) {
+    const source = path.resolve(repositoryRoot, 'node_modules', packageName, fileName);
+
+    try {
+      await stat(source);
+    } catch {
+      console.error(
+        `Cannot sync ${packageName}/${fileName}: it is missing at ${source}. ` +
+          `If ${packageName} no longer ships this file, remove it from untracedAssets.`,
+      );
+      process.exit(1);
+    }
+
+    const targets = await findTracedPackageDirectories(websiteVercelFunctionsRoot, packageName);
+
+    if (targets.length === 0) {
+      console.error(
+        `Cannot sync ${packageName}/${fileName}: no traced copy of ${packageName} exists under ` +
+          `${websiteVercelFunctionsRoot}. Either the dependency is gone — in which case remove it ` +
+          `from untracedAssets — or tracing changed and this script would silently do nothing.`,
+      );
+      process.exit(1);
+    }
+
+    for (const target of targets) {
+      const destination = path.join(target, fileName);
+      await copyFile(source, destination);
+
+      // Copying can succeed against a path that is not what the runtime resolves,
+      // so confirm the file is readable where harfbuzzjs will look for it.
+      const { size } = await stat(destination);
+      if (size === 0) {
+        console.error(`Synced ${fileName} to ${destination} but it is empty.`);
+        process.exit(1);
+      }
+
+      console.log(
+        `Synced ${packageName}/${fileName} into ${path.relative(repositoryRoot, target)}`,
+      );
+    }
+  }
+};
+
+await syncServerlessWasm();

--- a/turbo.json
+++ b/turbo.json
@@ -106,6 +106,7 @@
         "../../packages/components/**/*.{svelte,ts,js}",
         "../../packages/markdown/src/**/*.ts",
         "../../packages/utilities/**/*.ts",
+        "../../packages/scripts/*.ts",
         "../../image-manifest.json",
         ".generated/**",
         "!build/**",


### PR DESCRIPTION
Retries the satori 0.33 upgrade that #178 shipped and #180 reverted, this time with the wasm actually in the bundle and verified against the built artifact.

## Why it broke

satori 0.33 shapes text with `harfbuzzjs`, which resolves its binary as `scriptDirectory + "hb.wasm"` — a path constructed at runtime. `@vercel/nft` traces static references, so it copies `harfbuzzjs/hb.js`, `index.js` and `package.json` into the function and leaves `hb.wasm` behind. Every Open Graph route then fails with `ENOENT ... /var/task/node_modules/harfbuzzjs/hb.wasm`.

There is no injection point to work around it: `harfbuzzjs/index.js` calls `hb()` with no arguments, so its `locateFile` and `instantiateWasm` hooks are unreachable through satori, and satori's exported `init` is an empty function. The file has to exist where harfbuzzjs looks.

## The fix

`packages/scripts/sync-serverless-wasm.ts` runs after `vite build` and copies `hb.wasm` into every traced copy of `harfbuzzjs` under `.vercel/output`. It exits non-zero if the source file is missing, if no traced copy of the package is found, or if the copy lands empty — so the failure mode that shipped in #178, a silent absence, becomes a failed build instead.

It is invoked by path rather than registered as a package bin. bun does not refresh a workspace bin map in `bun.lock` when a bin is added (confirmed on 1.4.2, including after deleting `node_modules`), and CI installs with `--frozen-lockfile`, so a new bin would not be linked there.

## Verification

The point of failure last time was verifying against a dev server, where `node_modules` is on disk and the bug cannot occur. These checks run against the built artifact instead:

**Before the fix**, a `VERCEL=1` build produces a bundle with `harfbuzzjs/hb.js` and no `hb.wasm`. Copying that function's `node_modules` somewhere with no repository `node_modules` on any parent path and loading harfbuzzjs reproduces production exactly:

```
Aborted(Error: ENOENT: no such file or directory, open '.../harfbuzzjs/hb.wasm')
```

**After the fix**, `hb.wasm` is present in `.vercel/output`, harfbuzz initializes from that isolated copy, and satori renders a 600x200 SVG containing real `<path>` glyph data using a font taken from the build's own static output.

`continuous-integration:validate` passes.

## One thing this PR does not fix

While verifying, I found a **pre-existing** bug unrelated to satori. A cold rebuild of `.generated/content-enhancements` produces a bundle that inserts the "On this page" table of contents twice, which trips axe's `landmark-unique` rule and fails the accessibility spec. It reproduces identically on unmodified `main` — wipe `.generated`, run `turbo run build --force`, and the page has two `nav[aria-label="On this page"]` landmarks where production has one.

CI and production are currently unaffected because Turbo restores an older cached bundle (115 chunks) rather than building the current source (87 chunks). That also means the bug lands the moment that cache entry is evicted. Production was checked directly and currently renders one TOC. Worth its own issue; deliberately out of scope here.

https://claude.ai/code/session_01GnBamDXuW1ectE37sCUUiU
