### PR TITLE
fix: apply content enhancements once when the entry loads twice

### DIFF
--- a/applications/website/tests/content-pages.spec.ts
+++ b/applications/website/tests/content-pages.spec.ts
@@ -65,6 +65,24 @@ test('scrollable code blocks are reachable by keyboard', async ({ page }) => {
   }
 });
 
+test('content enhancements apply exactly once per document', async ({ page }) => {
+  await page.goto('/writing/setup-python');
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+
+  // The entry is loaded with a cache-busting query while its chunks import it
+  // back bare, so the browser can instantiate the module twice. If both
+  // instances enhance, every injected element is duplicated.
+  const counts = await page.evaluate(() => ({
+    contentDocuments: document.querySelectorAll('[data-content-document]').length,
+    tableOfContents: document.querySelectorAll('nav[aria-label="On this page"]').length,
+  }));
+
+  expect(counts.contentDocuments).toBe(1);
+  expect(counts.tableOfContents).toBe(1);
+});
+
 test('writing post page has no accessibility violations', async ({ page }) => {
   await page.goto('/writing/setup-python');
   // Overflow, and therefore the scrollable-region-focusable rule, depends on

--- a/applications/website/tests/content-pages.spec.ts
+++ b/applications/website/tests/content-pages.spec.ts
@@ -67,9 +67,12 @@ test('scrollable code blocks are reachable by keyboard', async ({ page }) => {
 
 test('content enhancements apply exactly once per document', async ({ page }) => {
   await page.goto('/writing/setup-python');
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-  });
+  // Counting before the enhancers finish would read a half-applied page: too
+  // early and there is no table of contents at all, or only the first of two.
+  // Wait for the enhanced marker, then for the network to settle, so a second
+  // module instance has had its chance to load and duplicate the nav.
+  await expect(page.locator('[data-content-document][data-content-enhanced="true"]')).toBeVisible();
+  await page.waitForLoadState('networkidle');
 
   // The entry is loaded with a cache-busting query while its chunks import it
   // back bare, so the browser can instantiate the module twice. If both
@@ -87,7 +90,11 @@ test('writing post page has no accessibility violations', async ({ page }) => {
   await page.goto('/writing/setup-python');
   // Overflow, and therefore the scrollable-region-focusable rule, depends on
   // font metrics. Without this the check races font loading and fails ~4% of
-  // runs on whichever violations happen to be live at that instant.
+  // runs on whichever violations happen to be live at that instant. Audit the
+  // enhanced page too, since enhancers inject landmarks and controls of their
+  // own that axe should see.
+  await expect(page.locator('[data-content-document][data-content-enhanced="true"]')).toBeVisible();
+  await page.waitForLoadState('networkidle');
   await page.evaluate(async () => {
     await document.fonts.ready;
   });

--- a/packages/content-enhancements/src/content-enhancements.ts
+++ b/packages/content-enhancements/src/content-enhancements.ts
@@ -64,19 +64,41 @@ const applyEnhancements = async (): Promise<void> => {
   );
 };
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', applyEnhancements, { once: true });
-} else {
-  applyEnhancements();
+/**
+ * The page loads this entry with a cache-busting `?v=` query, while the lazily
+ * imported enhancer chunks import it back by its bare filename for shared
+ * symbols. Those are two different URLs, so the browser instantiates this
+ * module twice and runs everything below a second time. `cleanupsByRoot` is
+ * per-instance, so the second instance sees no prior work and enhances every
+ * root again — which is how a page ends up with two "On this page" navs and a
+ * duplicate landmark. Claim a flag on `window` so only the first instance
+ * drives enhancements; the second becomes inert.
+ */
+const ACTIVE_FLAG = '__contentEnhancementsActive';
+
+type EnhancementWindow = Window & { [ACTIVE_FLAG]?: boolean };
+const enhancementWindow = window as EnhancementWindow;
+
+if (!enhancementWindow[ACTIVE_FLAG]) {
+  enhancementWindow[ACTIVE_FLAG] = true;
+  registerEnhancementLifecycle();
 }
 
-window.addEventListener('pagehide', () => {
-  for (const root of getRoots()) cleanupRoot(root);
-});
+function registerEnhancementLifecycle(): void {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyEnhancements, { once: true });
+  } else {
+    applyEnhancements();
+  }
 
-// If the browser restores the document from the back/forward cache the
-// pagehide listener above has already torn every enhancement down. Re-run
-// them so copy buttons, diagrams, and playgrounds come back.
-window.addEventListener('pageshow', (event) => {
-  if (event.persisted) applyEnhancements();
-});
+  window.addEventListener('pagehide', () => {
+    for (const root of getRoots()) cleanupRoot(root);
+  });
+
+  // If the browser restores the document from the back/forward cache the
+  // pagehide listener above has already torn every enhancement down. Re-run
+  // them so copy buttons, diagrams, and playgrounds come back.
+  window.addEventListener('pageshow', (event) => {
+    if (event.persisted) applyEnhancements();
+  });
+}


### PR DESCRIPTION
Fixes the duplicate table of contents found while verifying #182. This is not hypothetical any more: it took down that PR's integration run.

## What happens

`content-enhancements.svelte` loads the entry with a cache-busting query:

```
/generated/content-enhancements/content-enhancements.js?v=<build hash>
```

`Bun.build` runs with `splitting: true`, and the lazily imported enhancer chunks import shared symbols back from the entry by its bare filename — twelve of them do:

```js
import{v}from"./content-enhancements.js"
```

`?v=<hash>` and the bare path are two different URLs, so the browser instantiates the module **twice** and runs its top-level side effects twice. `cleanupsByRoot` is a module-level `WeakMap`, so the second instance sees no prior work and enhances every root again. The page ends up with two `nav[aria-label="On this page"]` landmarks, which trips axe's `landmark-unique`.

The observable signature is distinctive: two navs, but only one `[data-content-document]` and one `[data-content-enhanced]`. That rules out the nested-wrapper double-enhancement this repo already guards against — the wrapper is fine, the module is doubled.

## The fix

Claim a flag on `window` so only the first instance registers the lifecycle; the second becomes inert. This holds regardless of how the bundler splits chunks later, which matters because the trigger was a bundling change nobody made deliberately.

The second instance is still fetched — one extra request for an already-cached file. Removing the query entirely, or moving the hash into the entry filename, would avoid that too, but filename hashing turns a stale hash into a 404 in dev where today it harmlessly resolves. Not worth trading a dev-server failure mode for one cached request; noting it as the alternative.

## Why it hid for so long

It only reproduces on a **cold** build. Turbo's cached `content:build` artifact (115 chunks) predates the split that made chunks import the entry back, so CI and production kept restoring a bundle that does not exhibit the bug. Building the current source produces 87 chunks and reproduces it every time.

That cache finally missed on #182, whose integration run failed with exactly this violation. Production currently serves one TOC — I checked the live page directly — but it was one cache eviction away from shipping the duplicate.

## Verification

Confirmed against the failing condition rather than the cached one: wipe `.generated`, `turbo run build --force`, then run the suite.

- Without the fix, the new regression test reports 2 tables of contents against an expected 1, and the accessibility spec fails 4 out of 4 runs.
- With it, `content-pages.spec.ts` passes 13/13 on a cold build, and the full suite is green: `continuous-integration:validate` plus 55 integration specs.

Reproduced identically on unmodified `main` before writing any of this, so it is pre-existing and unrelated to the satori work that surfaced it.

https://claude.ai/code/session_01GnBamDXuW1ectE37sCUUiU
